### PR TITLE
Update dependencies

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -26,14 +26,14 @@ mainClassName = "org.vaccineimpact.api.app.SparkAppKt"
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile "com.sparkjava:spark-core:2.5.4"
+    compile "com.sparkjava:spark-core:2.7.1"
 
-    compile "org.postgresql:postgresql:9.4.1212.jre7"
-    compile "org.jooq:jooq:3.9.1"
-    compile "org.jooq:jooq-meta:3.9.1"
+    compile "org.postgresql:postgresql:42.1.4"
+    compile "org.jooq:jooq:3.10.2"
+    compile "org.jooq:jooq-meta:3.10.2"
 
-    compile "org.pac4j:spark-pac4j:2.0.0"
-    compile "org.pac4j:pac4j-http:2.0.0"
+    compile "org.pac4j:spark-pac4j:2.1.0"
+    compile "org.pac4j:pac4j-http:2.2.0"
 
     compile project(":databaseInterface")
     compile project(":models")
@@ -43,9 +43,9 @@ dependencies {
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "org.assertj:assertj-core:3.8.0"
-    testCompile "com.beust:klaxon:0.31"
+    testCompile "com.beust:klaxon:0.32"
     testCompile project(":testHelpers")
 }
 

--- a/src/blackboxTests/build.gradle
+++ b/src/blackboxTests/build.gradle
@@ -2,14 +2,14 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:3.8.0"
 
-    testCompile "org.slf4j:slf4j-simple:1.7.21"
+    testCompile "org.slf4j:slf4j-simple:1.7.25"
 
     testCompile "khttp:khttp:0.1.0"
-    testCompile "com.beust:klaxon:0.31"
-    testCompile "com.opencsv:opencsv:3.9"
+    testCompile "com.beust:klaxon:0.32"
+    testCompile "com.opencsv:opencsv:4.1"
     testCompile "com.auth0:java-jwt:3.3.0"
 
-    testCompile "com.github.fge:json-schema-validator:2.2.6"
+    testCompile "com.github.fge:json-schema-validator:2.2.8"
 
     testCompile project(":testHelpers")
     testCompile project(":databaseInterface")

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -1,6 +1,3 @@
-group 'org.vaccineimpact'
-version '1.0-SNAPSHOT'
-
 buildscript {
     ext.kotlin_version = '1.1.60'
 
@@ -13,6 +10,13 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
+
+plugins {
+    id 'com.github.ben-manes.versions' version '0.17.0'
+}
+
+group 'org.vaccineimpact'
+version '1.0-SNAPSHOT'
 
 task run(dependsOn: ':app:run')
 task generateDatabaseInterface(dependsOn: ':generateDatabaseInterface:run')
@@ -90,7 +94,7 @@ subprojects {
 
     dependencies {
         compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
-        compile "org.slf4j:slf4j-simple:1.7.21"
+        compile "org.slf4j:slf4j-simple:1.7.25"
     }
 
     task copyConfig(type: Copy, dependsOn: ':loadPropertiesTask') {

--- a/src/databaseInterface/build.gradle
+++ b/src/databaseInterface/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.postgresql:postgresql:9.4.1212.jre7"
-    compile "org.jooq:jooq:3.9.1"
-    compile "org.jooq:jooq-meta:3.9.1"
-    compile "org.apache.commons:commons-lang3:3.5"
+    compile "org.postgresql:postgresql:42.1.4"
+    compile "org.jooq:jooq:3.10.2"
+    compile "org.jooq:jooq-meta:3.10.2"
+    compile "org.apache.commons:commons-lang3:3.7"
 }

--- a/src/databaseTests/build.gradle
+++ b/src/databaseTests/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "org.assertj:assertj-core:3.8.0"
 
-    testCompile "org.jooq:jooq:3.9.1"
-    testCompile "org.jooq:jooq-meta:3.9.1"
+    testCompile "org.jooq:jooq:3.10.2"
+    testCompile "org.jooq:jooq-meta:3.10.2"
 
     testCompile project(":app")
     testCompile project(":models")

--- a/src/emails/build.gradle
+++ b/src/emails/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile 'com.github.spullara.mustache.java:compiler:0.9.5'
-    compile "org.simplejavamail:simple-java-mail:4.2.3"
+    compile "org.simplejavamail:simple-java-mail:4.4.5"
 
     compile project(":databaseInterface")
     compile project(":security")

--- a/src/generateDatabaseInterface/build.gradle
+++ b/src/generateDatabaseInterface/build.gradle
@@ -11,10 +11,10 @@ mainClassName = "org.vaccineimpact.api.generateDatabaseInterface.AppKt"
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile "org.postgresql:postgresql:9.4.1212.jre7"
-    compile "org.jooq:jooq:3.9.1"
-    compile "org.jooq:jooq-meta:3.9.1"
-    compile "org.jooq:jooq-codegen:3.9.1"
+    compile "org.postgresql:postgresql:42.1.4"
+    compile "org.jooq:jooq:3.10.2"
+    compile "org.jooq:jooq-meta:3.10.2"
+    compile "org.jooq:jooq-codegen:3.10.2"
 }
 
 run.dependsOn ':startDatabase'

--- a/src/security/build.gradle
+++ b/src/security/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
-    compile 'org.pac4j:spark-pac4j:2.0.0'
-    compile 'org.pac4j:pac4j-jwt:2.0.0'
-    compile 'commons-codec:commons-codec:1.10'
-    compile 'org.abstractj.kalium:kalium:0.6.0'
+    compile 'org.pac4j:spark-pac4j:2.1.0'
+    compile 'org.pac4j:pac4j-jwt:2.2.0'
+    compile 'commons-codec:commons-codec:1.11'
+    compile 'org.abstractj.kalium:kalium:0.7.0'
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "org.assertj:assertj-core:3.8.0"
-    testCompile "com.beust:klaxon:0.31"
+    testCompile "com.beust:klaxon:0.32"
     testCompile project(":testHelpers")
 
     compile project(":models")

--- a/src/serialization/build.gradle
+++ b/src/serialization/build.gradle
@@ -1,16 +1,16 @@
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.opencsv:opencsv:3.9"
-    compile "com.google.code.gson:gson:2.2.4"
+    compile "com.opencsv:opencsv:4.1"
+    compile "com.google.code.gson:gson:2.8.2"
     compile "com.github.salomonbrys.kotson:kotson:2.5.0"
 
     compile project(":models")
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile "org.assertj:assertj-core:3.8.0"
-    testCompile "com.beust:klaxon:0.31"
+    testCompile "com.beust:klaxon:0.32"
     testCompile project(":testHelpers")
 
 }

