### PR TITLE
i1000: Use types instead of strings

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -11,10 +11,11 @@ import org.vaccineimpact.api.models.helpers.ContentTypes
 import org.vaccineimpact.api.security.WebTokenHelper
 import spark.Spark
 import spark.route.HttpMethod
+import kotlin.reflect.KClass
 
 data class Endpoint(
         override val urlFragment: String,
-        override val controllerName: String,
+        override val controller: KClass<*>,
         override val actionName: String,
         override val contentType: String = ContentTypes.json,
         override val method: HttpMethod = HttpMethod.get,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
@@ -5,13 +5,14 @@ import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.app.security.PermissionRequirement
 import org.vaccineimpact.api.security.WebTokenHelper
 import spark.route.HttpMethod
+import kotlin.reflect.KClass
 
 typealias ResultProcessor = (Any?, ActionContext) -> Any?
 
 interface EndpointDefinition
 {
     val urlFragment: String
-    val controllerName: String
+    val controller: KClass<*>
     val actionName: String
     val method: HttpMethod
     val contentType: String

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -49,7 +49,7 @@ class Router(val config: RouteConfig,
         val route = getWrappedRoute(endpoint)::handle
         val contentType = endpoint.contentType
 
-        logger.info("Mapping $fullUrl to ${endpoint.actionName} on Controller ${endpoint.controllerName}")
+        logger.info("Mapping $fullUrl to ${endpoint.actionName} on ${endpoint.controller.simpleName}")
         when (endpoint.method)
         {
             HttpMethod.get -> Spark.get(fullUrl, contentType, route, this::transform)
@@ -76,11 +76,8 @@ class Router(val config: RouteConfig,
     private fun invokeControllerAction(endpoint: EndpointDefinition, context: ActionContext,
                                        repositories: Repositories): Any?
     {
-        val controllerName = endpoint.controllerName
         val actionName = endpoint.actionName
-
-        val className = "${controllerName}Controller"
-        val controllerType = Class.forName("org.vaccineimpact.api.app.controllers.$className")
+        val controllerType = endpoint.controller.java
         val controller = instantiateController(controllerType, context, repositories)
         val action = controllerType.getMethod(actionName)
 
@@ -91,7 +88,7 @@ class Router(val config: RouteConfig,
         catch (e: InvocationTargetException)
         {
             logger.warn("Exception was thrown whilst using reflection to invoke " +
-                    "$className.$actionName, see below for details")
+                    "$controllerType.$actionName, see below for details")
             throw e.targetException
         }
         return endpoint.postProcess(result, context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/DiseaseRouteConfig.kt
@@ -1,18 +1,19 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.*
+import org.vaccineimpact.api.app.controllers.DiseaseController
 
 object DiseaseRouteConfig : RouteConfig
 {
     private val baseUrl = "/diseases/"
-    private val controllerName = "Disease"
+    private val controller = DiseaseController::class
 
     override val endpoints: List<EndpointDefinition> = listOf(
-            Endpoint(baseUrl, controllerName, "getDiseases")
+            Endpoint(baseUrl, controller, "getDiseases")
                     .json()
                     .secure(),
 
-            Endpoint("$baseUrl:id/", controllerName, "getDisease")
+            Endpoint("$baseUrl:id/", controller, "getDisease")
                     .json()
                     .secure()
     )

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
@@ -1,47 +1,50 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.*
+import org.vaccineimpact.api.app.controllers.NewStyleOneTimeLinkController
+import org.vaccineimpact.api.app.controllers.TouchstoneController
 import org.vaccineimpact.api.app.controllers.endpoints.streamed
 
 object TouchstoneRouteConfig : RouteConfig
 {
     private val baseUrl = "/touchstones/"
-    private val controllerName = "Touchstone"
+    private val controller = TouchstoneController::class
 
     private val permissions = setOf("*/touchstones.read")
     private val scenarioPermissions = permissions + setOf("*/scenarios.read", "*/coverage.read")
     private val demographicPermissions = permissions + setOf("*/demographics.read")
 
     override val endpoints: List<EndpointDefinition> = listOf(
-            Endpoint(baseUrl, controllerName, "getTouchstones")
+            Endpoint(baseUrl, controller, "getTouchstones")
                     .json()
                     .secure(permissions),
 
-            Endpoint("$baseUrl:touchstone-id/scenarios/", controllerName, "getScenarios")
+            Endpoint("$baseUrl:touchstone-id/scenarios/", controller, "getScenarios")
                     .json()
                     .secure(scenarioPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/scenarios/", controllerName, "getScenarios")
+            Endpoint("$baseUrl:touchstone-id/scenarios/", controller, "getScenarios")
                     .json()
                     .secure(scenarioPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/scenarios/:scenario-id/", controllerName, "getScenario")
+            Endpoint("$baseUrl:touchstone-id/scenarios/:scenario-id/", controller, "getScenario")
                     .json()
                     .secure(scenarioPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/demographics/", controllerName, "getDemographicDatasets")
+            Endpoint("$baseUrl:touchstone-id/demographics/", controller, "getDemographicDatasets")
                     .json()
                     .secure(demographicPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/", controllerName, "getDemographicDataAndMetadata")
+            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/", controller, "getDemographicDataAndMetadata")
                     .json().streamed()
                     .secure(demographicPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/", controllerName, "getDemographicData")
+            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/", controller, "getDemographicData")
                     .csv().streamed()
                     .secure(demographicPermissions),
 
-            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/get_onetime_link/", "NewStyleOneTimeLink", "getTokenForDemographicData")
+            Endpoint("$baseUrl:touchstone-id/demographics/:source-code/:type-code/get_onetime_link/",
+                    NewStyleOneTimeLinkController::class, "getTokenForDemographicData")
                     .json()
                     .secure(demographicPermissions)
     )


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1000

First review and merge: https://github.com/vimc/montagu-api/pull/144

This isn't strictly to do with VIMC-1000, but as I was passing this seemed like an easy improvement to make. Is there any reason to prefer strings to just a reference to the class? This way if we rename the class, refactoring will take care of everything for us.