### PR TITLE
API should use configurable keypair for token signing

### DIFF
--- a/scripts/run-blackbox-tests.sh
+++ b/scripts/run-blackbox-tests.sh
@@ -3,8 +3,7 @@ cert_tool_version=59657b2
 
 docker-compose pull
 docker-compose --project-name montagu up -d
-docker run docker.montagu.dide.ic.ac.uk:5000/montagu-cert-tool:$cert_tool_version gen-self-signed password > keystore
-./scripts/add-certificate-to-docker.sh keystore montagu_api_1
+docker exec montagu_api_1 touch /etc/montagu/api/go_signal
 
 docker build -f blackbox.Dockerfile -t montagu-api-blackbox-tests .
 docker run --network montagu_default montagu-api-blackbox-tests

--- a/scripts/run-blackbox-tests.sh
+++ b/scripts/run-blackbox-tests.sh
@@ -6,6 +6,7 @@ cert_tool_version=59657b2
 # Run API and DB
 docker-compose pull
 docker-compose --project-name montagu up -d
+docker exec montagu_api_1 mkdir -p /etc/montagu/api/
 docker exec montagu_api_1 touch /etc/montagu/api/go_signal
 
 # Build and run image that can run blackbox tests

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -64,17 +64,3 @@ distDocker {
 }
 
 copyConfig.finalizedBy 'showConfig'
-processResources.finalizedBy 'generateKeyPair'
-
-task generateKeyPair() {
-    doFirst {
-        exec {
-            def path = new File('build/classes/main/token_key')
-            path.mkdirs()
-            commandLine 'docker', 'run',
-                    '-v=' + path.getAbsolutePath() + ':/workspace',
-                    'docker.montagu.dide.ic.ac.uk:5000/montagu-cert-tool:6a7e736', 'gen-keypair', '/workspace'
-        }
-    }
-    outputs.upToDateWhen { false }
-}

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -64,3 +64,17 @@ distDocker {
 }
 
 copyConfig.finalizedBy 'showConfig'
+processResources.finalizedBy 'generateKeyPair'
+
+task generateKeyPair() {
+    doFirst {
+        exec {
+            def path = new File('build/classes/main/token_key')
+            path.mkdirs()
+            commandLine 'docker', 'run',
+                    '-v=' + path.getAbsolutePath() + ':/workspace',
+                    'docker.montagu.dide.ic.ac.uk:5000/montagu-cert-tool:6a7e736', 'gen-keypair', '/workspace'
+        }
+    }
+    outputs.upToDateWhen { false }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.api.app.controllers.OneTimeLinkController
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.makeRepositories
 import org.vaccineimpact.api.db.Config
+import org.vaccineimpact.api.security.KeyHelper
 import org.vaccineimpact.api.security.WebTokenHelper
 import java.io.File
 import java.net.BindException
@@ -25,7 +26,7 @@ fun main(args: Array<String>)
 class MontaguApi
 {
     private val urlBase = "/v1"
-    private val tokenHelper = WebTokenHelper()
+    private val tokenHelper = WebTokenHelper(KeyHelper.keyPair)
 
     private val logger = LoggerFactory.getLogger(MontaguApi::class.java)
 
@@ -97,6 +98,8 @@ class MontaguApi
     }
 }
 
+// This is so that we can copy files into the Docker container after it exists
+// but before the API starts running.
 private fun waitForGoSignal()
 {
     val path = File("/etc/montagu/api/go_signal")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.makeRepositories
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.security.WebTokenHelper
+import java.io.File
 import java.net.BindException
 import java.net.ServerSocket
 import kotlin.system.exitProcess
@@ -16,6 +17,7 @@ import spark.Spark as spk
 
 fun main(args: Array<String>)
 {
+    waitForGoSignal()
     val api = MontaguApi()
     api.run(makeRepositories())
 }
@@ -93,4 +95,17 @@ class MontaguApi
             return false
         }
     }
