### PR TITLE
pass serializer in as explicit dependency everywhere

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/DirectActionContext.kt
@@ -8,9 +8,10 @@ import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.serialization.DataTableDeserializer
 import org.vaccineimpact.api.app.errors.ValidationError
 import org.vaccineimpact.api.serialization.ModelBinder
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.api.serialization.Serializer
 import spark.Request
 import spark.Response
 import org.vaccineimpact.api.serialization.validation.ValidationException
@@ -18,7 +19,8 @@ import java.io.OutputStream
 import java.util.zip.GZIPOutputStream
 import kotlin.reflect.KClass
 
-open class DirectActionContext(private val context: SparkWebContext): ActionContext
+open class DirectActionContext(private val context: SparkWebContext,
+                               private val serializer: Serializer = MontaguSerializer.instance): ActionContext
 {
     override val request
             get() = context.sparkRequest
@@ -49,7 +51,7 @@ open class DirectActionContext(private val context: SparkWebContext): ActionCont
     {
         return try
         {
-            DataTableDeserializer.deserialize(request.body(), klass, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(request.body(), klass, serializer).toList()
         }
         catch(e: ValidationException)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
@@ -6,13 +6,14 @@ import org.slf4j.LoggerFactory
 import org.vaccineimpact.api.app.errors.MontaguError
 import org.vaccineimpact.api.app.errors.UnableToParseJsonError
 import org.vaccineimpact.api.app.errors.UnexpectedError
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
 import spark.Request
 import spark.Response
 import spark.Spark as spk
 
 @Suppress("RemoveExplicitTypeArguments")
-open class ErrorHandler
+open class ErrorHandler(private val serializer: Serializer = MontaguSerializer.instance)
 {
     private val logger = LoggerFactory.getLogger(ErrorHandler::class.java)
     private val postgresHandler = PostgresErrorHandler()
@@ -28,7 +29,7 @@ open class ErrorHandler
     open fun handleError(error: MontaguError, req: Request, res: Response)
     {
         logger.warn("For request ${req.uri()}, a ${error::class.simpleName} occurred with the following problems: ${error.problems}")
-        res.body(Serializer.instance.toJson(error.asResult()))
+        res.body(serializer.toJson(error.asResult()))
         res.status(error.httpStatus)
         addDefaultResponseHeaders(res)
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/AbstractController.kt
@@ -10,14 +10,16 @@ import org.vaccineimpact.api.app.controllers.endpoints.getWrappedRoute
 import org.vaccineimpact.api.app.errors.UnsupportedValueException
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.TokenRepository
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.serialization.Serializer
 import spark.Spark
 import spark.route.HttpMethod
 import java.time.Duration
 
-abstract class AbstractController(controllerContext: ControllerContext)
+abstract class AbstractController(controllerContext: ControllerContext,
+                                  protected val serializer: Serializer = MontaguSerializer.instance)
 {
     protected val logger: Logger = LoggerFactory.getLogger(AbstractController::class.java)
     protected val repos = controllerContext.repositoryFactory
@@ -39,7 +41,7 @@ abstract class AbstractController(controllerContext: ControllerContext)
             duration: Duration = tokenHelper.oneTimeLinkLifeSpan
     ): String
     {
-        val actionAsString = Serializer.instance.serializeEnum(action)
+        val actionAsString = serializer.serializeEnum(action)
         val params = context.params()
         val queryString = context.queryString()
         val token = tokenHelper.generateOneTimeActionToken(actionAsString, params, queryString, duration, context.username!!)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -211,7 +211,8 @@ open class ModellingGroupController(context: ControllerContext)
         request.raw().getPart("file").inputStream.bufferedReader().use {
 
             // Then add the burden estimates
-            val data = DataTableDeserializer.deserialize(it.readText(), BurdenEstimate::class, Serializer.instance).toList()
+            val data = DataTableDeserializer.deserialize(it.readText(), BurdenEstimate::class,
+                    serializer).toList()
             return saveBurdenEstimates(data, estimateRepository, context, path)
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
@@ -3,9 +3,10 @@ package org.vaccineimpact.api.app.controllers.endpoints
 import org.vaccineimpact.api.models.helpers.ContentTypes
 import org.vaccineimpact.api.app.DefaultHeadersFilter
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.AuthenticationResponse
 import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.serialization.Serializer
 import spark.Route
 import spark.Spark
 import spark.route.HttpMethod
@@ -18,7 +19,8 @@ data class Endpoint<TRoute>(
         override val routeWrapper: (TRoute) -> Route,
         override val method: HttpMethod = HttpMethod.get,
         override val contentType: String = ContentTypes.json,
-        private val additionalSetupCallback: SetupCallback? = null
+        private val additionalSetupCallback: SetupCallback? = null,
+        private val serializer: Serializer = MontaguSerializer.instance
 ) : EndpointDefinition<TRoute>
 {
     init
@@ -37,8 +39,8 @@ data class Endpoint<TRoute>(
 
     override fun transform(x: Any) = when (x)
     {
-        is AuthenticationResponse -> Serializer.instance.gson.toJson(x)!!
-        else -> Serializer.instance.toResult(x)
+        is AuthenticationResponse -> serializer.gson.toJson(x)!!
+        else -> serializer.toResult(x)
     }
 
     fun withAdditionalSetup(newCallback: SetupCallback): Endpoint<TRoute>

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/StreamedEndpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/StreamedEndpoint.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.app.controllers.endpoints
 
 import org.vaccineimpact.api.app.ActionContext
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.serialization.StreamSerializable
 
@@ -10,7 +11,7 @@ fun <TRepository> ((ActionContext, TRepository) -> StreamSerializable<*>).stream
     return { context, repo -> stream(this(context, repo), context) }
 }
 
-fun stream(data: StreamSerializable<*>, context: ActionContext) =
+fun stream(data: StreamSerializable<*>, context: ActionContext, serializer: Serializer = MontaguSerializer.instance) =
         context.streamedResponse(data.contentType) { stream ->
-            data.serialize(stream, Serializer.instance)
+            data.serialize(stream, serializer)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
@@ -5,17 +5,19 @@ import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.RequestLogger
 import org.vaccineimpact.api.app.addDefaultResponseHeaders
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
 
-abstract class MontaguHttpActionAdapter(private val repositoryFactory: RepositoryFactory)
+abstract class MontaguHttpActionAdapter(private val repositoryFactory: RepositoryFactory,
+                                        protected val serializer: Serializer = MontaguSerializer.instance)
     : DefaultHttpActionAdapter()
 {
     protected fun haltWithError(code: Int, context: SparkWebContext, errors: List<ErrorInfo>)
     {
-        haltWithError(code, context, Serializer.instance.toJson(Result(ResultStatus.FAILURE, null, errors)))
+        haltWithError(code, context, serializer.toJson(Result(ResultStatus.FAILURE, null, errors)))
     }
 
     protected fun haltWithError(code: Int, context: SparkWebContext, response: String)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/TokenIssuingConfigFactory.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/TokenIssuingConfigFactory.kt
@@ -6,11 +6,14 @@ import org.pac4j.core.context.HttpConstants
 import org.pac4j.http.client.direct.DirectBasicAuthClient
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.FailedAuthentication
+import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.ruleBasedSerializer
 import spark.Spark as spk
 
-class TokenIssuingConfigFactory(private val repositoryFactory: RepositoryFactory) : ConfigFactory
+class TokenIssuingConfigFactory(private val repositoryFactory: RepositoryFactory,
+                                private val serializer: Serializer = MontaguSerializer.instance) : ConfigFactory
 {
     override fun build(vararg parameters: Any?): Config
     {
@@ -22,11 +25,11 @@ class TokenIssuingConfigFactory(private val repositoryFactory: RepositoryFactory
     }
 }
 
-class BasicAuthActionAdapter(repositoryFactory: RepositoryFactory)
-    : MontaguHttpActionAdapter(repositoryFactory)
+class BasicAuthActionAdapter(repositoryFactory: RepositoryFactory, serializer: Serializer = MontaguSerializer.instance)
+    : MontaguHttpActionAdapter(repositoryFactory, serializer)
 {
     private val unauthorizedResponse: String
-            = Serializer.instance.gson.toJson(FailedAuthentication("Bad credentials"))
+            = serializer.gson.toJson(FailedAuthentication("Bad credentials"))
 
     override fun adapt(code: Int, context: SparkWebContext): Any? = when (code)
     {

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
@@ -129,7 +129,7 @@ open class DataTableDeserializer<out T>(
         fun <T : Any> deserialize(
                 body: String,
                 type: KClass<T>,
-                serializer: Serializer = Serializer.instance
+                serializer: Serializer = MontaguSerializer.instance
         ): Sequence<T>
         {
             return getDeserializer(type, serializer).deserialize(body)

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/ModelBinder.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/ModelBinder.kt
@@ -9,11 +9,11 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 
-class ModelBinder
+class ModelBinder(private val serializer: Serializer = MontaguSerializer.instance)
 {
     fun <T : Any> deserialize(body: String, klass: Class<T>): T
     {
-        val model = Serializer.instance.fromJson(body, klass)
+        val model = serializer.fromJson(body, klass)
         val errors = verify(model)
         if (errors.any())
         {

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/RuleBasedSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/RuleBasedSerializer.kt
@@ -30,10 +30,12 @@ inline fun <reified T : Any> applyRules(it: SerializerArg<T>, json: JsonObject)
     }
 }
 
-fun <T> removeFieldIfNull(original: T, json: JsonObject, property: KProperty1<T, Any?>)
+fun <T> removeFieldIfNull(original: T, json: JsonObject,
+                          property: KProperty1<T, Any?>,
+                          serializer: Serializer = MontaguSerializer.instance)
 {
     if (property.get(original) == null)
     {
-        json.remove(Serializer.instance.convertFieldName(property.name))
+        json.remove(serializer.convertFieldName(property.name))
     }
 }

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.vaccineimpact.api.serialization.DataTableDeserializer
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.TouchstoneStatus
 import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.serialization.DataTable
@@ -92,7 +92,7 @@ free text,in-preparation""")
             text,int,dec
             "joe",1,6.53
             "bob",2,2.0"""
-        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, Serializer.instance).toList()
+        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
         assertThat(rows).containsExactlyElementsOf(listOf(
                 MixedTypes("joe", 1, BigDecimal.valueOf(6.53)),
                 MixedTypes("bob", 2, BigDecimal.valueOf(2.0))
@@ -106,7 +106,7 @@ free text,in-preparation""")
             Text,Int,dec
             "joe",1,6.53
             "bob",2,2.0"""
-        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, Serializer.instance).toList()
+        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
         assertThat(rows).containsExactlyElementsOf(listOf(
                 MixedTypes("joe", 1, BigDecimal.valueOf(6.53)),
                 MixedTypes("bob", 2, BigDecimal.valueOf(2.0))
@@ -120,7 +120,7 @@ free text,in-preparation""")
             a,b,c,d
             1,2,3,4"""
         checkValidationError("csv-unexpected-header") {
-            DataTableDeserializer.deserialize(csv, ABC::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, ABC::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -132,7 +132,7 @@ free text,in-preparation""")
             1,2,3
             1,2,3,4"""
         checkValidationError("csv-wrong-row-length:2") {
-            DataTableDeserializer.deserialize(csv, ABC::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, ABC::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -144,7 +144,7 @@ free text,in-preparation""")
             1,2,3
             1,2"""
         checkValidationError("csv-wrong-row-length:2") {
-            DataTableDeserializer.deserialize(csv, ABC::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, ABC::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -156,7 +156,7 @@ free text,in-preparation""")
             "joe",1,3.14
             "sam",2.6,1"""
         checkValidationError("csv-bad-data-type:2:int", "Unable to parse '2.6' as Int? (Row 2, column int)") {
-            DataTableDeserializer.deserialize(csv, MixedTypes::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -167,7 +167,7 @@ free text,in-preparation""")
             a,b,x,y,z
             1,"joe",1,2,3
             2,"bob",4,5,6"""
-        val rows = DataTableDeserializer.deserialize(csv, Flexible::class, Serializer.instance).toList()
+        val rows = DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
         assertThat(rows).containsExactlyElementsOf(listOf(
                 Flexible(1, "joe", mapOf("x" to 1, "y" to 2, "z" to 3)),
                 Flexible(2, "bob", mapOf("x" to 4, "y" to 5, "z" to 6))
@@ -182,7 +182,7 @@ free text,in-preparation""")
             1,2,3
             3,4,5"""
         checkValidationError("csv-unexpected-header") {
-            DataTableDeserializer.deserialize(csv, Flexible::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -194,7 +194,7 @@ free text,in-preparation""")
             0,"p",1,2,3
             0,"q",1,2"""
         checkValidationError("csv-wrong-row-length:2") {
-            DataTableDeserializer.deserialize(csv, Flexible::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -206,7 +206,7 @@ free text,in-preparation""")
             0,"p",1,2,3
             0,"q",1,2,3,4"""
         checkValidationError("csv-wrong-row-length:2") {
-            DataTableDeserializer.deserialize(csv, Flexible::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
         }
     }
 
@@ -218,12 +218,12 @@ free text,in-preparation""")
             0,"p",1,2,3
             0,"q",1,2,3.5"""
         checkValidationError("csv-bad-data-type:2:z") {
-            DataTableDeserializer.deserialize(csv, Flexible::class, Serializer.instance).toList()
+            DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
         }
     }
 
     private fun serialize(table: DataTable<*>) = serializeToStreamAndGetAsString {
-        table.serialize(it, Serializer.instance)
+        table.serialize(it, MontaguSerializer.instance)
     }.trim()
 
     private fun checkValidationError(code: String, message: String? = null, body: () -> Any?)

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/FlexibleDataTableTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/FlexibleDataTableTests.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.api.tests.serialization
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.api.serialization.FlexibleDataTable
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.helpers.FlexibleProperty
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import org.vaccineimpact.api.test_helpers.serializeToStreamAndGetAsString
@@ -87,6 +87,6 @@ x,y,<NA>""")
     }
 
     private fun serialize(table: FlexibleDataTable<*>) = serializeToStreamAndGetAsString {
-        table.serialize(it, Serializer.instance)
+        table.serialize(it, MontaguSerializer.instance)
     }.trim()
 }

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/SerializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/SerializerTests.kt
@@ -5,7 +5,7 @@ import com.beust.klaxon.Parser
 import com.beust.klaxon.json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.LocalDate
@@ -14,7 +14,7 @@ import java.time.ZoneId
 
 class SerializerTests : MontaguTests()
 {
-    private val serializer = Serializer.instance
+    private val serializer = MontaguSerializer.instance
 
     @Test
     fun `convertFieldName handles empty string`()


### PR DESCRIPTION
Created an interface that the MontaguSerializer implements, and changed all classes that depend on the serializer to accept an instance as a constructor parameter, for clearer dependencies and clean unit testing