### PR TITLE
Make sure we always convert ValidationException into ValidationError

### DIFF
--- a/spec/ErrorCode.schema.json
+++ b/spec/ErrorCode.schema.json
@@ -2,5 +2,5 @@
     "id": "ErrorCode",
     "type": "string",
     "minLength": 1,
-    "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*(:[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)*$"
+    "pattern": "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*(:[a-zA-Z0-9_]+(-[a-zA-Z0-9_]+)*)*$"
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
@@ -7,8 +7,10 @@ import org.slf4j.LoggerFactory
 import org.vaccineimpact.api.app.errors.MontaguError
 import org.vaccineimpact.api.app.errors.UnableToParseJsonError
 import org.vaccineimpact.api.app.errors.UnexpectedError
+import org.vaccineimpact.api.app.errors.ValidationError
 import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.validation.ValidationException
 import spark.Request
 import spark.Response
 import spark.Spark as spk
@@ -24,6 +26,7 @@ open class ErrorHandler(private val logger: Logger = LoggerFactory.getLogger(Err
     {
         sparkException<JsonSyntaxException> { e, req, res -> handleError(UnableToParseJsonError(e), req, res) }
         sparkException<DataAccessException> { e, req, res -> postgresHandler.handleException(e, req, res, this) }
+        sparkException<ValidationException> { e, req, res-> handleError(ValidationError(e.errors), req, res) }
         sparkException<Exception>(this::handleError)
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -6,7 +6,6 @@ import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.api.app.addDefaultResponseHeaders
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.MissingRequiredPermissionError
-import org.vaccineimpact.api.app.errors.ValidationError
 import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
@@ -14,7 +13,6 @@ import org.vaccineimpact.api.serialization.DataTableDeserializer
 import org.vaccineimpact.api.serialization.ModelBinder
 import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.Serializer
-import org.vaccineimpact.api.serialization.validation.ValidationException
 import spark.Request
 import spark.Response
 import java.io.OutputStream
@@ -40,16 +38,7 @@ class DirectActionContext(private val context: SparkWebContext,
     override fun params(): Map<String, String> = request.params()
     override fun params(key: String): String = request.params(key)
     override fun <T : Any> postData(klass: Class<T>): T
-    {
-        return try
-        {
-            ModelBinder().deserialize(request.body(), klass)
-        }
-        catch (e: ValidationException)
-        {
-            throw ValidationError(e.errors)
-        }
-    }
+            = ModelBinder().deserialize(request.body(), klass)
 
     override fun getPart(name: String): Reader
     {
@@ -72,16 +61,7 @@ class DirectActionContext(private val context: SparkWebContext,
     }
 
     override fun <T : Any> csvData(klass: KClass<T>, from: RequestBodySource): Sequence<T>
-    {
-        return try
-        {
-            DataTableDeserializer.deserialize(from.getContent(this), klass, serializer)
-        }
-        catch (e: ValidationException)
-        {
-            throw ValidationError(e.errors)
-        }
-    }
+            = DataTableDeserializer.deserialize(from.getContent(this), klass, serializer)
 
     override fun setResponseStatus(status: Int)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnexpectedError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnexpectedError.kt
@@ -1,6 +1,9 @@
 package org.vaccineimpact.api.app.errors
 
 import org.apache.commons.lang3.RandomStringUtils
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.vaccineimpact.api.app.ErrorHandler
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.models.ErrorInfo
 
@@ -9,10 +12,22 @@ val supportAddress = Config["contact.support"]
 // The purpose of the code, even though it's not used anywhere else, is that the full text of the error gets logged.
 // So if a user gives you a code like UAA-BBB-CCC you can then search through the logs to find and see the associated
 // stack trace.
-class UnexpectedError : MontaguError(500, listOf(ErrorInfo(
+class UnexpectedError private constructor(exception: Exception) : MontaguError(500, listOf(ErrorInfo(
         "unexpected-error",
         "An unexpected error occurred. Please contact support at $supportAddress and quote this code: ${newCode()}"
 )))
+{
+    companion object
+    {
+        fun new(exception: Exception, logger: Logger = LoggerFactory.getLogger(ErrorHandler::class.java)): UnexpectedError
+        {
+            logger.error(unhandledExceptionMessage, exception)
+            return UnexpectedError(exception)
+        }
+
+        private const val unhandledExceptionMessage = "An unhandled exception occurred"
+    }
+}
 
 private fun newCode(): String
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/ValidationError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/ValidationError.kt
@@ -1,5 +1,10 @@
 package org.vaccineimpact.api.app.errors
 
 import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.api.serialization.validation.ValidationException
 
 class ValidationError(errors: List<ErrorInfo>) : MontaguError(400, errors)
+{
+    constructor(exception: ValidationException)
+            : this(exception.errors)
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -178,7 +178,7 @@ class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
         }
 
         val mockErrorHandler = mock<ErrorHandler>() {
-            on { logExceptionAndReturnMontaguError(any(), any()) } doReturn UnexpectedError()
+            on { logExceptionAndReturnMontaguError(any(), any()) } doReturn UnexpectedError.new(Exception())
         }
 
         val controller = makeController(
@@ -204,7 +204,7 @@ class OneTimeLinkControllerTests : ControllerTests<OneTimeLinkController>()
         }
 
         val mockErrorHandler = mock<ErrorHandler>() {
-            on { logExceptionAndReturnMontaguError(any(), any()) } doReturn UnexpectedError()
+            on { logExceptionAndReturnMontaguError(any(), any()) } doReturn UnexpectedError.new(Exception())
         }
 
         val controller = makeController(

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/errors/PostgresErrorTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/errors/PostgresErrorTests.kt
@@ -28,8 +28,7 @@ Detail: Key (lower(email))=(email@example.com) already exists."""
         val fakeException = mock<Exception> {
             on { toString() } doReturn (exceptionText)
         }
-        val parent = mock<ErrorHandler>()
-        handler.handleException(fakeException, mock(), mock(), parent)
-        verify(parent).handleError(argThat<DuplicateKeyError> { problems.first().code == "duplicate-key:email" }, any(), any())
+        val error = handler.handleException(fakeException)
+        assertThat(error).isInstanceOf(DuplicateKeyError::class.java)
     }
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/BurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/BurdenEstimateTests.kt
@@ -63,6 +63,10 @@ abstract class BurdenEstimateTests : DatabaseTest()
    "Hib3",   1996,    50,     "AGO",       "Angola",          5000,     1000,      NA,    5670
    "Hib3",   1997,    50,     "AGO",       "Angola",          6000,     1200,      NA,    5870
 """
+    val badCSVData = """
+"disease", "year", "age", "country", "country_name", "cohort_size", "deaths", "cases", "dalys"
+   "Hib3",   1996,    50,     "AFG",  "Afghanistan",              ,         ,        ,
+"""
 
     data class ReturnedIds(val responsibilityId: Int, val modelVersionId: Int)
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/UploadBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/UploadBurdenEstimateTests.kt
@@ -74,7 +74,7 @@ class UploadBurdenEstimateTests : BurdenEstimateTests()
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
         val helper = RequestHelper()
         val response = helper.post(url, badCSVData, token = token)
-        JSONValidator().validateError(response.text, "csv-unexpected-header")
+        JSONValidator().validateError(response.text, "csv-bad-data-type:1:cohort_size")
     }
 
     @Test
@@ -170,7 +170,7 @@ class UploadBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `bad CSV data results in ValidationError in redirect`()
+    fun `bad CSV headers results in ValidationError in redirect`()
     {
         validate("$url/get_onetime_link/?redirectUrl=http://localhost") against "Token" given { db ->
             setUp(db)

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/UploadBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/UploadBurdenEstimateTests.kt
@@ -58,12 +58,22 @@ class UploadBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `bad CSV data results in ValidationError`()
+    fun `bad CSV headers results in ValidationError`()
     {
         JooqContext().use { setUp(it) }
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
         val helper = RequestHelper()
         val response = helper.post(url, "bad_header,year,age,country,country_name,cohort_size", token = token)
+        JSONValidator().validateError(response.text, "csv-unexpected-header")
+    }
+
+    @Test
+    fun `bad CSV data results in ValidationError`()
+    {
+        JooqContext().use { setUp(it) }
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val helper = RequestHelper()
+        val response = helper.post(url, badCSVData, token = token)
         JSONValidator().validateError(response.text, "csv-unexpected-header")
     }
 


### PR DESCRIPTION
The problem was that, due to the lazy evaluation of the sequence, the processing wasn't actually happening inside the try...catch block, it was happening later.

To be merged after https://github.com/vimc/montagu-api/pull/132