### PR TITLE
refactor DiseaseController

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.api.app
 
 import org.slf4j.LoggerFactory
+import org.vaccineimpact.api.app.app_start.Router
+import org.vaccineimpact.api.app.app_start.route_config.MontaguRouteConfig
 import org.vaccineimpact.api.app.controllers.ControllerContext
 import org.vaccineimpact.api.app.controllers.HomeController
 import org.vaccineimpact.api.app.controllers.MontaguControllers
@@ -9,6 +11,7 @@ import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.security.KeyHelper
 import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import java.io.File
 import java.net.BindException
 import java.net.ServerSocket
@@ -54,6 +57,10 @@ class MontaguApi
             it.mapEndpoints()
         }
         HomeController(endpoints, controllerContext).mapEndpoints()
+
+        Router(MontaguRouteConfig, MontaguSerializer.instance,
+                tokenHelper, repositoryFactory)
+                .mapEndpoints(urlBase)
 
         if (!Config.authEnabled)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
@@ -2,4 +2,8 @@ package org.vaccineimpact.api.app.app_start
 
 import org.vaccineimpact.api.app.ActionContext
 
-abstract class Controller(val context: ActionContext)
+abstract class BaseController(val context: ActionContext): Controller
+
+interface Controller{
+
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
@@ -1,0 +1,5 @@
+package org.vaccineimpact.api.app.app_start
+
+import org.vaccineimpact.api.app.ActionContext
+
+abstract class Controller(val context: ActionContext)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Controller.kt
@@ -2,8 +2,4 @@ package org.vaccineimpact.api.app.app_start
 
 import org.vaccineimpact.api.app.ActionContext
 
-abstract class BaseController(val context: ActionContext): Controller
-
-interface Controller{
-
-}
+abstract class Controller(val context: ActionContext)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -67,11 +67,6 @@ fun Endpoint.secure(permissions: Set<String> = setOf()): Endpoint
     return this.copy(requiredPermissions = allPermissions)
 }
 
