### PR TITLE
method to support getting parts from multipart data

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -34,13 +34,13 @@ data class OneTimeLink(val action: OneTimeAction,
                     OneTimeAction.BURDENS -> controllers.groupBurdenEstimates.addBurdenEstimates(
                             context,
                             repos.burdenEstimates,
-                            RequestBodySource.HTMLMultipart()
+                            RequestBodySource.HTMLMultipart("file")
                     )
                     OneTimeAction.BURDENS_CREATE -> controllers.groupBurdenEstimates.createBurdenEstimateSet(context, repos.burdenEstimates)
                     OneTimeAction.BURDENS_POPULATE -> controllers.groupBurdenEstimates.populateBurdenEstimateSet(
                             context,
                             repos.burdenEstimates,
-                            RequestBodySource.HTMLMultipart()
+                            RequestBodySource.HTMLMultipart("file")
                     )
                     OneTimeAction.COVERAGE -> stream(controllers.modellingGroup.getCoverageData(context, repos.modellingGroup), context)
                     OneTimeAction.DEMOGRAPHY -> stream(controllers.touchstone.getDemographicData(context, repos.touchstone), context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -34,13 +34,13 @@ data class OneTimeLink(val action: OneTimeAction,
                     OneTimeAction.BURDENS -> controllers.groupBurdenEstimates.addBurdenEstimates(
                             context,
                             repos.burdenEstimates,
-                            RequestBodySource.HTMLMultipartFile()
+                            RequestBodySource.HTMLMultipart()
                     )
                     OneTimeAction.BURDENS_CREATE -> controllers.groupBurdenEstimates.createBurdenEstimateSet(context, repos.burdenEstimates)
                     OneTimeAction.BURDENS_POPULATE -> controllers.groupBurdenEstimates.populateBurdenEstimateSet(
                             context,
                             repos.burdenEstimates,
-                            RequestBodySource.HTMLMultipartFile()
+                            RequestBodySource.HTMLMultipart()
                     )
                     OneTimeAction.COVERAGE -> stream(controllers.modellingGroup.getCoverageData(context, repos.modellingGroup), context)
                     OneTimeAction.DEMOGRAPHY -> stream(controllers.touchstone.getDemographicData(context, repos.touchstone), context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
@@ -23,6 +23,7 @@ interface ActionContext
     fun queryString(): String?
     fun params(): Map<String, String>
     fun params(key: String): String
+    fun getPart(name: String): String
     fun <T: Any> postData(klass: Class<T>): T
     fun <T: Any> csvData(klass: KClass<T>, from: RequestBodySource): List<T>
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -76,7 +76,7 @@ class DirectActionContext(private val context: SparkWebContext,
     {
         return try
         {
-            DataTableDeserializer.deserialize(from.getFile(this), klass, serializer).toList()
+            DataTableDeserializer.deserialize(from.getContent(this), klass, serializer).toList()
         }
         catch (e: ValidationException)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -4,24 +4,26 @@ import org.pac4j.core.profile.CommonProfile
 import org.pac4j.core.profile.ProfileManager
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.addDefaultResponseHeaders
+import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.MissingRequiredPermissionError
-import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.app.errors.ValidationError
-import org.vaccineimpact.api.serialization.ModelBinder
-import org.vaccineimpact.api.serialization.MontaguSerializer
+import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.api.serialization.DataTableDeserializer
+import org.vaccineimpact.api.serialization.ModelBinder
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.validation.ValidationException
 import spark.Request
 import spark.Response
-import org.vaccineimpact.api.serialization.validation.ValidationException
 import java.io.OutputStream
 import java.util.zip.GZIPOutputStream
+import javax.servlet.MultipartConfigElement
 import kotlin.reflect.KClass
 
-open class DirectActionContext(private val context: SparkWebContext,
-                               private val serializer: Serializer = MontaguSerializer.instance): ActionContext
+class DirectActionContext(private val context: SparkWebContext,
+                          private val serializer: Serializer = MontaguSerializer.instance) : ActionContext
 {
     override val request
         get() = context.sparkRequest
@@ -42,9 +44,31 @@ open class DirectActionContext(private val context: SparkWebContext,
         {
             ModelBinder().deserialize(request.body(), klass)
         }
-        catch(e: ValidationException)
+        catch (e: ValidationException)
         {
             throw ValidationError(e.errors)
+        }
+    }
+
+    override fun getPart(name: String): String
+    {
+        val contentType = request.contentType()
+        if (!contentType.startsWith("multipart/form-data"))
+        {
+            throw BadRequest("This endpoint expects multipart/form-data but this request is of type $contentType")
+        }
+
+        if (request.raw().getAttribute("org.eclipse.jetty.multipartConfig") == null)
+        {
+            val multipartConfigElement = MultipartConfigElement(System.getProperty("java.io.tmpdir"))
+            request.raw().setAttribute("org.eclipse.jetty.multipartConfig", multipartConfigElement)
+        }
+
+        val part = request.raw().getPart(name)
+                ?: throw BadRequest("No value passed for required POST parameter '$name'")
+
+        return part.inputStream.bufferedReader().use {
+            it.readText()
         }
     }
 
@@ -52,9 +76,9 @@ open class DirectActionContext(private val context: SparkWebContext,
     {
         return try
         {
-            DataTableDeserializer.deserialize(from.getBody(this), klass, serializer).toList()
+            DataTableDeserializer.deserialize(from.getFile(this), klass, serializer).toList()
         }
-        catch(e: ValidationException)
+        catch (e: ValidationException)
         {
             throw ValidationError(e.errors)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -55,7 +55,7 @@ class DirectActionContext(private val context: SparkWebContext,
         val contentType = request.contentType()
         if (!contentType.startsWith("multipart/form-data"))
         {
-            throw BadRequest("This endpoint expects multipart/form-data but this request is of type $contentType")
+            throw BadRequest("Trying to extract a part from multipart/form-data but this request is of type $contentType")
         }
 
         if (request.raw().getAttribute("org.eclipse.jetty.multipartConfig") == null)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestBodySource.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestBodySource.kt
@@ -5,31 +5,18 @@ import javax.servlet.MultipartConfigElement
 sealed class RequestBodySource
 {
     // Later, we should not return a string, but a stream or sequence of lines
-    abstract fun getBody(context: ActionContext): String
+    abstract fun getFile(context: ActionContext): String
 
     class Simple : RequestBodySource()
     {
-        override fun getBody(context: ActionContext): String
-        {
-            return context.request.body()
-        }
+        override fun getFile(context: ActionContext)
+                = context.request.body()
     }
 
-    class HTMLMultipartFile : RequestBodySource()
+    class HTMLMultipart : RequestBodySource()
     {
-        override fun getBody(context: ActionContext): String
-        {
-            val request = context.request
-            if (request.raw().getAttribute("org.eclipse.jetty.multipartConfig") == null)
-            {
-                val multipartConfigElement = MultipartConfigElement(System.getProperty("java.io.tmpdir"))
-                request.raw().setAttribute("org.eclipse.jetty.multipartConfig", multipartConfigElement)
-            }
-
-            return request.raw().getPart("file").inputStream.bufferedReader().use {
-                it.readText()
-            }
-        }
+        override fun getFile(context: ActionContext)
+                = context.getPart("file")
     }
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestBodySource.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestBodySource.kt
@@ -5,18 +5,18 @@ import javax.servlet.MultipartConfigElement
 sealed class RequestBodySource
 {
     // Later, we should not return a string, but a stream or sequence of lines
-    abstract fun getFile(context: ActionContext): String
+    abstract fun getContent(context: ActionContext): String
 
     class Simple : RequestBodySource()
     {
-        override fun getFile(context: ActionContext)
+        override fun getContent(context: ActionContext)
                 = context.request.body()
     }
 
-    class HTMLMultipart : RequestBodySource()
+    class HTMLMultipart(private val partName: String) : RequestBodySource()
     {
-        override fun getFile(context: ActionContext)
-                = context.getPart("file")
+        override fun getContent(context: ActionContext)
+                = context.getPart(partName)
     }
 }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
@@ -108,7 +108,7 @@ class DirectActionContextTests : MontaguTests()
         assertThatThrownBy {
             context.getPart("whatever")
         }.isInstanceOf(BadRequest::class.java)
-                .hasMessageContaining("This endpoint expects multipart/form-data but this request is of type text/plain")
+                .hasMessageContaining("Trying to extract a part from multipart/form-data but this request is of type text/plain")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
@@ -138,8 +138,11 @@ class DirectActionContextTests : MontaguTests()
     {
         val profile = CommonProfile()
 
+        val mockPart = mock<Part>(){
+            on { inputStream } doReturn "something".byteInputStream()
+        }
         val mockServletRequest = mock<HttpServletRequest>() {
-            on { getPart("whatever") } doReturn FakePart()
+            on { getPart("whatever") } doReturn mockPart
         }
 
         val mockRequest = mock<Request> {
@@ -164,57 +167,4 @@ class DirectActionContextTests : MontaguTests()
         return webContext
     }
 
-    private class FakePart : Part
-    {
-        override fun getName(): String
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun write(fileName: String?)
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getHeader(name: String?): String
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getSize(): Long
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getContentType(): String
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getHeaders(name: String?): MutableCollection<String>
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getHeaderNames(): MutableCollection<String>
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getInputStream(): InputStream
-        {
-            return "something".byteInputStream()
-        }
-
-        override fun delete()
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-        override fun getSubmittedFileName(): String
-        {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-        }
-
-    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
@@ -11,12 +11,16 @@ import org.pac4j.core.profile.CommonProfile
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.context.DirectActionContext
 import org.vaccineimpact.api.app.context.postData
+import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.security.PERMISSIONS
 import org.vaccineimpact.api.models.Scope
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import spark.Request
+import java.io.InputStream
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.Part
 
 class DirectActionContextTests : MontaguTests()
 {
@@ -85,11 +89,132 @@ class DirectActionContextTests : MontaguTests()
         assertThat(model).isEqualTo(Model(1, listOf("x", "y"), Model(100, listOf("z"), null)))
     }
 
+    @Test
+    fun `throw BadRequest if getPart called on non multipart request`()
+    {
+        val profile = CommonProfile()
+
+        val mockRequest = mock<Request> {
+            on { raw() } doReturn mock<HttpServletRequest>()
+            on { contentType() } doReturn "text/plain"
+        }
+
+        val webContext = mock<SparkWebContext> {
+            on { getRequestAttribute(Pac4jConstants.USER_PROFILES) } doReturn profile
+            on { sparkRequest } doReturn mockRequest
+        }
+
+        val context = DirectActionContext(webContext)
+        assertThatThrownBy {
+            context.getPart("whatever")
+        }.isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining("This endpoint expects multipart/form-data but this request is of type text/plain")
+    }
+
+    @Test
+    fun `throw BadRequest if getPart called on non existent part`()
+    {
+        val profile = CommonProfile()
+
+        val mockRequest = mock<Request> {
+            on { raw() } doReturn mock<HttpServletRequest>()
+            on { contentType() } doReturn "multipart/form-data"
+        }
+
+        val webContext = mock<SparkWebContext> {
+            on { getRequestAttribute(Pac4jConstants.USER_PROFILES) } doReturn profile
+            on { sparkRequest } doReturn mockRequest
+        }
+
+        val context = DirectActionContext(webContext)
+        assertThatThrownBy {
+            context.getPart("whatever")
+        }.isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining("No value passed for required POST parameter 'whatever'")
+    }
+
+    @Test
+    fun `can get part`()
+    {
+        val profile = CommonProfile()
+
+        val mockServletRequest = mock<HttpServletRequest>() {
+            on { getPart("whatever") } doReturn FakePart()
+        }
+
+        val mockRequest = mock<Request> {
+            on { raw() } doReturn mockServletRequest
+            on { contentType() } doReturn "multipart/form-data"
+        }
+
+        val webContext = mock<SparkWebContext> {
+            on { getRequestAttribute(Pac4jConstants.USER_PROFILES) } doReturn profile
+            on { sparkRequest } doReturn mockRequest
+        }
+
+        val context = DirectActionContext(webContext)
+        assertThat(context.getPart("whatever")).isEqualTo("something")
+    }
+
     private fun mockWebContext(profile: CommonProfile): SparkWebContext
     {
         val webContext = mock<SparkWebContext> {
             on { getRequestAttribute(Pac4jConstants.USER_PROFILES) } doReturn profile
         }
         return webContext
+    }
+
+    private class FakePart : Part
+    {
+        override fun getName(): String
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun write(fileName: String?)
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getHeader(name: String?): String
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getSize(): Long
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getContentType(): String
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getHeaders(name: String?): MutableCollection<String>
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getHeaderNames(): MutableCollection<String>
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getInputStream(): InputStream
+        {
+            return "something".byteInputStream()
+        }
+
+        override fun delete()
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
+        override fun getSubmittedFileName(): String
+        {
+            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        }
+
     }
 }


### PR DESCRIPTION
* New method on `ActionContext` to get a named part from a multipart request.
* Tests
* Some slight refactoring of the `RequestBodySource` class in light of the above change