--- a/src/testHelpers/build.gradle
+++ b/src/testHelpers/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile "junit:junit:4.12"
-    compile "org.jooq:jooq:3.9.1"
-    compile "org.jooq:jooq-meta:3.9.1"
+    compile "org.jooq:jooq:3.10.2"
+    compile "org.jooq:jooq-meta:3.10.2"
 
     compile project(':databaseInterface')
     compile project(':models')

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -14,13 +14,13 @@ apply plugin: 'docker'
 mainClassName = "org.vaccineimpact.api.security.AppKt"
 
 dependencies {
-    compile "org.slf4j:slf4j-simple:1.7.21"
-    compile "org.simplejavamail:simple-java-mail:4.2.3"
+    compile "org.slf4j:slf4j-simple:1.7.25"
+    compile "org.simplejavamail:simple-java-mail:4.4.5"
     compile project(":security")
 
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.3.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
     testCompile project(":testHelpers")
 }
 

--- a/src/validateSchema/build.gradle
+++ b/src/validateSchema/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    compile 'com.atlassian.commonmark:commonmark:0.9.0'
+    compile 'com.atlassian.commonmark:commonmark:0.10.0'
     compile "org.assertj:assertj-core:3.8.0"
-    compile "com.github.fge:json-schema-validator:2.2.6"
+    compile "com.github.fge:json-schema-validator:2.2.8"
 
     testCompile "junit:junit:4.12"
 }


### PR DESCRIPTION
This updates all dependent libraries to the latest stable version. I used [this Gradle plugin](https://github.com/ben-manes/gradle-versions-plugin) to automatically detect the latest version, and then manually did find + replace.

Notes:

1. Postgres have decided to change their version number scheme, since the summer, so we have gone from version 9 to version 42. * shrug *
1. jOOQ have changed the generated code in a non-backwards compatible mode, so this branch has compilation errors. The [next PR](https://github.com/vimc/montagu-api/pull/141) then regenerates the jOOQ code - so you should review both PRs together and then merge together. But because the jOOQ code is so verbose it made this PR unreadable, so I split it out.