### PR TITLE
return empty wide table if no rows in long table

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.api.app.controllers
 
-import org.vaccineimpact.api.models.helpers.OneTimeAction
 import org.vaccineimpact.api.app.ActionContext
 import org.vaccineimpact.api.app.controllers.endpoints.EndpointDefinition
 import org.vaccineimpact.api.app.controllers.endpoints.oneRepoEndpoint
@@ -10,10 +9,16 @@ import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.MissingRequiredPermissionError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.postData
-import org.vaccineimpact.api.app.repositories.*
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.RepositoryFactory
+import org.vaccineimpact.api.app.repositories.UserRepository
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
 import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.serialization.*
+import org.vaccineimpact.api.models.helpers.OneTimeAction
+import org.vaccineimpact.api.serialization.FlexibleDataTable
+import org.vaccineimpact.api.serialization.SplitData
+import org.vaccineimpact.api.serialization.StreamSerializable
 import spark.route.HttpMethod
 
 
@@ -135,10 +140,19 @@ open class ModellingGroupController(context: ControllerContext)
                     mapWideCoverageRow(it)
                 }
 
+
         // all the rows should have the same number of years, so we just look at the first row
-        val years = rows.first().coverageAndTargetPerYear.keys.toList()
+        val years = if (rows.any())
+        {
+            rows.first().coverageAndTargetPerYear.keys.toList()
+        }
+        else
+        {
+            listOf()
+        }
 
         return FlexibleDataTable.new(rows.asSequence(), years)
+
     }
 
     private fun mapWideCoverageRow(records: List<LongCoverageRow>)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ModellingGroupControllersTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ModellingGroupControllersTests.kt
@@ -10,6 +10,7 @@ import org.vaccineimpact.api.app.controllers.ModellingGroupController
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.MissingRequiredPermissionError
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.repositories.UserRepository
 import org.vaccineimpact.api.serialization.SplitData
 import org.vaccineimpact.api.db.nextDecimal
@@ -192,6 +193,29 @@ class ModellingGroupControllersTests : ControllerTests<ModellingGroupController>
         Assertions.assertThat(headers).hasSameElementsAs(expectedHeaders)
         Assertions.assertThat(firstRow.coverageAndTargetPerYear["target_$testYear"] == testTarget)
         Assertions.assertThat(firstRow.coverageAndTargetPerYear["coverage_$testYear"] == testCoverage)
+    }
+
+    @Test
+    fun `wide format table is empty if long format is`()
+    {
+        val coverageSets = mockCoverageSetsData(TouchstoneStatus.IN_PREPARATION)
+        val splitData = SplitData(coverageSets, DataTable.new(listOf<LongCoverageRow>().asSequence()))
+        val repo = mock<ModellingGroupRepository> {
+            on { getCoverageData(any(), any(), any()) } doReturn splitData
+        }
+
+        val context = mock<ActionContext> {
+            on { it.params(":group-id") } doReturn "gId"
+            on { it.params(":touchstone-id") } doReturn "tId"
+            on { it.params(":scenario-id") } doReturn "sId"
+            on { it.queryParams("format") } doReturn "wide"
+            on { hasPermission(any()) } doReturn true
+        }
+
+        val controller = ModellingGroupController(mockControllerContext())
+        val data = controller.getCoverageData(context, repo).data
+
+        Assertions.assertThat(data.count()).isEqualTo(0)
     }
 
     private val years = listOf(1985, 1990, 1995, 2000)


### PR DESCRIPTION
Fixes the bug discovered by Margaret: 

"I also tried to download the wide formats of the four coverage files. They all worked, except for the wide no vaccination coverage spreadsheet, which gave an error message when I tried to download it. I, however, know that I must simply put 0 for all of the entries in this spreadsheet."