### PR TITLE
Handle transactions properly

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestLogger.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestLogger.kt
@@ -7,7 +7,7 @@ import spark.Request
 import spark.Response
 import java.time.Instant
 
-class RequestLogger(val accessLogRepository: () -> AccessLogRepository)
+class RequestLogger(private val accessLogRepository: AccessLogRepository)
 {
     fun log(req: Request, res: Response)
     {
@@ -16,9 +16,7 @@ class RequestLogger(val accessLogRepository: () -> AccessLogRepository)
         val resource = req.pathInfo()
         val statusCode = res.status()
         val ip = req.ip()
-        accessLogRepository().use {
-            it.log(principal, timestamp, resource, statusCode, ip)
-        }
+        accessLogRepository.log(principal, timestamp, resource, statusCode, ip)
     }
     fun log(context: SparkWebContext)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
@@ -8,7 +8,7 @@ import org.vaccineimpact.api.app.OneTimeLinkActionContext
 import org.vaccineimpact.api.app.controllers.endpoints.EndpointDefinition
 import org.vaccineimpact.api.app.controllers.endpoints.getWrappedRoute
 import org.vaccineimpact.api.app.errors.UnsupportedValueException
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.serialization.Serializer
 import org.vaccineimpact.api.db.Config
@@ -20,12 +20,12 @@ import java.time.Duration
 abstract class AbstractController(controllerContext: ControllerContext)
 {
     protected val logger: Logger = LoggerFactory.getLogger(AbstractController::class.java)
-    protected val repos = controllerContext.repositories
+    protected val repos = controllerContext.repositoryFactory
     private val urlBase = controllerContext.urlBase
     val tokenHelper = controllerContext.tokenHelper
 
     abstract val urlComponent: String
-    abstract fun endpoints(repos: Repositories): Iterable<EndpointDefinition<*>>
+    abstract fun endpoints(repos: RepositoryFactory): Iterable<EndpointDefinition<*>>
 
     fun mapEndpoints(): List<String>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ControllerContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ControllerContext.kt
@@ -1,10 +1,10 @@
 package org.vaccineimpact.api.app.controllers
 
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.security.WebTokenHelper
 
 open class ControllerContext(
         open val urlBase: String,
-        open val repositories: Repositories,
+        open val repositoryFactory: RepositoryFactory,
         open val tokenHelper: WebTokenHelper
 )

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -3,16 +3,16 @@ package org.vaccineimpact.api.app.controllers
 import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
 import org.vaccineimpact.api.app.controllers.endpoints.secured
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.models.Disease
 
 class DiseaseController(context: ControllerContext) : AbstractController(context)
 {
     override val urlComponent = "/diseases"
-    override fun endpoints(repos: Repositories) = listOf(
-            oneRepoEndpoint("/", this::getDiseases, repos.simpleObjects).secured(),
-            oneRepoEndpoint("/:id/", this::getDisease, repos.simpleObjects).secured()
+    override fun endpoints(repos: RepositoryFactory) = listOf(
+            oneRepoEndpoint("/", this::getDiseases, repos, { it.simpleObjects }).secured(),
+            oneRepoEndpoint("/:id/", this::getDisease, repos, { it.simpleObjects }).secured()
     )
 
     @Suppress("UNUSED_PARAMETER")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/HomeController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/HomeController.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.endpoints.basicEndpoint
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.db.Config
 
 class HomeController(
@@ -11,7 +11,7 @@ class HomeController(
 ) : AbstractController(context)
 {
     override val urlComponent = ""
-    override fun endpoints(repos: Repositories) = listOf(
+    override fun endpoints(repos: RepositoryFactory) = listOf(
             basicEndpoint("/", this::index)
     )
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModelController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModelController.kt
@@ -4,15 +4,15 @@ import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
 import org.vaccineimpact.api.app.controllers.endpoints.secured
 import org.vaccineimpact.api.app.repositories.ModelRepository
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.models.Model
 
 class ModelController(context: ControllerContext) : AbstractController(context)
 {
     override val urlComponent = "/models"
-    override fun endpoints(repos: Repositories) = listOf(
-            oneRepoEndpoint("/", this::getModels, repos.modelRepository).secured(setOf("*/models.read")),
-            oneRepoEndpoint("/:id/", this::getModel, repos.modelRepository).secured(setOf("*/models.read"))
+    override fun endpoints(repos: RepositoryFactory) = listOf(
+            oneRepoEndpoint("/", this::getModels, repos, { it.modelRepository }).secured(setOf("*/models.read")),
+            oneRepoEndpoint("/:id/", this::getModel, repos, { it.modelRepository }).secured(setOf("*/models.read"))
     )
 
     @Suppress("UNUSED_PARAMETER")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -12,6 +12,7 @@ import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.serialization.DataTable
 import org.vaccineimpact.api.app.serialization.SplitData
 import org.vaccineimpact.api.models.*
@@ -33,19 +34,19 @@ open class ModellingGroupController(context: ControllerContext)
     val scenarioURL = "$responsibilitiesURL/:scenario-id"
     val coverageURL = "$scenarioURL/coverage"
 
-    override fun endpoints(repos: Repositories): Iterable<EndpointDefinition<*>>
+    override fun endpoints(repos: RepositoryFactory): Iterable<EndpointDefinition<*>>
     {
-        val repo = repos.modellingGroup
+        val repo: (Repositories) -> ModellingGroupRepository = { it.modellingGroup }
         return listOf(
-                oneRepoEndpoint("/",                           this::getModellingGroups, repo).secured(setOf("*/modelling-groups.read")),
-                oneRepoEndpoint("/:group-id/",                 this::getModellingGroup, repo).secured(setOf("*/modelling-groups.read", "*/models.read")),
-                oneRepoEndpoint("$responsibilitiesURL/",       this::getResponsibilities, repo).secured(responsibilityPermissions),
-                oneRepoEndpoint("$scenarioURL/",               this::getResponsibility, repo).secured(responsibilityPermissions),
-                oneRepoEndpoint("$scenarioURL/coverage_sets/", this::getCoverageSets, repo).secured(coveragePermissions),
-                oneRepoEndpoint("$coverageURL/",               this::getCoverageDataAndMetadata, repo, contentType = "application/json").secured(coveragePermissions),
-                oneRepoEndpoint("$coverageURL/",               this::getCoverageData, repo, contentType = "text/csv").secured(coveragePermissions),
-                oneRepoEndpoint("$coverageURL/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.COVERAGE) }, repos.token).secured(coveragePermissions),
-                oneRepoEndpoint("$scenarioURL/estimates/",     this::addBurdenEstimate, repos.burdenEstimates, method = HttpMethod.post)
+                oneRepoEndpoint("/",                           this::getModellingGroups, repos, repo).secured(setOf("*/modelling-groups.read")),
+                oneRepoEndpoint("/:group-id/",                 this::getModellingGroup, repos, repo).secured(setOf("*/modelling-groups.read", "*/models.read")),
+                oneRepoEndpoint("$responsibilitiesURL/",       this::getResponsibilities, repos, repo).secured(responsibilityPermissions),
+                oneRepoEndpoint("$scenarioURL/",               this::getResponsibility, repos, repo).secured(responsibilityPermissions),
+                oneRepoEndpoint("$scenarioURL/coverage_sets/", this::getCoverageSets, repos, repo).secured(coveragePermissions),
+                oneRepoEndpoint("$coverageURL/",               this::getCoverageDataAndMetadata, repos, repo, contentType = "application/json").secured(coveragePermissions),
+                oneRepoEndpoint("$coverageURL/",               this::getCoverageData, repos, repo, contentType = "text/csv").secured(coveragePermissions),
+                oneRepoEndpoint("$coverageURL/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.COVERAGE) }, repos, { it.token }).secured(coveragePermissions),
+                oneRepoEndpoint("$scenarioURL/estimates/",     this::addBurdenEstimate, repos, { it.burdenEstimates }, method = HttpMethod.post)
                         .secured(setOf("$groupScope/estimates.write", "$groupScope/responsibilities.read"))
         )
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -4,7 +4,7 @@ import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.OneTimeLink
 import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
 import org.vaccineimpact.api.app.errors.InvalidOneTimeLinkToken
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.security.WebTokenHelper
 import spark.route.HttpMethod
@@ -18,9 +18,9 @@ class OneTimeLinkController(
     override val urlComponent = ""
     val url = "/onetime_link/:token/"
 
-    override fun endpoints(repos: Repositories) = listOf(
-            oneRepoEndpoint(url, this::onetimeLink, repos.token, method = HttpMethod.get),
-            oneRepoEndpoint(url, this::onetimeLink, repos.token, method = HttpMethod.post)
+    override fun endpoints(repos: RepositoryFactory) = listOf(
+            oneRepoEndpoint(url, this::onetimeLink, repos, { it.token }, method = HttpMethod.get),
+            oneRepoEndpoint(url, this::onetimeLink, repos, { it.token }, method = HttpMethod.post)
     )
 
     fun onetimeLink(context: ActionContext, repo: TokenRepository): Any

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
@@ -6,8 +6,8 @@ import org.vaccineimpact.api.app.controllers.endpoints.EndpointDefinition
 import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
 import org.vaccineimpact.api.app.controllers.endpoints.secured
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
-import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.serialization.DataTable
 import org.vaccineimpact.api.app.serialization.SplitData
@@ -21,17 +21,17 @@ class TouchstoneController(context: ControllerContext) : AbstractController(cont
     private val demographicPermissions = permissions + setOf("*/demographics.read")
 
     override val urlComponent: String = "/touchstones"
-    override fun endpoints(repos: Repositories): Iterable<EndpointDefinition<*>>
+    override fun endpoints(repos: RepositoryFactory): Iterable<EndpointDefinition<*>>
     {
-        val repo = repos.touchstone
+        val repo: (Repositories) -> TouchstoneRepository = { it.touchstone }
         return listOf(
-                oneRepoEndpoint("/", this::getTouchstones, repo).secured(permissions),
-                oneRepoEndpoint("/:touchstone-id/scenarios/", this::getScenarios, repo).secured(scenarioPermissions),
-                oneRepoEndpoint("/:touchstone-id/scenarios/:scenario-id/", this::getScenario, repo).secured(scenarioPermissions),
-                oneRepoEndpoint("/:touchstone-id/demographics/", this::getDemographicTypes, repo).secured(demographicPermissions),
-                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/", this::getDemographicDataAndMetadata, repo, contentType = "application/json").secured(demographicPermissions),
-                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/", this::getDemographicData, repo, contentType = "text/csv").secured(demographicPermissions),
-                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.DEMOGRAPHY) }, repos.token).secured(demographicPermissions)
+                oneRepoEndpoint("/", this::getTouchstones, repos, repo).secured(permissions),
+                oneRepoEndpoint("/:touchstone-id/scenarios/", this::getScenarios, repos, repo).secured(scenarioPermissions),
+                oneRepoEndpoint("/:touchstone-id/scenarios/:scenario-id/", this::getScenario, repos, repo).secured(scenarioPermissions),
+                oneRepoEndpoint("/:touchstone-id/demographics/", this::getDemographicTypes, repos, repo).secured(demographicPermissions),
+                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/", this::getDemographicDataAndMetadata, repos, repo, contentType = "application/json").secured(demographicPermissions),
+                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/", this::getDemographicData, repos, repo, contentType = "text/csv").secured(demographicPermissions),
+                oneRepoEndpoint("/:touchstone-id/demographics/:source-code/:type-code/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.DEMOGRAPHY) }, repos, { it.token }).secured(demographicPermissions)
 
         )
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.api.app.controllers.endpoints
 
 import org.vaccineimpact.api.ContentTypes
 import org.vaccineimpact.api.app.DefaultHeadersFilter
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.serialization.DataTable
 import org.vaccineimpact.api.app.serialization.Serializer
 import org.vaccineimpact.api.app.serialization.SplitData
@@ -12,7 +12,7 @@ import spark.Route
 import spark.Spark
 import spark.route.HttpMethod
 
-typealias SetupCallback = (String, WebTokenHelper, Repositories) -> Unit
+typealias SetupCallback = (String, WebTokenHelper, RepositoryFactory) -> Unit
 
 data class Endpoint<TRoute>(
         override val urlFragment: String,
@@ -31,7 +31,7 @@ data class Endpoint<TRoute>(
         }
     }
 
-    override fun additionalSetup(url: String, tokenHelper: WebTokenHelper, repos: Repositories)
+    override fun additionalSetup(url: String, tokenHelper: WebTokenHelper, repos: RepositoryFactory)
     {
         Spark.after(url, contentType, DefaultHeadersFilter(contentType, method))
         additionalSetupCallback?.invoke(url, tokenHelper, repos)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/EndpointDefinition.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/EndpointDefinition.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.api.app.controllers.endpoints
 
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.security.WebTokenHelper
 import spark.Route
 import spark.route.HttpMethod
@@ -13,7 +13,7 @@ interface EndpointDefinition<TRoute>
     val method: HttpMethod
     val contentType: String
 
-    fun additionalSetup(url: String, tokenHelper: WebTokenHelper, repos: Repositories)
+    fun additionalSetup(url: String, tokenHelper: WebTokenHelper, repos: RepositoryFactory)
     fun transform(x: Any): String
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/SecuredEndpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/SecuredEndpoint.kt
@@ -10,11 +10,11 @@ import spark.Spark
 // steps checks the user has a valid token and has all the required permissions
 fun <TRoute> Endpoint<TRoute>.secured(permissions: Set<String> = emptySet()): Endpoint<TRoute>
 {
-    return this.withAdditionalSetup({ url, tokenHelper, repos ->
+    return this.withAdditionalSetup({ url, tokenHelper, repositoryFactory ->
         val allPermissions = (permissions + "*/can-login").map {
             PermissionRequirement.parse(it)
         }
-        val configFactory = TokenVerifyingConfigFactory(tokenHelper, allPermissions.toSet(), repos.accessLogRepository)
+        val configFactory = TokenVerifyingConfigFactory(tokenHelper, allPermissions.toSet(), repositoryFactory)
         val tokenVerifier = configFactory.build()
         Spark.before(url, SecurityFilter(
                 tokenVerifier,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repositories.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repositories.kt
@@ -1,73 +1,52 @@
 package org.vaccineimpact.api.app.repositories
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.vaccineimpact.api.app.repositories.jooq.*
 import org.vaccineimpact.api.db.JooqContext
 
-open class Repositories(
-        open val simpleObjects: () -> SimpleObjectsRepository,
-        open val user: () -> UserRepository,
-        open val token: () -> TokenRepository,
-        open val accessLogRepository: () -> AccessLogRepository,
-        open val modelRepository: () -> ModelRepository,
-        open val touchstone: () -> TouchstoneRepository,
-        open val scenario: () -> ScenarioRepository,
-        open val modellingGroup: () -> ModellingGroupRepository,
-        open val burdenEstimates: () -> BurdenEstimateRepository
-)
-
-fun makeRepositories(): Repositories
+open class RepositoryFactory
 {
-    fun simpleObjects(db: JooqContext, cfg: Configuration) = JooqSimpleObjectsRepository(db, cfg)
-    fun user(db: JooqContext, cfg: Configuration) = JooqUserRepository(db, cfg)
-    fun token(db: JooqContext, cfg: Configuration) = JooqTokenRepository(db, cfg)
-    fun accessLogRepository(db: JooqContext, cfg: Configuration) = JooqAccessLogRepository(db, cfg)
-    fun model(db: JooqContext, cfg: Configuration) = JooqModelRepository(db, cfg)
-    fun scenario(db: JooqContext, cfg: Configuration) = JooqScenarioRepository(db, cfg)
-    fun touchstone(db: JooqContext, cfg: Configuration) = JooqTouchstoneRepository(db, scenario(db, cfg), cfg)
-    fun modellingGroup(db: JooqContext, cfg: Configuration) = JooqModellingGroupRepository(
-            db,
-            touchstone(db, cfg),
-            scenario(db, cfg),
-            cfg
-    )
-    fun burdenEstimates(db: JooqContext, cfg: Configuration) = JooqBurdenEstimateRepository(
-            db,
-            scenario(db, cfg),
-            touchstone(db, cfg),
-            modellingGroup(db, cfg),
-            cfg
-    )
-
-    return Repositories(
-            wrapRepository(::simpleObjects),
-            wrapRepository(::user),
-            wrapRepository(::token),
-            wrapRepository(::accessLogRepository),
-            wrapRepository(::model),
-            wrapRepository(::touchstone),
-            wrapRepository(::scenario),
-            wrapRepository(::modellingGroup),
-            wrapRepository(::burdenEstimates)
-    )
+    open fun <T> inTransaction(work: (Repositories) -> T): T
+    {
+        var result: T? = null
+        JooqContext().use { db ->
+            db.dsl.transaction { config ->
+                val dsl = DSL.using(config)
+                result = work(Repositories(dsl))
+            }
+        }
+        return result!!
+    }
 }
 
-/** Given that we have a repository 'factory' - a function that constructs a repository
- * using a JooqContext - this gives us a new, parameter-less function.
- * Every time this new function is invoked, a new instance of the repository is returned
- * with a new JooqContext instance.
- * It is up to the consumer of the repository to close the repository (and thus the
- * JooqContext
- */
-private fun <T : Repository> wrapRepository(factory: (JooqContext, Configuration) -> T): () -> T
+open class Repositories(val dsl: DSLContext)
 {
-    return {
-        val db = JooqContext()
-        var result: T? = null
-        db.dsl.transaction { config ->
-            result = factory(db, config)
-            //Implicitly committed, unless an exception is thrown
-        }
-        result!!
+    open val simpleObjects: SimpleObjectsRepository by lazy {
+        JooqSimpleObjectsRepository(dsl)
+    }
+    open val user: UserRepository by lazy {
+        JooqUserRepository(dsl)
+    }
+    open val token: TokenRepository by lazy {
+        JooqTokenRepository(dsl)
+    }
+    open val accessLogRepository: AccessLogRepository by lazy {
+        JooqAccessLogRepository(dsl)
+    }
+    open val modelRepository: ModelRepository by lazy {
+        JooqModelRepository(dsl)
+    }
+    open val touchstone: TouchstoneRepository by lazy {
+        JooqTouchstoneRepository(dsl, scenario)
+    }
+    open val scenario: ScenarioRepository by lazy {
+        JooqScenarioRepository(dsl)
+    }
+    open val modellingGroup: ModellingGroupRepository by lazy {
+        JooqModellingGroupRepository(dsl, touchstone, scenario)
+    }
+    open val burdenEstimates: BurdenEstimateRepository by lazy {
+        JooqBurdenEstimateRepository(dsl, scenario, touchstone, modellingGroup)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repository.kt
@@ -1,5 +1,3 @@
 package org.vaccineimpact.api.app.repositories
 
-import java.io.Closeable
-
-interface Repository : Closeable
+interface Repository

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqAccessLogRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqAccessLogRepository.kt
@@ -1,13 +1,12 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.repositories.AccessLogRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.API_ACCESS_LOG
 import java.sql.Timestamp
 import java.time.Instant
 
-class JooqAccessLogRepository(db: JooqContext, config: Configuration) : JooqRepository(db, config), AccessLogRepository
+class JooqAccessLogRepository(dsl: DSLContext) : JooqRepository(dsl), AccessLogRepository
 {
     override fun log(principal: String?, timestamp: Instant, resource: String, responseStatus: Int, ipAddress: String)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.errors.DatabaseContentsError
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
@@ -8,7 +8,6 @@ import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.*
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.db.joinPath
@@ -24,12 +23,11 @@ private data class ResponsibilityInfo
 constructor(val id: Int, val disease: String)
 
 class JooqBurdenEstimateRepository(
-        db: JooqContext,
+        dsl: DSLContext,
         private val scenarioRepository: ScenarioRepository,
         override val touchstoneRepository: TouchstoneRepository,
-        private val modellingGroupRepository: ModellingGroupRepository,
-        config: Configuration? = null
-) : JooqRepository(db, config), BurdenEstimateRepository
+        private val modellingGroupRepository: ModellingGroupRepository
+) : JooqRepository(dsl), BurdenEstimateRepository
 {
     override fun addBurdenEstimateSet(groupId: String, touchstoneId: String, scenarioId: String,
                                       estimates: List<BurdenEstimate>, uploader: String, timestamp: Instant): Int

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModelRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModelRepository.kt
@@ -1,13 +1,14 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
 import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.ModelRepository
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.MODEL
 import org.vaccineimpact.api.models.Model
 
-class JooqModelRepository(db: JooqContext, config: Configuration? = null) : JooqRepository(db, config), ModelRepository
+class JooqModelRepository(dsl: DSLContext) : JooqRepository(dsl), ModelRepository
 {
     override fun all(): List<Model>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -18,12 +18,11 @@ import org.vaccineimpact.api.db.tables.records.ResponsibilitySetRecord
 import org.vaccineimpact.api.models.*
 
 class JooqModellingGroupRepository(
-        db: JooqContext,
+        dsl: DSLContext,
         private val touchstoneRepository: TouchstoneRepository,
-        private val scenarioRepository: ScenarioRepository,
-        config: Configuration? = null
+        private val scenarioRepository: ScenarioRepository
 )
-    : JooqRepository(db, config), ModellingGroupRepository
+    : JooqRepository(dsl), ModellingGroupRepository
 {
     override fun getModellingGroups(): Iterable<ModellingGroup>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
@@ -1,21 +1,14 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
 import org.jooq.DSLContext
-import org.jooq.impl.DSL
 import org.vaccineimpact.api.Deserializer
 import org.vaccineimpact.api.UnknownEnumValue
 import org.vaccineimpact.api.app.errors.BadDatabaseConstant
-import org.vaccineimpact.api.db.JooqContext
-import java.io.Closeable
+import org.vaccineimpact.api.app.repositories.Repository
 
-abstract class JooqRepository(
-        private val db: JooqContext,
-        private val config: Configuration? = null
-): Closeable
+abstract class JooqRepository(val dsl: DSLContext): Repository
 {
     val deserializer = Deserializer()
-    val dsl: DSLContext = DSL.using(config ?: db.dsl.configuration())
 
     protected inline fun <reified T: Enum<T>> mapEnum(raw: String): T
     {
@@ -27,10 +20,5 @@ abstract class JooqRepository(
         {
             throw BadDatabaseConstant(e.name, e.type)
         }
-    }
-
-    override fun close()
-    {
-        db.close()
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
@@ -1,18 +1,16 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.jooq.Record
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.ScenarioRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.SCENARIO
 import org.vaccineimpact.api.db.Tables.SCENARIO_DESCRIPTION
 import org.vaccineimpact.api.db.fieldsAsList
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.models.Scenario
 
-class JooqScenarioRepository(db: JooqContext, config: Configuration? = null)
-    : JooqRepository(db, config), ScenarioRepository
+class JooqScenarioRepository(dsl: DSLContext) : JooqRepository(dsl), ScenarioRepository
 {
     override fun checkScenarioDescriptionExists(id: String)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqSimpleObjectsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqSimpleObjectsRepository.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
 import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.DISEASE
@@ -8,7 +9,7 @@ import org.vaccineimpact.api.db.tables.records.DiseaseRecord
 import org.vaccineimpact.api.models.Disease
 
 
-class JooqSimpleObjectsRepository(db: JooqContext, config: Configuration? = null) : JooqRepository(db, config), SimpleObjectsRepository
+class JooqSimpleObjectsRepository(dsl: DSLContext) : JooqRepository(dsl), SimpleObjectsRepository
 {
     override val diseases = JooqSimpleDataSet.new(dsl, DISEASE, { it.ID }, this::mapDisease)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTokenRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTokenRepository.kt
@@ -1,12 +1,11 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.repositories.TokenRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.ONETIME_TOKEN
 import org.vaccineimpact.api.models.HasKey
 
-class JooqTokenRepository(db: JooqContext, config: Configuration? = null) : JooqRepository(db, config), TokenRepository
+class JooqTokenRepository(dsl: DSLContext) : JooqRepository(dsl), TokenRepository
 {
     data class OneTimeToken(override val id: String) : HasKey<String>
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -20,11 +20,8 @@ import org.vaccineimpact.api.db.tables.records.TouchstoneRecord
 import org.vaccineimpact.api.models.*
 import java.math.BigDecimal
 
-class JooqTouchstoneRepository(
-        db: JooqContext,
-        private val scenarioRepository: ScenarioRepository,
-        config: Configuration? = null
-) : JooqRepository(db, config), TouchstoneRepository
+class JooqTouchstoneRepository(dsl: DSLContext, private val scenarioRepository: ScenarioRepository)
+    : JooqRepository(dsl), TouchstoneRepository
 {
     override fun getDemographicDataset(statisticTypeCode: String,
                                        source: String,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
@@ -1,11 +1,10 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.Configuration
+import org.jooq.DSLContext
 import org.jooq.Record
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.models.CreateUser
 import org.vaccineimpact.api.app.repositories.UserRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.*
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.db.tables.records.AppUserRecord
@@ -20,10 +19,7 @@ import org.vaccineimpact.api.security.UserProperties
 import java.sql.Timestamp
 import java.time.Instant
 
-class JooqUserRepository(
-        db: JooqContext,
-        config: Configuration? = null
-) : JooqRepository(db, config), UserRepository
+class JooqUserRepository(dsl: DSLContext): JooqRepository(dsl), UserRepository
 {
     override fun updateLastLoggedIn(username: String)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/DatabasePasswordAuthenticator.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/DatabasePasswordAuthenticator.kt
@@ -42,7 +42,7 @@ class DatabasePasswordAuthenticator : Authenticator<UsernamePasswordCredentials>
     private fun validate(email: String, password: String): MontaguUser
     {
         return JooqContext().use { db ->
-            val repo = JooqUserRepository(db, db.dsl.configuration())
+            val repo = JooqUserRepository(db.dsl)
             val user = repo.getMontaguUserByEmail(email)
             if (user == null)
             {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
@@ -4,13 +4,13 @@ import org.pac4j.sparkjava.DefaultHttpActionAdapter
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.RequestLogger
 import org.vaccineimpact.api.app.addDefaultResponseHeaders
-import org.vaccineimpact.api.app.repositories.AccessLogRepository
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.serialization.Serializer
 import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
 
-abstract class MontaguHttpActionAdapter(private val accessLogRepository: () -> AccessLogRepository)
+abstract class MontaguHttpActionAdapter(private val repositoryFactory: RepositoryFactory)
     : DefaultHttpActionAdapter()
 {
     protected fun haltWithError(code: Int, context: SparkWebContext, errors: List<ErrorInfo>)
@@ -21,7 +21,9 @@ abstract class MontaguHttpActionAdapter(private val accessLogRepository: () -> A
     protected fun haltWithError(code: Int, context: SparkWebContext, response: String)
     {
         addDefaultResponseHeaders(context.response)
-        RequestLogger(accessLogRepository).log(context)
+        repositoryFactory.inTransaction { repos ->
+            RequestLogger(repos.accessLogRepository).log(context)
+        }
         spark.Spark.halt(code, response)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/TokenIssuingConfigFactory.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/TokenIssuingConfigFactory.kt
@@ -4,29 +4,27 @@ import org.pac4j.core.config.Config
 import org.pac4j.core.config.ConfigFactory
 import org.pac4j.core.context.HttpConstants
 import org.pac4j.http.client.direct.DirectBasicAuthClient
-import org.pac4j.sparkjava.DefaultHttpActionAdapter
 import org.pac4j.sparkjava.SparkWebContext
-import org.vaccineimpact.api.app.RequestLogger
-import org.vaccineimpact.api.app.addDefaultResponseHeaders
 import org.vaccineimpact.api.app.repositories.AccessLogRepository
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.serialization.Serializer
 import org.vaccineimpact.api.models.FailedAuthentication
 import spark.Spark as spk
 
-class TokenIssuingConfigFactory(private val accessLogRepository: () -> AccessLogRepository) : ConfigFactory
+class TokenIssuingConfigFactory(private val repositoryFactory: RepositoryFactory) : ConfigFactory
 {
     override fun build(vararg parameters: Any?): Config
     {
         val authClient = DirectBasicAuthClient(DatabasePasswordAuthenticator())
         return Config(authClient).apply {
-            httpActionAdapter = BasicAuthActionAdapter(accessLogRepository)
+            httpActionAdapter = BasicAuthActionAdapter(repositoryFactory)
             addMethodMatchers()
         }
     }
 }
 
-class BasicAuthActionAdapter(accessLogRepository: () -> AccessLogRepository)
-    : MontaguHttpActionAdapter(accessLogRepository)
+class BasicAuthActionAdapter(repositoryFactory: RepositoryFactory)
+    : MontaguHttpActionAdapter(repositoryFactory)
 {
     private val unauthorizedResponse: String
             = Serializer.instance.gson.toJson(FailedAuthentication("Bad credentials"))

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkTests.kt
@@ -12,6 +12,7 @@ import org.vaccineimpact.api.app.controllers.MontaguControllers
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.test_helpers.MontaguTests
+import org.vaccineimpact.api.tests.mocks.asFactory
 
 class OneTimeLinkTests : MontaguTests()
 {
@@ -63,12 +64,12 @@ class OneTimeLinkTests : MontaguTests()
             on { modellingGroup } doReturn modelling
         }
         val repos =  mock<Repositories> {
-            on { modellingGroup } doReturn { mock<ModellingGroupRepository>() }
+            on { modellingGroup } doReturn mock<ModellingGroupRepository>()
         }
 
         // Object under test
         val link = OneTimeLink(OneTimeAction.COVERAGE, mapOf(":key" to "value"), mapOf(":queryKey" to "queryValue"))
-        link.perform(controllers, mock(), repos)
+        link.perform(controllers, mock(), repos.asFactory())
 
         // Expectations
         verify(modelling).getCoverageData(check {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
@@ -7,7 +7,7 @@ import org.vaccineimpact.api.OneTimeAction
 import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.AbstractController
 import org.vaccineimpact.api.app.controllers.ControllerContext
-import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.security.WebTokenHelper
 import java.time.Duration
@@ -22,7 +22,7 @@ class AbstractControllerTests : ControllerTests<AbstractController>()
     private class Controller(context: ControllerContext) : AbstractController(context)
     {
         override val urlComponent = "/test"
-        override fun endpoints(repos: Repositories) = throw NotImplementedError("Not needed for tests")
+        override fun endpoints(repos: RepositoryFactory) = throw NotImplementedError("Not needed for tests")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ControllerTests.kt
@@ -1,18 +1,13 @@
 package org.vaccineimpact.api.tests.controllers
 
-import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import org.junit.Test
-import org.vaccineimpact.api.OneTimeAction
-import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.AbstractController
 import org.vaccineimpact.api.app.controllers.ControllerContext
 import org.vaccineimpact.api.app.repositories.Repositories
-import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.test_helpers.MontaguTests
+import org.vaccineimpact.api.tests.mocks.asFactory
 
 abstract class ControllerTests<out TController : AbstractController> : MontaguTests()
 {
@@ -26,7 +21,7 @@ abstract class ControllerTests<out TController : AbstractController> : MontaguTe
             on { urlBase } doReturn "/v1"
             if (repositories != null)
             {
-                on { this.repositories } doReturn repositories
+                on { this.repositoryFactory } doReturn repositories.asFactory()
             }
             if (webTokenHelper != null)
             {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -10,9 +10,10 @@ import org.vaccineimpact.api.app.controllers.ModellingGroupController
 import org.vaccineimpact.api.app.controllers.MontaguControllers
 import org.vaccineimpact.api.app.controllers.OneTimeLinkController
 import org.vaccineimpact.api.app.errors.InvalidOneTimeLinkToken
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TokenRepository
-import org.vaccineimpact.api.app.repositories.makeRepositories
+import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.security.WebTokenHelper
 
 class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
@@ -59,7 +60,7 @@ class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
                         "payload" to ":group-id=gId&:touchstone-id=tId&:scenario-id=sId"
                 ),
                 repos = mock {
-                    on { modellingGroup } doReturn { mock() }
+                    on { modellingGroup } doReturn mock<ModellingGroupRepository>()
                 }
         )
         controller.onetimeLink(actionContext(), makeRepository())
@@ -77,7 +78,7 @@ class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
         val helper = makeTokenHelper(allowToken = helperAllowToken, claims = claims)
         val controllerContext = mockControllerContext(
                 webTokenHelper = helper,
-                repositories = repos ?: makeRepositories()
+                repositories = repos ?: Repositories(JooqContext().dsl)
         )
         val otherController = modellingGroupController ?: mock<ModellingGroupController>()
         val otherControllers = mock<MontaguControllers> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -13,7 +13,6 @@ import org.vaccineimpact.api.app.errors.InvalidOneTimeLinkToken
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TokenRepository
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.security.WebTokenHelper
 
 class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
@@ -78,7 +77,7 @@ class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
         val helper = makeTokenHelper(allowToken = helperAllowToken, claims = claims)
         val controllerContext = mockControllerContext(
                 webTokenHelper = helper,
-                repositories = repos ?: Repositories(JooqContext().dsl)
+                repositories = repos ?: mock()
         )
         val otherController = modellingGroupController ?: mock<ModellingGroupController>()
         val otherControllers = mock<MontaguControllers> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.controllers.PasswordController
 import org.vaccineimpact.api.app.errors.MissingRequiredParameterError
 import org.vaccineimpact.api.app.models.SetPassword
 import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.repositories.UserRepository
 import org.vaccineimpact.api.emails.EmailManager
 import org.vaccineimpact.api.emails.PasswordSetEmail
@@ -92,8 +93,8 @@ class PasswordControllerTests : ControllerTests<PasswordController>()
             on { getMontaguUserByEmail("fake@example.com") } doReturn user
         }
         return mock {
-            on { this.user } doReturn { userRepo }
-            on { this.token } doReturn { mock() }
+            on { this.user } doReturn userRepo
+            on { this.token } doReturn mock<TokenRepository>()
         }
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.controllers.ControllerContext
 import org.vaccineimpact.api.app.controllers.UserController
 import org.vaccineimpact.api.app.models.CreateUser
 import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.repositories.UserRepository
 import org.vaccineimpact.api.emails.EmailManager
 import org.vaccineimpact.api.emails.NewUserEmail
@@ -59,8 +60,8 @@ class CreateUserTests : UserControllerTests()
     private fun makeRepos(userRepo: UserRepository = mock()): Repositories
     {
         return mock {
-            on { user } doReturn { userRepo }
-            on { token } doReturn { mock() }
+            on { user } doReturn userRepo
+            on { token } doReturn mock<TokenRepository>()
         }
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/mocks/MockRepositoryFactory.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/mocks/MockRepositoryFactory.kt
@@ -1,0 +1,14 @@
+package org.vaccineimpact.api.tests.mocks
+
+import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+
+class MockRepositoryFactory(val repositories: Repositories) : RepositoryFactory()
+{
+    override fun <T> inTransaction(work: (Repositories) -> T): T
+    {
+        return work(repositories)
+    }
+}
+
+fun Repositories.asFactory() = MockRepositoryFactory(this)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/BurdenEstimateRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/BurdenEstimateRepositoryTests.kt
@@ -29,10 +29,10 @@ class BurdenEstimateRepositoryTests : RepositoryTests<BurdenEstimateRepository>(
 
     override fun makeRepository(db: JooqContext): BurdenEstimateRepository
     {
-        val scenario = JooqScenarioRepository(db)
-        val touchstone = JooqTouchstoneRepository(db, scenario)
-        val modellingGroup = JooqModellingGroupRepository(db, touchstone, scenario)
-        return JooqBurdenEstimateRepository(db, scenario, touchstone, modellingGroup)
+        val scenario = JooqScenarioRepository(db.dsl)
+        val touchstone = JooqTouchstoneRepository(db.dsl, scenario)
+        val modellingGroup = JooqModellingGroupRepository(db.dsl, touchstone, scenario)
+        return JooqBurdenEstimateRepository(db.dsl, scenario, touchstone, modellingGroup)
     }
 
     private val scenarioId = "scenario-1"

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/DiseaseTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/DiseaseTests.kt
@@ -48,5 +48,5 @@ class DiseaseTests : RepositoryTests<SimpleObjectsRepository>()
         }
     }
 
-    override fun makeRepository(db: JooqContext) = JooqSimpleObjectsRepository(db)
+    override fun makeRepository(db: JooqContext) = JooqSimpleObjectsRepository(db.dsl)
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/ModelTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/ModelTests.kt
@@ -52,5 +52,5 @@ class ModelTests : RepositoryTests<ModelRepository>()
         }
     }
 
-    override fun makeRepository(db: JooqContext) = JooqModelRepository(db)
+    override fun makeRepository(db: JooqContext) = JooqModelRepository(db.dsl)
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/TokenRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/TokenRepositoryTests.kt
@@ -9,7 +9,7 @@ import org.vaccineimpact.api.db.Tables.ONETIME_TOKEN
 
 class TokenRepositoryTests : RepositoryTests<TokenRepository>()
 {
-    override fun makeRepository(db: JooqContext) = JooqTokenRepository(db)
+    override fun makeRepository(db: JooqContext) = JooqTokenRepository(db.dsl)
 
     @Test
     fun `can store token`()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/TransactionalityTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/TransactionalityTests.kt
@@ -1,0 +1,54 @@
+package org.vaccineimpact.api.databaseTests
+
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.vaccineimpact.api.app.controllers.endpoints.Endpoint
+import org.vaccineimpact.api.app.controllers.endpoints.getWrappedRoute
+import org.vaccineimpact.api.app.controllers.endpoints.multiRepoEndpoint
+import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.app.repositories.TokenRepository
+import org.vaccineimpact.api.db.JooqContext
+import org.vaccineimpact.api.db.Tables.ONETIME_TOKEN
+import org.vaccineimpact.api.test_helpers.DatabaseTest
+
+class TransactionalityTests : DatabaseTest()
+{
+    @Test
+    fun `oneRepoEndpoint changes are made in a transaction`()
+    {
+        val endpoint = makeFakeEndpoint { repo ->
+            repo.storeToken("TEST")
+            throw Exception("This will make the transaction rollback")
+        }
+
+        assertThatThrownBy {
+            endpoint.getWrappedRoute().handle(mock(), mock())
+        }
+        JooqContext().use { db ->
+            assertThat(db.dsl.fetch(ONETIME_TOKEN)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `multiRepoEndpoint changes are made in a transaction`()
+    {
+        val endpoint = multiRepoEndpoint("/", { _, repos ->
+            repos.token.storeToken("TEST")
+        }, RepositoryFactory())
+
+        assertThatThrownBy {
+            endpoint.getWrappedRoute().handle(mock(), mock())
+        }
+        JooqContext().use { db ->
+            assertThat(db.dsl.fetch(ONETIME_TOKEN)).isEmpty()
+        }
+    }
+
+    private fun makeFakeEndpoint(handler: (TokenRepository) -> Unit): Endpoint<*>
+    {
+        return oneRepoEndpoint("/", { _, repo -> handler(repo) }, RepositoryFactory(), { it.token })
+    }
+}

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/UserTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/UserTests.kt
@@ -23,7 +23,7 @@ class UserTests : RepositoryTests<UserRepository>()
 {
     val username = "test.user"
     val email = "test@example.com"
-    override fun makeRepository(db: JooqContext) = JooqUserRepository(db)
+    override fun makeRepository(db: JooqContext) = JooqUserRepository(db.dsl)
 
     private fun addTestUser(db: JooqContext)
     {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/modellingGroupRepository/ModellingGroupRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/modellingGroupRepository/ModellingGroupRepositoryTests.kt
@@ -11,8 +11,8 @@ abstract class ModellingGroupRepositoryTests : RepositoryTests<ModellingGroupRep
 {
     override fun makeRepository(db: JooqContext): ModellingGroupRepository
     {
-        val scenarioRepository = JooqScenarioRepository(db)
-        val touchstoneRepository = JooqTouchstoneRepository(db, scenarioRepository)
-        return JooqModellingGroupRepository(db, touchstoneRepository, scenarioRepository)
+        val scenarioRepository = JooqScenarioRepository(db.dsl)
+        val touchstoneRepository = JooqTouchstoneRepository(db.dsl, scenarioRepository)
+        return JooqModellingGroupRepository(db.dsl, touchstoneRepository, scenarioRepository)
     }
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/touchstoneRepository/TouchstoneRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/touchstoneRepository/TouchstoneRepositoryTests.kt
@@ -19,8 +19,8 @@ abstract class TouchstoneRepositoryTests : RepositoryTests<TouchstoneRepository>
 
     override fun makeRepository(db: JooqContext): TouchstoneRepository
     {
-        val scenarioRepository = JooqScenarioRepository(db)
-        return JooqTouchstoneRepository(db, scenarioRepository)
+        val scenarioRepository = JooqScenarioRepository(db.dsl)
+        return JooqTouchstoneRepository(db.dsl, scenarioRepository)
     }
 
     protected fun createTouchstoneAndScenarioDescriptions(it: JooqContext)


### PR DESCRIPTION
This required a pretty big rewrite, but I think the resulting code is actually a fair bit simpler.

Here's basically what's changed: Previously we had the `Repositories` object, that contained a factory for each repository, which would provide each one with their own database connection. Now we have a separate `RepositoryFactory` class that will make an instance of the `Repositories` object, which now contains actual instantiated repositories, all sharing a single database connection and transaction.

This has resulted in the code getting simpler in most places. The places where it has gotten more complicated are places where we were kind of doing things in a fudged way anyway before; the new approach forces us to always handle it correctly.