### PR TITLE
Add onetime link endoint for uploading burden estimates

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLinkActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLinkActionContext.kt
@@ -3,7 +3,8 @@ package org.vaccineimpact.api.app
 class OneTimeLinkActionContext(
         private val payload: Map<String, String>,
         private val queryParams: Map<String, String>,
-        context: ActionContext
+        context: ActionContext,
+        username: String
 ) : ActionContext by context
 {
     override fun params() = payload
@@ -23,4 +24,5 @@ class OneTimeLinkActionContext(
         return queryParams[key]
     }
 
+    override val username: String? = username
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
@@ -42,7 +42,7 @@ abstract class AbstractController(controllerContext: ControllerContext)
         val actionAsString = Serializer.instance.serializeEnum(action)
         val params = context.params()
         val queryString = context.queryString()
-        val token = tokenHelper.generateOneTimeActionToken(actionAsString, params, queryString, duration)
+        val token = tokenHelper.generateOneTimeActionToken(actionAsString, params, queryString, duration, context.username!!)
         repo.storeToken(token)
         return token
     }
@@ -50,7 +50,7 @@ abstract class AbstractController(controllerContext: ControllerContext)
     fun getSetPasswordToken(username: String, context: ActionContext, repo: TokenRepository): String
     {
         val params = mapOf(":username" to username)
-        val contextWithParams = OneTimeLinkActionContext(params, emptyMap(), context)
+        val contextWithParams = OneTimeLinkActionContext(params, emptyMap(), context, username)
         return getOneTimeLinkToken(contextWithParams, repo, OneTimeAction.SET_PASSWORD, duration = Duration.ofDays(1))
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -47,6 +47,8 @@ open class ModellingGroupController(context: ControllerContext)
                 oneRepoEndpoint("$coverageURL/",               this::getCoverageData, repos, repo, contentType = "text/csv").secured(coveragePermissions),
                 oneRepoEndpoint("$coverageURL/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.COVERAGE) }, repos, { it.token }).secured(coveragePermissions),
                 oneRepoEndpoint("$scenarioURL/estimates/",     this::addBurdenEstimate, repos, { it.burdenEstimates }, method = HttpMethod.post)
+                        .secured(setOf("$groupScope/estimates.write", "$groupScope/responsibilities.read")),
+                oneRepoEndpoint("$scenarioURL/estimates/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.BURDENS)}, repos, { it.token})
                         .secured(setOf("$groupScope/estimates.write", "$groupScope/responsibilities.read"))
         )
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkActionContextTests.kt
@@ -13,7 +13,7 @@ class OneTimeLinkActionContextTests : MontaguTests()
     fun `can retrieve parameter from payload with or without colon`()
     {
         val payload = mapOf(":key" to "value")
-        val context = OneTimeLinkActionContext(payload, mapOf(), mock())
+        val context = OneTimeLinkActionContext(payload, mapOf(), mock(), username = "test.user")
 
         assertThat(context.params("key")).isEqualTo("value")
         assertThat(context.params(":key")).isEqualTo("value")
@@ -24,7 +24,7 @@ class OneTimeLinkActionContextTests : MontaguTests()
     fun `can retrieve query params from payload`()
     {
         val queryParams = mapOf("query" to "answer")
-        val context = OneTimeLinkActionContext(mapOf(), queryParams, mock())
+        val context = OneTimeLinkActionContext(mapOf(), queryParams, mock(), username = "test.user")
 
         assertThat(context.queryParams("query")).isEqualTo("answer")
         assertThat(context.queryParams("bad key")).isNull()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/OneTimeLinkTests.kt
@@ -22,7 +22,8 @@ class OneTimeLinkTests : MontaguTests()
         val actual = OneTimeLink.parseClaims(mapOf(
                 "action" to "coverage",
                 "payload" to "a=1&b=2",
-                "query" to "q=3&z=4"
+                "query" to "q=3&z=4",
+                "username" to "test.user"
         ))
         assertThat(actual).isEqualTo(OneTimeLink(
                 action = OneTimeAction.COVERAGE,
@@ -33,7 +34,8 @@ class OneTimeLinkTests : MontaguTests()
                 queryParams = mapOf(
                         "q" to "3",
                         "z" to "4"
-                )
+                ),
+                username = "test.user"
         ))
     }
 
@@ -43,7 +45,8 @@ class OneTimeLinkTests : MontaguTests()
         val actual = OneTimeLink.parseClaims(mapOf(
                 "action" to "coverage",
                 "payload" to "a=1&b=2",
-                "query" to ""
+                "query" to "",
+                "username" to "test.user"
         ))
         assertThat(actual).isEqualTo(OneTimeLink(
                 action = OneTimeAction.COVERAGE,
@@ -51,7 +54,8 @@ class OneTimeLinkTests : MontaguTests()
                         "a" to "1",
                         "b" to "2"
                 ),
-                queryParams = mapOf()
+                queryParams = mapOf(),
+                username = "test.user"
         ))
     }
 