+}
+
+private fun waitForGoSignal()
+{
+    val path = File("/etc/montagu/api/go_signal")
+    println("Waiting for signal file at $path.")
+    println("(In development environments, run `sudo touch $path`)")
+
+    while (!path.exists())
+    {
+        Thread.sleep(2000)
+    }
+    println("Go signal detected. Running API")
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -6,11 +6,8 @@ import org.junit.Before
 import org.junit.Test
 import org.vaccineimpact.api.models.permissions.ReifiedRole
 import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.security.MontaguUser
-import org.vaccineimpact.api.security.UserProperties
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
-import org.vaccineimpact.api.security.MontaguTokenAuthenticator
-import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.security.*
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Instant
 import java.util.*
@@ -37,7 +34,7 @@ class WebTokenHelperTests : MontaguTests()
     @Before
     fun createHelper()
     {
-        helper = WebTokenHelper()
+        helper = WebTokenHelper(KeyHelper.keyPair)
     }
 
     @Test
@@ -92,7 +89,7 @@ class WebTokenHelperTests : MontaguTests()
     @Test
     fun `token fails validation when token is signed by wrong key`()
     {
-        val sauron = WebTokenHelper()
+        val sauron = WebTokenHelper(KeyHelper.generateKeyPair())
         val evilToken = sauron.generateToken(MontaguUser(properties, roles, permissions))
         val verifier = MontaguTokenAuthenticator(helper)
         assertThat(verifier.validateToken(evilToken)).isNull()

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/KeyHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/KeyHelper.kt
@@ -1,0 +1,52 @@
+package org.vaccineimpact.api.security
+
+import org.vaccineimpact.api.db.getResource
+import java.io.File
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+
+object KeyHelper
+{
+    private val keyFactory = KeyFactory.getInstance("RSA")
+
+    val keyPair by lazy {
+        val path = firstPathThatExistsFrom(listOf(
+                "/etc/montagu/api/token_key",
+                getResource("").path + "token_key"
+        ))
+        KeyPair(loadPublicKey(path), loadPrivateKey(path))
+    }
+
+    private fun loadPublicKey(path: String): PublicKey
+    {
+        val keyBytes = File(path, "public_key.der").readBytes()
+        val spec = X509EncodedKeySpec(keyBytes)
+        return keyFactory.generatePublic(spec)
+    }
+
+    private fun loadPrivateKey(path: String): PrivateKey
+    {
+        val file = File(path, "private_key.der")
+        try
+        {
+            val keyBytes = file.readBytes()
+            val spec = PKCS8EncodedKeySpec(keyBytes)
+            return keyFactory.generatePrivate(spec)
+        }
+        finally
+        {
+            // Don't leave the private key lying around once we've read it
+            file.delete()
+        }
+    }
+
+    private fun firstPathThatExistsFrom(paths: List<String>): String
+    {
+        return paths.firstOrNull { File(it, "public_key.der").exists() }
+            ?: throw MissingTokenKeyPairException(paths)
+    }
+}

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/KeyHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/KeyHelper.kt
@@ -54,7 +54,7 @@ object KeyHelper
         }
     }
 
-    private fun generateKeyPair(): KeyPair
+    fun generateKeyPair(): KeyPair
     {
         logger.info("Unable to find a token keypair at $keyPath. Generating a new")
         logger.info("RSA keypair for token signing. If other applications need to")

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/MissingTokenKeyPairException.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/MissingTokenKeyPairException.kt
@@ -1,0 +1,4 @@
+package org.vaccineimpact.api.security
+
+class MissingTokenKeyPairException(val paths: List<String>)
+    : Exception("Unable to find a keypair at any of:\n" + paths.joinToString("\n"))

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -4,17 +4,18 @@ import org.pac4j.core.profile.CommonProfile
 import org.pac4j.jwt.config.signature.RSASignatureConfiguration
 import org.pac4j.jwt.profile.JwtGenerator
 import org.vaccineimpact.api.db.Config
+import java.security.KeyPair
 import java.security.SecureRandom
 import java.time.Duration
 import java.time.Instant
 import java.util.*
 
-open class WebTokenHelper
+open class WebTokenHelper(keyPair: KeyPair)
 {
     val lifeSpan: Duration = Duration.ofSeconds(Config["token.lifespan"].toLong())
     val oneTimeLinkLifeSpan: Duration = Duration.ofMinutes(10)
     val issuer = Config["token.issuer"]
-    val signatureConfiguration = RSASignatureConfiguration(KeyHelper.keyPair)
+    val signatureConfiguration = RSASignatureConfiguration(keyPair)
     val generator = JwtGenerator<CommonProfile>(signatureConfiguration)
     private val random = SecureRandom()
 

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -4,8 +4,6 @@ import org.pac4j.core.profile.CommonProfile
 import org.pac4j.jwt.config.signature.RSASignatureConfiguration
 import org.pac4j.jwt.profile.JwtGenerator
 import org.vaccineimpact.api.db.Config
-import java.security.KeyPair
-import java.security.KeyPairGenerator
 import java.security.SecureRandom
 import java.time.Duration
 import java.time.Instant
@@ -15,13 +13,10 @@ open class WebTokenHelper
 {
     val lifeSpan: Duration = Duration.ofSeconds(Config["token.lifespan"].toLong())
     val oneTimeLinkLifeSpan: Duration = Duration.ofMinutes(10)
-    private val keyPair = generateKeyPair()
     val issuer = Config["token.issuer"]
-    val signatureConfiguration = RSASignatureConfiguration(keyPair)
+    val signatureConfiguration = RSASignatureConfiguration(KeyHelper.keyPair)
     val generator = JwtGenerator<CommonProfile>(signatureConfiguration)
     private val random = SecureRandom()
-
-    //val publicKey: String = Base64.getUrlEncoder().encodeToString(keyPair.public.encoded)
 
     fun generateToken(user: MontaguUser): String
     {
@@ -57,14 +52,6 @@ open class WebTokenHelper
         val bytes = ByteArray(32)
         random.nextBytes(bytes)
         return Base64.getEncoder().encodeToString(bytes)
-    }
-
-    private fun generateKeyPair(): KeyPair
-    {
-        val generator = KeyPairGenerator.getInstance("RSA").apply {
-            initialize(1024)
-        }
-        return generator.generateKeyPair()
     }
 
     companion object


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-395

By default the API still generates a new keypair if none is provided. This makes testing (e.g. blackbox tests) much easier, and seems nice to me - otherwise the API container can't run the API by itself, which just seems awkward. It's not a security hole - it just means other containers can't automatically use the same public key.

There's also [this PR](https://github.com/vimc/montagu/pull/1) for the deployment tool that actually generates the keypair and injects it, but until we've talked through the deployment tool I'm not expecting you to review that. So I guess for now I'll just merge that one in once you've reviewed this PR.