### PR TITLE
i1000: Preliminary changes

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -50,17 +50,19 @@ class MontaguApi
         })
         ErrorHandler.setup()
 
+        // Old style controllers
         val controllerContext = ControllerContext(urlBase, repositoryFactory, tokenHelper)
         val standardControllers = MontaguControllers(controllerContext)
         val oneTimeLink = OneTimeLinkController(controllerContext, standardControllers)
-        val endpoints = (standardControllers.all + oneTimeLink).flatMap {
+        val oldStyleEndpoints = (standardControllers.all + oneTimeLink).flatMap {
             it.mapEndpoints()
         }
-        HomeController(endpoints, controllerContext).mapEndpoints()
 
-        Router(MontaguRouteConfig, MontaguSerializer.instance,
-                tokenHelper, repositoryFactory)
-                .mapEndpoints(urlBase)
+        // New style controllers
+        val router = Router(MontaguRouteConfig, MontaguSerializer.instance, tokenHelper, repositoryFactory)
+        val newStyleEndpoints = router.mapEndpoints(urlBase)
+
+        HomeController(oldStyleEndpoints + newStyleEndpoints, controllerContext).mapEndpoints()
 
         if (!Config.authEnabled)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SparkApp.kt
@@ -62,7 +62,8 @@ class MontaguApi
         val router = Router(MontaguRouteConfig, MontaguSerializer.instance, tokenHelper, repositoryFactory)
         val newStyleEndpoints = router.mapEndpoints(urlBase)
 
-        HomeController(oldStyleEndpoints + newStyleEndpoints, controllerContext).mapEndpoints()
+        val allEndpoints = (oldStyleEndpoints + newStyleEndpoints).sorted()
+        HomeController(allEndpoints, controllerContext).mapEndpoints()
 
         if (!Config.authEnabled)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.security.MontaguAuthorizer
 import org.vaccineimpact.api.app.security.PermissionRequirement
 import org.vaccineimpact.api.app.security.TokenVerifyingConfigFactory
+import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.models.helpers.ContentTypes
 import org.vaccineimpact.api.security.WebTokenHelper
 import spark.Spark
@@ -44,17 +45,20 @@ data class Endpoint(
 
     private fun addSecurityFilter(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
     {
-        val configFactory = TokenVerifyingConfigFactory(webTokenHelper,
-                requiredPermissions.toSet(), repositoryFactory)
+        if (Config.authEnabled)
+        {
+            val configFactory = TokenVerifyingConfigFactory(webTokenHelper,
+                    requiredPermissions.toSet(), repositoryFactory)
 
-        val config = configFactory.build()
+            val config = configFactory.build()
 
-        Spark.before(url, org.pac4j.sparkjava.SecurityFilter(
-                config,
-                configFactory.allClients(),
-                MontaguAuthorizer::class.java.simpleName,
-                "method:$method"
-        ))
+            Spark.before(url, org.pac4j.sparkjava.SecurityFilter(
+                    config,
+                    configFactory.allClients(),
+                    MontaguAuthorizer::class.java.simpleName,
+                    "method:$method"
+            ))
+        }
     }
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -26,11 +26,12 @@ class Router(val config: RouteConfig,
         val urls: MutableList<String> = mutableListOf()
     }
 
-    fun mapEndpoints(urlBase: String)
+    fun mapEndpoints(urlBase: String): List<String>
     {
         urls.addAll(config.endpoints.map {
            mapEndpoint(it, urlBase)
         })
+        return urls
     }
 
     private fun transform(x: Any) = when (x)


### PR DESCRIPTION
This is bringing the new style endpoints more in line with the old style endpoints in ways that weren't strictly related to the ticket, but which made working on them easier.

In particular:

* Make the index page list all endpoints, not just the old style ones
* Make new style endpoints respect the `app.auth` setting.