### PR TITLE
Refactor code to be as it was before merge.

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
@@ -31,7 +31,7 @@ open class GroupBurdenEstimatesController(context: ControllerContext) : Abstract
         return listOf(
                 oneRepoEndpoint("/", this::getBurdenEstimates, repos, { it.burdenEstimates }, method = HttpMethod.get)
                         .secured(permissions("read")),
-                oneRepoEndpoint("/",  {  c,r -> addBurdenEstimates(c,r, RequestBodySource.Simple()) }, repos, { it.burdenEstimates }, method = HttpMethod.post)
+                oneRepoEndpoint("/", this::addBurdenEstimates, repos, { it.burdenEstimates }, method = HttpMethod.post)
                         .secured(permissions("write")),
                 oneRepoEndpoint("/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.BURDENS) }, repos, { it.token })
                         .secured(permissions("write"))
@@ -49,6 +49,8 @@ open class GroupBurdenEstimatesController(context: ControllerContext) : Abstract
         return estimateRepository.getBurdenEstimateSets(path.groupId, path.touchstoneId, path.scenarioId)
     }
 
+    open fun addBurdenEstimates(context: ActionContext, estimateRepository: BurdenEstimateRepository)
+            = addBurdenEstimates(context, estimateRepository, RequestBodySource.Simple())
 
     open fun addBurdenEstimates(
             context: ActionContext,

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/UploadBurdenEstimateTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/UploadBurdenEstimateTests.kt
@@ -66,7 +66,7 @@ class UploadBurdenEstimateTests : ControllerTests<GroupBurdenEstimatesController
 
         val before = Instant.now()
         val controller = GroupBurdenEstimatesController(mockControllerContext())
-        controller.addBurdenEstimates(mockActionContext(data), repo, RequestBodySource.Simple())
+        controller.addBurdenEstimates(mockActionContext(data), repo)
         val after = Instant.now()
         verify(touchstoneSet).get("touchstone-1")
         verify(repo).addBurdenEstimateSet(
@@ -88,7 +88,7 @@ class UploadBurdenEstimateTests : ControllerTests<GroupBurdenEstimatesController
                 ))
         )
         val controller = GroupBurdenEstimatesController(mockControllerContext())
-        assertThatThrownBy { controller.addBurdenEstimates(mockActionContext(data), mockRepository(), RequestBodySource.Simple()) }
+        assertThatThrownBy { controller.addBurdenEstimates(mockActionContext(data), mockRepository()) }
                 .isInstanceOf(InconsistentDataError::class.java)
     }
 


### PR DESCRIPTION
Thanks for resolving the compile errors. This PR tweaks it slightly, to the way it was before the merge mucked things up. I think it's a bit nicer (in this case) to have the overload, as it allows us to make the endpoint definition more readable.