### PR TITLE
Don't make the `Access-Control-Allow-Origin` header endpoint-specific

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/Helpers.kt
@@ -29,7 +29,6 @@ fun addDefaultResponseHeaders(res: HttpServletResponse, contentType: String = "$
 {
     res.contentType = contentType
     res.addHeader("Content-Encoding", "gzip")
-    res.addHeader("Access-Control-Allow-Origin", "*")
 }
 
 class DefaultHeadersFilter(val contentType: String, val method: HttpMethod) : Filter

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -35,7 +35,7 @@ class MontaguApi
         setupPort()
         spk.redirect.get("/", urlBase)
         spk.before("*", ::addTrailingSlashes)
-        spk.after("*", { _, res ->
+        spk.before("*", { _, res ->
             res.header("Access-Control-Allow-Origin", "*")
         })
         spk.options("*", { _, res ->

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -35,6 +35,9 @@ class MontaguApi
         setupPort()
         spk.redirect.get("/", urlBase)
         spk.before("*", ::addTrailingSlashes)
+        spk.after("*", { _, res ->
+            res.header("Access-Control-Allow-Origin", "*")
+        })
         spk.options("*", { _, res ->
             res.header("Access-Control-Allow-Headers", "Authorization")
         })

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/DefaultHeadersFilterTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/DefaultHeadersFilterTests.kt
@@ -30,7 +30,6 @@ class DefaultHeadersFilterTests : MontaguTests()
         val filter = DefaultHeadersFilter(contentType, HttpMethod.get)
         val mockResponse = filter.handleMockRequest(HttpMethod.get)
         verify(mockResponse).addHeader("Content-Encoding", "gzip")
-        verify(mockResponse).addHeader("Access-Control-Allow-Origin", "*")
     }
 
     @Test


### PR DESCRIPTION
While working on [VIMC-459](https://vimc.myjetbrains.com/youtrack/issue/VIMC-459) I found that my changes to make filters HTTP method-specific had broken the webapps. This is what a lack of integration tests gets us!

I realized that while the other parts of `addDefaultResponseHeaders` are endpoint-specific (as in, some endpoints might want to opt out of them and do something different) we always want to apply the `Access-Control-Allow-Origin` header, so we may as well just apply that to the "*" path.