### PR TITLE
Stream demographic data from database to browser

### DIFF
--- a/spec/DemographicMetadata.schema.json
+++ b/spec/DemographicMetadata.schema.json
@@ -4,11 +4,11 @@
     "properties": {
         "id": { "$ref": "StandardIdentifier.schema.json" },
         "name": { "type": "string" },
-        "source": { "anyOf": [ {"type": "string"}, {"type": "null"} ]},
+        "source": { "type": "string" },
         "countries": { "type": "array", "items": { "$ref": "CountryId.schema.json"  } },
         "age_interpretation": { "type": "string" },
         "unit": { "type": "string" },
-        "gender": { "anyOf": [ {"type": "string"}, {"type": "null"} ]}
+        "gender": { "type": "string" }
     },
     "additionalProperties": false,
     "required": [ "id", "source", "name", "countries", "age_interpretation", "unit" ]

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -127,7 +127,7 @@ open class ModellingGroupController(context: ControllerContext)
         return SplitData(splitData.structuredMetadata, tableData)
     }
 
-    private fun getWideDatatable(data: Iterable<LongCoverageRow>):
+    private fun getWideDatatable(data: Sequence<LongCoverageRow>):
             FlexibleDataTable<WideCoverageRow>
     {
         val groupedRows = data
@@ -147,7 +147,7 @@ open class ModellingGroupController(context: ControllerContext)
         // all the rows should have the same number of years, so we just look at the first row
         val years = rows.first().coverageAndTargetPerYear.keys.toList()
 
-        return FlexibleDataTable.new(rows, years)
+        return FlexibleDataTable.new(rows.asSequence(), years)
     }
 
     private fun mapWideCoverageRow(records: List<LongCoverageRow>)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
@@ -89,10 +89,9 @@ class TouchstoneController(context: ControllerContext) : AbstractController(cont
         }
 
         return SplitData(splitData.structuredMetadata, tableData)
-
     }
 