@@ -68,7 +72,7 @@ class OneTimeLinkTests : MontaguTests()
         }
 
         // Object under test
-        val link = OneTimeLink(OneTimeAction.COVERAGE, mapOf(":key" to "value"), mapOf(":queryKey" to "queryValue"))
+        val link = OneTimeLink(OneTimeAction.COVERAGE, mapOf(":key" to "value"), mapOf(":queryKey" to "queryValue"), "test.user")
         link.perform(controllers, mock(), repos.asFactory())
 
         // Expectations

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
@@ -41,6 +41,7 @@ class AbstractControllerTests : ControllerTests<AbstractController>()
         val parameters = mapOf(":a" to "1", ":b" to "2")
         val context = mock<ActionContext> {
             on { params() } doReturn parameters
+            on { username } doReturn "test.user"
         }
         val tokenRepo = mock<TokenRepository>()
         val tokenHelper = tokenHelperThatCanGenerateOnetimeTokens()
@@ -66,12 +67,12 @@ class AbstractControllerTests : ControllerTests<AbstractController>()
                 argThat { this[":username"] == "user" },
                 eq(null),
                 eq(Duration.ofDays(1)),
-                username = "test.user"
+                eq("user")
         )
     }
 
     private fun tokenHelperThatCanGenerateOnetimeTokens() = mock<WebTokenHelper> {
-        on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), username = "test.user") } doReturn "MY-TOKEN"
+        on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), any()) } doReturn "MY-TOKEN"
         on { oneTimeLinkLifeSpan } doReturn Duration.ofSeconds(30)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/AbstractControllerTests.kt
@@ -50,7 +50,7 @@ class AbstractControllerTests : ControllerTests<AbstractController>()
         controller.getOneTimeLinkToken(context, tokenRepo, OneTimeAction.COVERAGE)
 
         // Expectations
-        verify(tokenHelper).generateOneTimeActionToken("coverage", parameters, null)
+        verify(tokenHelper).generateOneTimeActionToken("coverage", parameters, null, username = "test.user")
         verify(tokenRepo).storeToken("MY-TOKEN")
     }
 
@@ -65,12 +65,13 @@ class AbstractControllerTests : ControllerTests<AbstractController>()
                 eq("set-password"),
                 argThat { this[":username"] == "user" },
                 eq(null),
-                eq(Duration.ofDays(1))
+                eq(Duration.ofDays(1)),
+                username = "test.user"
         )
     }
 
     private fun tokenHelperThatCanGenerateOnetimeTokens() = mock<WebTokenHelper> {
-        on { generateOneTimeActionToken(any(), any(), anyOrNull(), any()) } doReturn "MY-TOKEN"
+        on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), username = "test.user") } doReturn "MY-TOKEN"
         on { oneTimeLinkLifeSpan } doReturn Duration.ofSeconds(30)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
@@ -101,7 +101,7 @@ class PasswordControllerTests : ControllerTests<PasswordController>()
     private fun makeControllerForLinkRequest(emailManager: EmailManager): PasswordController
     {
         val tokenHelper = mock<WebTokenHelper> {
-            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), "test.user") } doReturn "TOKEN"
+            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), any()) } doReturn "TOKEN"
         }
         return PasswordController(
                 context = mockControllerContext(webTokenHelper = tokenHelper),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/PasswordControllerTests.kt
@@ -101,7 +101,7 @@ class PasswordControllerTests : ControllerTests<PasswordController>()
     private fun makeControllerForLinkRequest(emailManager: EmailManager): PasswordController
     {
         val tokenHelper = mock<WebTokenHelper> {
-            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any()) } doReturn "TOKEN"
+            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), "test.user") } doReturn "TOKEN"
         }
         return PasswordController(
                 context = mockControllerContext(webTokenHelper = tokenHelper),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
@@ -81,7 +81,7 @@ class CreateUserTests : UserControllerTests()
     private fun controllerContext(): ControllerContext
     {
         return mockControllerContext(webTokenHelper = mock {
-            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), username) } doReturn fakeToken
+            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), any()) } doReturn fakeToken
         })
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/userController/CreateUserTests.kt
@@ -81,7 +81,7 @@ class CreateUserTests : UserControllerTests()
     private fun controllerContext(): ControllerContext
     {
         return mockControllerContext(webTokenHelper = mock {
-            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any()) } doReturn fakeToken
+            on { generateOneTimeActionToken(any(), any(), anyOrNull(), any(), username) } doReturn fakeToken
         })
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -57,7 +57,7 @@ class WebTokenHelperTests : MontaguTests()
         val token = helper.generateOneTimeActionToken("test-action", mapOf(
                 ":a" to "1",
                 ":b" to "2"
-        ), queryString)
+        ), queryString, username = "test.user")
         val claims = helper.verify(token)
 
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
@@ -66,6 +66,7 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["action"]).isEqualTo("test-action")
         assertThat(claims["payload"]).isEqualTo(":a=1&:b=2")
         assertThat(claims["query"]).isEqualTo(queryString)
