### PR TITLE
Suggested refactor to reduce nesting

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/DataTableDeserializer.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/DataTableDeserializer.kt
@@ -85,30 +85,29 @@ open class DataTableDeserializer<out T>(
     {
         val problems = mutableListOf<ErrorInfo>()
         var index = 0
-        while (index < maxOf(headerCount, actualHeaders.size))
+        val maxHeaderCount = maxOf(headerCount, actualHeaders.size)
+        while (index < maxHeaderCount)
         {
             val expected = headers.getOrNull(index)
             val actual = actualHeaders.getOrNull(index)?.trim()
 
-            if (expected != null)
+            if (actual == null)
             {
-                val expectedName = expected.name
-                if (actual != null)
+                // at most one of actual and expected can be null, so we can infer here that expected is not null
+                problems.add(ErrorInfo("csv-missing-header", "Not enough column headers were provided. Expected a '${expected!!.name}' header."))
+            }
+            else if (expected == null)
+            {
+                if (!extraHeadersAllowed)
                 {
-                    if (expectedName != actual)
-                    {
-                        problems.add(ErrorInfo("csv-unexpected-header", "Expected column header '$expectedName'; found '$actual' instead (column $index)"))
-                    }
-                }
-                else
-                {
-                    problems.add(ErrorInfo("csv-missing-header", "Not enough column headers were provided. Expected a '$expectedName' header."))
+                    problems.add(ErrorInfo("csv-unexpected-header", "Too many column headers were provided. Unexpected '$actual' header."))
                 }
             }
-            else if (actual != null && !extraHeadersAllowed)
+            else if (actual != expected.name)
             {
-                problems.add(ErrorInfo("csv-unexpected-header", "Too many column headers were provided. Unexpected '$actual' header."))
+                problems.add(ErrorInfo("csv-unexpected-header", "Expected column header '${expected.name}'; found '$actual' instead (column $index)"))
             }
+
             index += 1
         }
 


### PR DESCRIPTION
Light refactor of the `checkHeaders` function, to reduce nesting and improve readability.