-    private fun getWideDemographicDatatable(data: Iterable<LongDemographicRow>):
+    private fun getWideDemographicDatatable(data: Sequence<LongDemographicRow>):
             FlexibleDataTable<WideDemographicRow>
     {
         val groupedRows = data
@@ -106,7 +105,7 @@ class TouchstoneController(context: ControllerContext) : AbstractController(cont
         // all the rows should have the same number of years, so we just look at the first row
         val years = rows.first().valuesPerYear.keys.toList()
 
-        return FlexibleDataTable.new(rows, years)
+        return FlexibleDataTable.new(rows.asSequence(), years)
     }
 
     fun getDemographicData(context: ActionContext, repo: TouchstoneRepository)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/DataTable.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/DataTable.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 
-open class DataTable<T : Any>(override val data: Iterable<T>, val type: KClass<T>) : StreamSerializable<T>
+open class DataTable<T : Any>(override val data: Sequence<T>, val type: KClass<T>) : StreamSerializable<T>
 {
     class DataTableHeader<T>(name: String, val property: KProperty1<T, *>, serializer: Serializer)
     {
@@ -68,6 +68,6 @@ open class DataTable<T : Any>(override val data: Iterable<T>, val type: KClass<T
     companion object
     {
         // Simple helper to get around JVM type erasure
-        inline fun <reified R : Any> new(data: Iterable<R>) = DataTable(data, R::class)
+        inline fun <reified R : Any> new(data: Sequence<R>) = DataTable(data, R::class)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/FlexibleDataTable.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/FlexibleDataTable.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 
-class FlexibleDataTable<T : Any>(data: Iterable<T>,
+class FlexibleDataTable<T : Any>(data: Sequence<T>,
                                  private val flexibleHeaders: Iterable<Any>,
                                  type: KClass<T>)
     : DataTable<T>(data, type)
@@ -62,7 +62,7 @@ class FlexibleDataTable<T : Any>(data: Iterable<T>,
     companion object
     {
         // Simple helper to get around JVM type erasure
-        inline fun <reified R : Any> new(data: Iterable<R>, flexibleHeaders: Iterable<Any>)
+        inline fun <reified R : Any> new(data: Sequence<R>, flexibleHeaders: Iterable<Any>)
                 = FlexibleDataTable(data, flexibleHeaders, R::class)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/Serializable.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/serialization/Serializable.kt
@@ -6,5 +6,5 @@ interface StreamSerializable<out T>
 {
     val contentType: String
     fun serialize(stream: OutputStream, serializer: Serializer)
-    val data: Iterable<T>
+    val data: Sequence<T>
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ModellingGroupControllersTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ModellingGroupControllersTests.kt
@@ -301,7 +301,7 @@ class ModellingGroupControllersTests : ControllerTests<ModellingGroupController>
     {
         val coverageSets = mockCoverageSetsData(status)
         val fakeRows = generateCoverageRows(testYear, target, coverage)
-        val data = SplitData(coverageSets, DataTable.new(fakeRows))
+        val data = SplitData(coverageSets, DataTable.new(fakeRows.asSequence()))
         return mock {
             on { getCoverageData(any(), any(), any()) } doReturn data
         }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
@@ -119,7 +119,7 @@ class TouchstoneControllerTests : ControllerTests<TouchstoneController>()
 
         val repo = mock<TouchstoneRepository> {
             on { getDemographicData(type, source, openTouchstone.id) } doReturn
-                    SplitData(demographicMetadata, DataTable.new(listOf()))
+                    SplitData(demographicMetadata, DataTable.new(emptySequence()))
             on { touchstones } doReturn InMemoryDataSet(listOf(openTouchstone))
         }
 
@@ -211,13 +211,14 @@ class TouchstoneControllerTests : ControllerTests<TouchstoneController>()
         val demographicMetadata = DemographicDataForTouchstone(openTouchstone,
                 DemographicMetadata("id", "name", null, listOf(), "people", "age", source))
 
-        val fakeRows = listOf(
+        val fakeRows = sequenceOf(
                 LongDemographicRow(123, "ABC", "ABC-country", 0, 5, 1980, "F", BigDecimal(1200)),
                 LongDemographicRow(123, "ABC", "ABC-country", 0, 5, 1985, "F", BigDecimal(1300)),
                 LongDemographicRow(123, "ABC", "ABC-country", 0, 5, 1990, "F", BigDecimal(1400)),
                 LongDemographicRow(123, "ABC", "ABC-country", 5, 10, 1980, "F", BigDecimal(1500)),
                 LongDemographicRow(456, "DEF", "DEF-country", 0, 5, 1980, "F", BigDecimal(2200)),
-                LongDemographicRow(456, "DEF", "DEF-country", 0, 5, 1985, "F", BigDecimal(2300)))
+                LongDemographicRow(456, "DEF", "DEF-country", 0, 5, 1985, "F", BigDecimal(2300))
+        )
 
         return mock<TouchstoneRepository> {
             on { getDemographicData(type, source, openTouchstone.id) } doReturn

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
@@ -24,14 +24,14 @@ class DataTableTests : MontaguTests()
     @Test
     fun `headers are written in order of constructor`()
     {
-        val table = DataTable.new<ABC>(emptyList())
+        val table = DataTable.new<ABC>(emptySequence())
         assertThat(serialize(table)).isEqualTo("""a,b,c""")
     }
 
     @Test
     fun `data is written out line by line`()
     {
-        val table = DataTable.new(listOf(
+        val table = DataTable.new(sequenceOf(
                 ABC("g", "h", "i"),
                 ABC("x", "y", "z")
         ))
@@ -43,7 +43,7 @@ x,y,z""")
     @Test
     fun `special characters are escaped`()
     {
-        val table = DataTable.new(listOf(
+        val table = DataTable.new(sequenceOf(
                 ABC("g", "h", "i"),
                 ABC("x", "y", "z"),
                 ABC("with, commas", """with "quotes" and no commas""", """both "quotes" and ,commas,""")
@@ -57,7 +57,7 @@ x,y,z
     @Test
     fun `mixed types are written out`()
     {
-        val table = DataTable.new(listOf(
+        val table = DataTable.new(sequenceOf(
                 MixedTypes("text", 123, BigDecimal("3.1415"))
         ))
         assertThat(serialize(table)).isEqualTo("""text,int,dec
@@ -67,7 +67,7 @@ text,123,3.1415""")
     @Test
     fun `null is converted to NA`()
     {
-        val table = DataTable.new(listOf(
+        val table = DataTable.new(sequenceOf(
                 MixedTypes(null, null, null)
         ))
         assertThat(serialize(table)).isEqualTo("""text,int,dec
@@ -77,7 +77,7 @@ text,123,3.1415""")
     @Test
     fun `enum is converted to lowercase with hyphens`()
     {
-        val table = DataTable.new(listOf(
+        val table = DataTable.new(sequenceOf(
                 WithEnums("free text", TouchstoneStatus.IN_PREPARATION)
         ))
         assertThat(serialize(table)).isEqualTo("""text,enum

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/serialization/FlexibleDataTableTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/serialization/FlexibleDataTableTests.kt
@@ -17,14 +17,14 @@ class FlexibleDataTableTests : MontaguTests()
     @Test
     fun `headers are written in order of constructor`()
     {
-        val table = FlexibleDataTable.new<ABC>(listOf(), listOf())
+        val table = FlexibleDataTable.new<ABC>(emptySequence(), listOf())
         Assertions.assertThat(serialize(table)).isEqualTo("""a,b""")
     }
 
     @Test
     fun `throws error if no property marked as flexible`()
     {
-        Assertions.assertThatThrownBy { FlexibleDataTable.new<XYZ>(listOf(), listOf()) }
+        Assertions.assertThatThrownBy { FlexibleDataTable.new<XYZ>(emptySequence(), listOf()) }
                 .hasMessage("No parameter marked as flexible." +
                         " Use the DataTable class to serialise data with fixed headers.")
     }
@@ -32,7 +32,7 @@ class FlexibleDataTableTests : MontaguTests()
     @Test
     fun `throws error if flexible property is not a map`()
     {
-        Assertions.assertThatThrownBy { FlexibleDataTable.new<DEF>(listOf(), listOf()) }
+        Assertions.assertThatThrownBy { FlexibleDataTable.new<DEF>(emptySequence(), listOf()) }
                 .hasMessage("Properties marked as flexible must be of " +
                         "type Map<*, *>, where * can be whatever you like.")
     }
@@ -40,14 +40,14 @@ class FlexibleDataTableTests : MontaguTests()
     @Test
     fun `extra headers are written at the end`()
     {
-        val table = FlexibleDataTable.new<ABC>(listOf(), listOf("extra1", "extra2"))
+        val table = FlexibleDataTable.new<ABC>(emptySequence(), listOf("extra1", "extra2"))
         Assertions.assertThat(serialize(table)).isEqualTo("""a,b,extra1,extra2""")
     }
 
     @Test
     fun `data is written out line by line`()
     {
-        val data = listOf(
+        val data = sequenceOf(
                 ABC("g", "h", mapOf("extra1" to "i", "extra2" to "j")),
                 ABC("x", "y", mapOf("extra1" to "z", "extra2" to "w"))
         )
@@ -61,7 +61,7 @@ x,y,z,w""")
     @Test
     fun `cell is null if row does not contain value for flexible header`()
     {
-        val data = listOf(
+        val data = sequenceOf(
                 ABC("g", "h", mapOf("extra1" to "i", "extra2" to "j")),
                 ABC("x", "y", mapOf("extra2" to "w"))
         )
@@ -75,7 +75,7 @@ x,y,<NA>,w""")
     @Test
     fun `flexible values do not get serialised if header not explicitly provided`()
     {
-        val data = listOf(
+        val data = sequenceOf(
                 ABC("g", "h", mapOf("extra1" to "i", "extra2" to "j")),
                 ABC("x", "y", mapOf("extra2" to "w"))
         )

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/DemographicTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/DemographicTests.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.api.blackboxTests.tests
 import com.beust.klaxon.json
 import com.github.fge.jackson.JsonLoader
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
 import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
@@ -109,7 +110,7 @@ class DemographicTests : DatabaseTest()
                     "age_interpretation" to "age",
                     "source" to "unwpp2015",
                     "unit" to "Number of people",
-                    "gender" to "Both",
+                    "gender" to "both",
                     "countries" to array(countries.sortedBy { it })
             )
         }.toJsonString())
@@ -147,7 +148,7 @@ class DemographicTests : DatabaseTest()
                     "age_interpretation" to "age of mother",
                     "source" to "unwpp2015",
                     "unit" to "Births per woman",
-                    "gender" to "Female",
+                    "gender" to "female",
                     "countries" to array(countries.sortedBy { it })
             )
         }.toJsonString())
@@ -214,7 +215,7 @@ class DemographicTests : DatabaseTest()
             val response = requestHelper.get(oneTimeURL)
             val body = schema.validate(response.text)
 
-            Assertions.assertThat(body.all { it[6] == "Female" }).isTrue()
+            assertThat(body).allMatch { it[6] == "female" }
         }
     }
 

--- a/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/LazyFetching.kt
+++ b/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/LazyFetching.kt
@@ -1,0 +1,10 @@
+package org.vaccineimpact.api.db
+
+import org.jooq.Record
+import org.jooq.ResultQuery
+
+fun <TRecord: Record> ResultQuery<TRecord>.fetchSequence(): Sequence<TRecord>
+{
+    val cursor = this.fetchSize(100).fetchLazy()
+    return generateSequence { cursor.fetchOne() }
+}

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityCoverageSetsTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityCoverageSetsTests.kt
@@ -67,7 +67,7 @@ class GetResponsibilityCoverageSetsTests : ModellingGroupRepositoryTests()
         } check {
             val result = it.getCoverageData(groupId, touchstoneId, scenarioId)
             checkMetadataIsAsExpected(result.structuredMetadata)
-            assertThat(result.tableData.data).containsExactlyElementsOf(listOf(
+            assertThat(result.tableData.data.toList()).containsExactlyElementsOf(listOf(
                     LongCoverageRow(scenarioId, "First", "YF", GAVISupportLevel.WITHOUT, ActivityType.CAMPAIGN,
                             "AAA", "AAA-Name", 2000, 10.toDecimal(), 20.toDecimal(), "10-20", 100.toDecimal(), "50.50".toDecimalOrNull()),
                     LongCoverageRow(scenarioId, "Second", "YF", GAVISupportLevel.WITH, ActivityType.CAMPAIGN,

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetDemographicsTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetDemographicsTests.kt
@@ -106,7 +106,7 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
             Assertions.assertThat(metadata.id).isEqualTo("tot-pop")
             Assertions.assertThat(metadata.name).isEqualTo("tot-pop descriptive name")
-            Assertions.assertThat(metadata.gender).isEqualTo("Both")
+            Assertions.assertThat(metadata.gender).isEqualTo("both")
             Assertions.assertThat(metadata.source).isEqualTo("unwpp2015")
             Assertions.assertThat(metadata.ageInterpretation).isEqualTo("age")
             Assertions.assertThat(metadata.unit).isEqualTo("Number of people")
@@ -117,7 +117,7 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
             Assertions.assertThat(metadata.id).isEqualTo("as-fert")
             Assertions.assertThat(metadata.name).isEqualTo("as-fert descriptive name")
-            Assertions.assertThat(metadata.gender).isEqualTo("Both")
+            Assertions.assertThat(metadata.gender).isEqualTo("both")
             Assertions.assertThat(metadata.source).isEqualTo("unwpp2015")
             Assertions.assertThat(metadata.ageInterpretation).isEqualTo("age of mother")
             Assertions.assertThat(metadata.unit).isEqualTo("Births per woman")
@@ -176,8 +176,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val data = it.getDemographicData("as-fert", source, touchstoneId)
-            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("Both")
-            Assertions.assertThat(data.tableData.data.any { it.gender == "Both" }).isTrue()
+            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("both")
+            Assertions.assertThat(data.tableData.data.any { it.gender == "both" }).isTrue()
 
         }
     }
@@ -196,8 +196,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val data = it.getDemographicData("tot-pop", source, touchstoneId, "female")
-            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("Both")
-            Assertions.assertThat(data.tableData.data.any { it.gender == "Both" }).isTrue()
+            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("both")
+            Assertions.assertThat(data.tableData.data.any { it.gender == "both" }).isTrue()
         }
     }
 
@@ -215,8 +215,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val data = it.getDemographicData("as-fert", source, touchstoneId, "female")
-            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("Female")
-            Assertions.assertThat(data.tableData.data.any { it.gender == "Female" }).isTrue()
+            Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("female")
+            Assertions.assertThat(data.tableData.data.any { it.gender == "female" }).isTrue()
         }
     }
 
@@ -250,8 +250,6 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val result = it.getDemographicData("tot-pop", source, touchstoneId)
-            Assertions.assertThat(result.structuredMetadata.demographicData.countries.count()).isEqualTo(0)
-            Assertions.assertThat(result.structuredMetadata.demographicData.source).isNull()
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
         }
     }
@@ -285,8 +283,6 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val result = it.getDemographicData("tot-pop", source, touchstoneId)
-            Assertions.assertThat(result.structuredMetadata.demographicData.countries.count()).isEqualTo(0)
-            Assertions.assertThat(result.structuredMetadata.demographicData.source).isNull()
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
 
         }
@@ -304,8 +300,6 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             val result = it.getDemographicData("tot-pop", source, touchstoneId)
-            Assertions.assertThat(result.structuredMetadata.demographicData.countries.count()).isEqualTo(0)
-            Assertions.assertThat(result.structuredMetadata.demographicData.source).isNull()
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
         }
     }
@@ -336,7 +330,7 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
             
             assertThat(metadata.countries).isEqualTo(expectedCountries)
             assertThat(metadata.source).isEqualTo(source)
-            assertThat(result.tableData.data.map { it.countryCode }.distinct()).isEqualTo(expectedCountries)
+            assertThat(result.tableData.data.toList().map { it.countryCode }.distinct()).isEqualTo(expectedCountries)
         }
     }
 
@@ -365,11 +359,9 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             var result = it.getDemographicData("tot-pop", source, anotherTouchstoneId)
-            Assertions.assertThat(result.structuredMetadata.demographicData.countries.count()).isEqualTo(0)
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
 
             result = it.getDemographicData("tot-pop", newSource, anotherTouchstoneId)
-            Assertions.assertThat(result.structuredMetadata.demographicData.countries.count()).isGreaterThan(0)
             Assertions.assertThat(result.tableData.data.count()).isGreaterThan(0)
         }
     }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -65,7 +65,7 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         } check {
             val result = it.getScenarioAndCoverageData(touchstoneId, scenarioId)
             checkScenarioIsAsExpected(result.structuredMetadata)
-            assertThat(result.tableData.data).containsExactlyElementsOf(listOf(
+            assertThat(result.tableData.data.toList()).containsExactlyElementsOf(listOf(
                     LongCoverageRow(scenarioId, "YF without", "YF", GAVISupportLevel.WITHOUT, ActivityType.CAMPAIGN,
                             "AAA", "AAA-Name",2000, 10.toDecimal(), 20.toDecimal(), "10-20", 100.toDecimal(), "50.50".toDecimalOrNull()),
                     LongCoverageRow(scenarioId, "YF with", "YF", GAVISupportLevel.WITH, ActivityType.CAMPAIGN,
@@ -84,7 +84,7 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         } check {
             val result = it.getScenarioAndCoverageData(touchstoneId, scenarioId)
             checkScenarioIsAsExpected(result.structuredMetadata)
-            assertThat(result.tableData.data).isEmpty()
+            assertThat(result.tableData.data.toList()).isEmpty()
         }
     }
 


### PR DESCRIPTION
There are two changes to semantics here, which you can see by looking at the repository tests:

1. Genders are now returned (in metadata and in table data) using the code field, rather than the name field - i.e. they are now all lower case.
2. Metadata is now returned (countries and source) even if no rows are returned. Previously we returned countries and source as null.

I think these changes should be fine. We should notify the modellers about the gender case change, in case anyone has any scripts that will be broken by the change. Let me know if you have any other concerns about the changes.