### PR TITLE
Don't allow burden estimate uploads for locked sets

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/OperationNotAllowedError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/OperationNotAllowedError.kt
@@ -1,0 +1,7 @@
+package org.vaccineimpact.api.app.errors
+
+import org.vaccineimpact.api.models.ErrorInfo
+
+class OperationNotAllowedError(message: String) : MontaguError(401, listOf(
+        ErrorInfo("forbidden", message)
+))

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -38,14 +38,15 @@ class JooqBurdenEstimateRepository(
         val modellingGroup = modellingGroupRepository.getModellingGroup(groupId)
 
         val responsibilityInfo = getResponsibilityInfo(modellingGroup.id, touchstoneId, scenarioId)
+        val status = responsibilityInfo.setStatus.toLowerCase()
 
-        if (responsibilityInfo.setStatus.toLowerCase() == ResponsibilitySetStatus.SUBMITTED.name.toLowerCase())
+        if (status == ResponsibilitySetStatus.SUBMITTED.name.toLowerCase())
         {
             throw OperationNotAllowedError("The burden estimates uploaded for this touchstone have been submitted " +
                     "for review. You cannot upload any new estimates.")
         }
 
-        if (responsibilityInfo.setStatus.toLowerCase() == ResponsibilitySetStatus.APPROVED.name.toLowerCase())
+        if (status == ResponsibilitySetStatus.APPROVED.name.toLowerCase())
         {
             throw OperationNotAllowedError("The burden estimates uploaded for this touchstone have been reviewed" +
                     " and approved. You cannot upload any new estimates.")

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/BurdenEstimateRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/BurdenEstimateRepositoryTests.kt
@@ -159,7 +159,7 @@ class BurdenEstimateRepositoryTests : RepositoryTests<BurdenEstimateRepository>(
     }
 
     private fun setupDatabase(db: JooqContext, addModel: Boolean = true,
-                              responsibilitySetStatus: String = ResponsibilitySetStatus.INCOMPLETE.toString()): ReturnedIds
+                              responsibilitySetStatus: String = "incomplete"): ReturnedIds
     {
         db.addTouchstone("touchstone", 1, "Touchstone 1", addName = true)
         db.addScenarioDescription(scenarioId, "Test scenario", "Hib3", addDisease = true)


### PR DESCRIPTION
Don't allow burden estimate set upload if responsibility set status is submitted or approved