-fun Endpoint.transform(): Endpoint
-{
-    return this.copy(transform = true)
-}
-
 fun Endpoint.json(): Endpoint
 {
     return this.copy(contentType = ContentTypes.json)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.app.app_start
 
+import org.pac4j.sparkjava.SecurityFilter
 import org.vaccineimpact.api.app.DefaultHeadersFilter
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.security.MontaguAuthorizer
@@ -52,7 +53,7 @@ data class Endpoint(
                 config,
                 configFactory.allClients(),
                 MontaguAuthorizer::class.java.simpleName,
-                "SkipOptions"
+                "method:$method"
         ))
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -1,0 +1,77 @@
+package org.vaccineimpact.api.app.app_start
+
+import org.vaccineimpact.api.app.DefaultHeadersFilter
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.app.security.MontaguAuthorizer
+import org.vaccineimpact.api.app.security.PermissionRequirement
+import org.vaccineimpact.api.app.security.TokenVerifyingConfigFactory
+import org.vaccineimpact.api.models.helpers.ContentTypes
+import org.vaccineimpact.api.security.WebTokenHelper
+import spark.Spark
+import spark.route.HttpMethod
+
+data class Endpoint(
+        override val urlFragment: String,
+        override val controllerName: String,
+        override val actionName: String,
+        override val contentType: String = ContentTypes.json,
+        override val method: HttpMethod = HttpMethod.get,
+        override val transform: Boolean = false,
+        override val requiredPermissions: List<PermissionRequirement> = listOf()
+
+) : EndpointDefinition
+{
+    init
+    {
+        if (!urlFragment.endsWith("/"))
+        {
+            throw Exception("All endpoint definitions must end with a forward slash: $urlFragment")
+        }
+    }
+
+    override fun additionalSetup(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
+    {
+        if (requiredPermissions.any())
+        {
+            addSecurityFilter(url, webTokenHelper, repositoryFactory)
+        }
+        if (this.contentType == ContentTypes.json)
+        {
+            Spark.after(url, ContentTypes.json, DefaultHeadersFilter("${ContentTypes.json}; charset=utf-8", method))
+        }
+    }
+
+    private fun addSecurityFilter(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
+    {
+        val configFactory = TokenVerifyingConfigFactory(webTokenHelper,
+                requiredPermissions.toSet(), repositoryFactory)
+
+        val config = configFactory.build()
+
+        Spark.before(url, org.pac4j.sparkjava.SecurityFilter(
+                config,
+                configFactory.allClients(),
+                MontaguAuthorizer::class.java.simpleName,
+                "SkipOptions"
+        ))
+    }
+
+}
+
+fun Endpoint.secure(permissions: Set<String> = setOf()): Endpoint
+{
+    val allPermissions = (permissions + "*/can-login").map {
+        PermissionRequirement.parse(it)
+    }
+    return this.copy(requiredPermissions = allPermissions)
+}
+
+fun Endpoint.transform(): Endpoint
+{
+    return this.copy(transform = true)
+}
+
+fun Endpoint.json(): Endpoint
+{
+    return this.copy(contentType = ContentTypes.json)
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
@@ -1,0 +1,19 @@
+package org.vaccineimpact.api.app.app_start
+
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.app.security.PermissionRequirement
+import org.vaccineimpact.api.security.WebTokenHelper
+import spark.route.HttpMethod
+
+interface EndpointDefinition
+{
+    val urlFragment: String
+    val controllerName: String
+    val actionName: String
+    val method: HttpMethod
+    val contentType: String
+    val transform: Boolean
+    val requiredPermissions: List<PermissionRequirement>
+
+    fun additionalSetup(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -1,0 +1,107 @@
+package org.vaccineimpact.api.app.app_start
+
+import org.slf4j.LoggerFactory
+import org.vaccineimpact.api.app.ActionContext
+import org.vaccineimpact.api.app.DirectActionContext
+import org.vaccineimpact.api.app.app_start.route_config.RouteConfig
+import org.vaccineimpact.api.app.errors.UnsupportedValueException
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.serialization.Serializer
+import spark.Route
+import spark.Spark
+import spark.route.HttpMethod
+
+class Router(val config: RouteConfig,
+             val serializer: Serializer,
+             val webTokenHelper: WebTokenHelper,
+             val repositoryFactory: RepositoryFactory)
+{
+    private val logger = LoggerFactory.getLogger(Router::class.java)
+
+    companion object
+    {
+        val urls: MutableList<String> = mutableListOf()
+    }
+
+    fun transform(x: Any) = serializer.toResult(x)
+
+    fun mapEndpoints(urlBase: String)
+    {
+        urls.addAll(config.endpoints.map {
+            when (it.transform)
+            {
+                true -> mapTransformedEndpoint(it, urlBase)
+                false -> mapEndpoint(it, urlBase)
+            }
+        })
+    }
+
+    private fun mapTransformedEndpoint(
+            endpoint: EndpointDefinition,
+            urlBase: String): String
+    {
+        val fullUrl = urlBase + endpoint.urlFragment
+        val route = getWrappedRoute(endpoint)::handle
+        val contentType = endpoint.contentType
+
+        logger.info("Mapping $fullUrl to ${endpoint.actionName} on Controller ${endpoint.controllerName}")
+        when (endpoint.method)
+        {
+            HttpMethod.get -> Spark.get(fullUrl, contentType, route, this::transform)
+            HttpMethod.post -> Spark.post(fullUrl, contentType, route, this::transform)
+            HttpMethod.put -> Spark.put(fullUrl, contentType, route, this::transform)
+            HttpMethod.patch -> Spark.patch(fullUrl, contentType, route, this::transform)
+            HttpMethod.delete -> Spark.delete(fullUrl, contentType, route, this::transform)
+            else -> throw UnsupportedValueException(endpoint.method)
+        }
+
+        endpoint.additionalSetup(fullUrl, webTokenHelper, repositoryFactory)
+        return fullUrl
+    }
+
+    private fun mapEndpoint(
+            endpoint: EndpointDefinition,
+            urlBase: String): String
+    {
+
+        val fullUrl = urlBase + endpoint.urlFragment
+        val route = getWrappedRoute(endpoint)::handle
+        val contentType = endpoint.contentType
+
+        logger.info("Mapping $fullUrl to ${endpoint.actionName} on Controller ${endpoint.controllerName}")
+        when (endpoint.method)
+        {
+            HttpMethod.get -> Spark.get(fullUrl, contentType, route)
+            HttpMethod.post -> Spark.post(fullUrl, contentType, route)
+            HttpMethod.put -> Spark.put(fullUrl, contentType, route)
+            HttpMethod.patch -> Spark.patch(fullUrl, contentType, route)
+            HttpMethod.delete -> Spark.delete(fullUrl, contentType, route)
+            else -> throw UnsupportedValueException(endpoint.method)
+        }
+
+        endpoint.additionalSetup(fullUrl, webTokenHelper, repositoryFactory)
+        return fullUrl
+    }
+
+
+    private fun getWrappedRoute(endpoint: EndpointDefinition): Route
+    {
+        return Route({ req, res -> invokeControllerAction(endpoint, DirectActionContext(req, res)) })
+    }
+
+    private fun invokeControllerAction(endpoint: EndpointDefinition, context: ActionContext): Any?
+    {
+        val controllerName = endpoint.controllerName
+        val actionName = endpoint.actionName
+
+        val controllerType = Class.forName("org.vaccineimpact.api.controllers.${controllerName}Controller")
+
+        val controller = controllerType.getConstructor(ActionContext::class.java)
+                .newInstance(context) as Controller
+        val action = controllerType.getMethod(actionName)
+
+        return action.invoke(controller)
+    }
+
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -70,7 +70,7 @@ class Router(val config: RouteConfig,
         val route = getWrappedRoute(endpoint)::handle
         val contentType = endpoint.contentType
 
-        logger.info("Mapping $fullUrl to ${endpoint.actionName} on Controller ${endpoint.controllerName}")
+        logger.info("Mapping $fullUrl to ${endpoint.actionName} on ${endpoint.controllerName}Controller")
         when (endpoint.method)
         {
             HttpMethod.get -> Spark.get(fullUrl, contentType, route)
@@ -103,7 +103,7 @@ class Router(val config: RouteConfig,
 
         val controllerType = Class.forName("org.vaccineimpact.api.app.controllers.${controllerName}Controller")
 
-        val controller = controllerType.getConstructor(ActionContext::class.java)
+        val controller = controllerType.getConstructor(ActionContext::class.java, Repositories::class.java)
                 .newInstance(context, repositories) as Controller
         val action = controllerType.getMethod(actionName)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -7,6 +7,7 @@ import org.vaccineimpact.api.app.app_start.route_config.RouteConfig
 import org.vaccineimpact.api.app.errors.UnsupportedValueException
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.models.AuthenticationResponse
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.serialization.Serializer
 import spark.Route
@@ -25,20 +26,20 @@ class Router(val config: RouteConfig,
         val urls: MutableList<String> = mutableListOf()
     }
 
-    fun transform(x: Any) = serializer.toResult(x)
-
     fun mapEndpoints(urlBase: String)
     {
         urls.addAll(config.endpoints.map {
-            when (it.transform)
-            {
-                true -> mapTransformedEndpoint(it, urlBase)
-                false -> mapEndpoint(it, urlBase)
-            }
+           mapEndpoint(it, urlBase)
         })
     }
 
-    private fun mapTransformedEndpoint(
+    private fun transform(x: Any) = when (x)
+    {
+        is AuthenticationResponse -> serializer.gson.toJson(x)!!
+        else -> serializer.toResult(x)
+    }
+
+    private fun mapEndpoint(
             endpoint: EndpointDefinition,
             urlBase: String): String
     {
@@ -60,31 +61,6 @@ class Router(val config: RouteConfig,
         endpoint.additionalSetup(fullUrl, webTokenHelper, repositoryFactory)
         return fullUrl
     }
-
-    private fun mapEndpoint(
-            endpoint: EndpointDefinition,
-            urlBase: String): String
-    {
-
-        val fullUrl = urlBase + endpoint.urlFragment
-        val route = getWrappedRoute(endpoint)::handle
-        val contentType = endpoint.contentType
-
-        logger.info("Mapping $fullUrl to ${endpoint.actionName} on ${endpoint.controllerName}Controller")
-        when (endpoint.method)
-        {
-            HttpMethod.get -> Spark.get(fullUrl, contentType, route)
-            HttpMethod.post -> Spark.post(fullUrl, contentType, route)
-            HttpMethod.put -> Spark.put(fullUrl, contentType, route)
-            HttpMethod.patch -> Spark.patch(fullUrl, contentType, route)
-            HttpMethod.delete -> Spark.delete(fullUrl, contentType, route)
-            else -> throw UnsupportedValueException(endpoint.method)
-        }
-
-        endpoint.additionalSetup(fullUrl, webTokenHelper, repositoryFactory)
-        return fullUrl
-    }
-
 
     private fun getWrappedRoute(endpoint: EndpointDefinition): Route
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -101,7 +101,7 @@ class Router(val config: RouteConfig,
         val controllerName = endpoint.controllerName
         val actionName = endpoint.actionName
 
-        val controllerType = Class.forName("org.vaccineimpact.api.controllers.${controllerName}Controller")
+        val controllerType = Class.forName("org.vaccineimpact.api.app.controllers.${controllerName}Controller")
 
         val controller = controllerType.getConstructor(ActionContext::class.java)
                 .newInstance(context, repositories) as Controller

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
@@ -10,10 +10,12 @@ object DiseaseRouteConfig : RouteConfig
     override val endpoints: List<EndpointDefinition> = listOf(
             Endpoint(baseUrl, controllerName, "getDiseases")
                     .json()
+                    .transform()
                     .secure(),
 
             Endpoint("$baseUrl:id/", controllerName, "getDisease")
                     .json()
+                    .transform()
                     .secure()
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
@@ -10,12 +10,10 @@ object DiseaseRouteConfig : RouteConfig
     override val endpoints: List<EndpointDefinition> = listOf(
             Endpoint(baseUrl, controllerName, "getDiseases")
                     .json()
-                    .transform()
                     .secure(),
 
             Endpoint("$baseUrl:id/", controllerName, "getDisease")
                     .json()
-                    .transform()
                     .secure()
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
@@ -1,0 +1,19 @@
+package org.vaccineimpact.api.app.app_start.route_config
+
+import org.vaccineimpact.api.app.app_start.*
+
+object DiseaseRouteConfig : RouteConfig
+{
+    private val baseUrl = "/diseases/"
+    private val controllerName = "Disease"
+
+    override val endpoints: List<EndpointDefinition> = listOf(
+            Endpoint(baseUrl, controllerName, "getDiseases")
+                    .json()
+                    .secure(),
+
+            Endpoint("$baseUrl:id/", controllerName, "getDisease")
+                    .json()
+                    .secure()
+    )
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/RouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/RouteConfig.kt
@@ -1,0 +1,14 @@
+package org.vaccineimpact.api.app.app_start.route_config
+
+import org.vaccineimpact.api.app.app_start.EndpointDefinition
+
+interface RouteConfig
+{
+    val endpoints: List<EndpointDefinition>
+}
+
+object MontaguRouteConfig : RouteConfig
+{
+    override val endpoints: List<EndpointDefinition> =
+            DiseaseRouteConfig.endpoints
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -1,15 +1,13 @@
 package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.ActionContext
-import org.vaccineimpact.api.app.DirectActionContext
-import org.vaccineimpact.api.app.app_start.Controller
+import org.vaccineimpact.api.app.app_start.BaseController
 import org.vaccineimpact.api.app.repositories.Repositories
-import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.models.Disease
 
 class DiseaseController(context: ActionContext,
-                        private val simpleObjectsRepository: SimpleObjectsRepository) : Controller(context)
+                        private val simpleObjectsRepository: SimpleObjectsRepository) : BaseController(context)
 {
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, repositories.simpleObjects)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -1,13 +1,14 @@
 package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.ActionContext
-import org.vaccineimpact.api.app.app_start.BaseController
+import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.models.Disease
 
 class DiseaseController(context: ActionContext,
-                        private val simpleObjectsRepository: SimpleObjectsRepository) : BaseController(context)
+                        private val simpleObjectsRepository: SimpleObjectsRepository)
+    : Controller(context)
 {
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, repositories.simpleObjects)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -3,23 +3,26 @@ package org.vaccineimpact.api.app.controllers
 import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.DirectActionContext
 import org.vaccineimpact.api.app.app_start.Controller
+import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.models.Disease
 
 class DiseaseController(context: ActionContext,
-                        val repo: SimpleObjectsRepository) : Controller(context)
+                        private val simpleObjectsRepository: SimpleObjectsRepository) : Controller(context)
 {
+    constructor(context: ActionContext, repositories: Repositories)
+            : this(context, repositories.simpleObjects)
 
     @Suppress("UNUSED_PARAMETER")
     fun getDiseases(): List<Disease>
     {
-        return repo.diseases.all().toList()
+        return simpleObjectsRepository.diseases.all().toList()
     }
 
     fun getDisease(): Disease
     {
-        return repo.diseases.get(diseaseId(context))
+        return simpleObjectsRepository.diseases.get(diseaseId(context))
     }
 
     private fun diseaseId(context: ActionContext): String = context.params(":id")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -13,7 +13,6 @@ class DiseaseController(context: ActionContext,
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, repositories.simpleObjects)
 
-    @Suppress("UNUSED_PARAMETER")
     fun getDiseases(): List<Disease>
     {
         return simpleObjectsRepository.diseases.all().toList()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -13,6 +13,8 @@ class DiseaseController(context: ActionContext,
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, repositories.simpleObjects)
 
+    private val diseaseId: String = context.params(":id")
+
     fun getDiseases(): List<Disease>
     {
         return simpleObjectsRepository.diseases.all().toList()
@@ -20,8 +22,6 @@ class DiseaseController(context: ActionContext,
 
     fun getDisease(): Disease
     {
-        return simpleObjectsRepository.diseases.get(diseaseId(context))
+        return simpleObjectsRepository.diseases.get(diseaseId)
     }
-
-    private fun diseaseId(context: ActionContext): String = context.params(":id")
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/DiseaseController.kt
@@ -1,27 +1,23 @@
 package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.ActionContext
-import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
-import org.vaccineimpact.api.app.controllers.endpoints.secured
+import org.vaccineimpact.api.app.DirectActionContext
+import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.repositories.SimpleObjectsRepository
 import org.vaccineimpact.api.models.Disease
 
-class DiseaseController(context: ControllerContext) : AbstractController(context)
+class DiseaseController(context: ActionContext,
+                        val repo: SimpleObjectsRepository) : Controller(context)
 {
-    override val urlComponent = "/diseases"
-    override fun endpoints(repos: RepositoryFactory) = listOf(
-            oneRepoEndpoint("/", this::getDiseases, repos, { it.simpleObjects }).secured(),
-            oneRepoEndpoint("/:id/", this::getDisease, repos, { it.simpleObjects }).secured()
-    )
 
     @Suppress("UNUSED_PARAMETER")
-    fun getDiseases(context: ActionContext, repo: SimpleObjectsRepository): List<Disease>
+    fun getDiseases(): List<Disease>
     {
         return repo.diseases.all().toList()
     }
 
-    fun getDisease(context: ActionContext, repo: SimpleObjectsRepository): Disease
+    fun getDisease(): Disease
     {
         return repo.diseases.get(diseaseId(context))
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/MontaguControllers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/MontaguControllers.kt
@@ -3,7 +3,6 @@ package org.vaccineimpact.api.app.controllers
 open class MontaguControllers(context: ControllerContext)
 {
     open val auth = AuthenticationController(context)
-    open val disease = DiseaseController(context)
     open val touchstone = TouchstoneController(context)
     open val modellingGroup = ModellingGroupController(context)
     open val user = UserController(context)
@@ -13,7 +12,6 @@ open class MontaguControllers(context: ControllerContext)
     val all
         get() = listOf(
                 auth,
-                disease,
                 touchstone,
                 modellingGroup,
                 user,


### PR DESCRIPTION
First attempt at bringing in the alternative API architecture, where controllers are instantiated per request, routing is moved out of the controller into a RouteConfig object, and endpoints simplified.

Any thoughts? 

One thing that is a little unsatisfactory to me but I can't see a clever way around it: 

All controllers will have to have a constructor that takes an `ActionContext` and a `Repositories` object. However, ideally, for clear dependency injection and unit testing, we'd like controllers to also have a constructor in which they take the individual repos that they really want, as opposed to the whole repositories container. See the 2 constructors for `DiseaseController` to see what I mean. And in fact, this other constructor will have to be the primary one (or at least, I can't see a way of making it otherwise.) But that means that the abstract base `Controller` class can't enforce that the class has a constructor that takes a `Repositories` argument, which is a shame, because the Router depends on the existence of a constructor with that signature.

Let me know if that makes sense/if you can see a better pattern that allows us to enforce that all all controllers have a constructor with the required signature.