+        assertThat(claims["username"]).isEqualTo("test.user")
     }
 
     @Test
@@ -74,7 +75,7 @@ class WebTokenHelperTests : MontaguTests()
         val token = helper.generateOneTimeActionToken("test-action", mapOf(
                 ":a" to "1",
                 ":b" to "2"
-        ), null)
+        ), null, username = "test.user")
         val claims = helper.verify(token)
 
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
@@ -83,6 +84,7 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["action"]).isEqualTo("test-action")
         assertThat(claims["payload"]).isEqualTo(":a=1&:b=2")
         assertThat(claims["query"]).isNull()
+        assertThat(claims["username"]).isEqualTo("test.user")
     }
 
     @Test

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BurdenEstimateTests.kt
@@ -2,11 +2,13 @@ package org.vaccineimpact.api.blackboxTests
 
 import org.junit.Test
 import org.vaccineimpact.api.blackboxTests.helpers.LocationContraint
+import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
 import org.vaccineimpact.api.blackboxTests.helpers.validate
 import org.vaccineimpact.api.blackboxTests.schemas.CSVSchema
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.test_helpers.DatabaseTest
+import org.vaccineimpact.api.validateSchema.JSONValidator
 import spark.route.HttpMethod
 
 class BurdenEstimateTests : DatabaseTest()
@@ -37,6 +39,32 @@ class BurdenEstimateTests : DatabaseTest()
                     "$groupScope/responsibilities.read"
             )
         } andCheckObjectCreation LocationContraint(url, unknownId = true)
+    }
+
+    @Test
+    fun `can upload burden estimate via onetime link`()
+    {
+        validate("$url/get_onetime_link/") against "Token" given { db ->
+            db.addTouchstone("touchstone", 1, "Touchstone 1", addName = true)
+            db.addScenarioDescription(scenarioId, "Test scenario", "Hib3", addDisease = true)
+            db.addGroup(groupId, "Test group")
+            db.addModel("model-1", groupId, versions = listOf("version-1"))
+            val setId = db.addResponsibilitySet(groupId, touchstoneId)
+            db.addResponsibility(setId, touchstoneId, scenarioId)
+        } requiringPermissions {
+            PermissionSet(
+                    "$groupScope/estimates.write",
+                    "$groupScope/responsibilities.read"
+            )
+        } andCheckString { token ->
+            val oneTimeURL = "/onetime_link/$token/"
+            val requestHelper = RequestHelper()
+            val response = requestHelper.post(oneTimeURL, csvData)
+            assert(response.statusCode == 201)
+
+            val badResponse =  requestHelper.get(oneTimeURL)
+            JSONValidator().validateError(badResponse.text, expectedErrorCode = "invalid-token-used")
+        }
     }
 
     val csvData = """

--- a/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/OneTimeAction.kt
+++ b/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/OneTimeAction.kt
@@ -4,5 +4,6 @@ enum class OneTimeAction
 {
     COVERAGE,
     DEMOGRAPHY,
-    SET_PASSWORD
+    SET_PASSWORD,
+    BURDENS
 }

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -26,7 +26,8 @@ open class WebTokenHelper(keyPair: KeyPair)
     open fun generateOneTimeActionToken(action: String,
                                         params: Map<String, String>,
                                         queryString: String?,
-                                        lifeSpan: Duration = oneTimeLinkLifeSpan): String
+                                        lifeSpan: Duration = oneTimeLinkLifeSpan,
+                                        username: String): String
     {
         return generator.generate(mapOf(
                 "iss" to issuer,
@@ -35,7 +36,8 @@ open class WebTokenHelper(keyPair: KeyPair)
                 "action" to action,
                 "payload" to params.map { "${it.key}=${it.value}" }.joinToString("&"),
                 "query" to queryString,
-                "nonce" to getNonce()
+                "nonce" to getNonce(),
+                "username" to username
         ))
     }
 


### PR DESCRIPTION
* include username in onetime link token claims and make available in onetime link action context
* add one time link for burden estimate upload