### PR TITLE
Use Java version 8

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -96,6 +96,12 @@ subprojects {
         compile "org.slf4j:slf4j-simple:1.7.25"
     }
 
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+
     task copyConfig(type: Copy, dependsOn: ':loadPropertiesTask') {
         from 'src/main/resources'
         include '*'


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-949

This is necessary for later work on this ticket. I thought we were already using JVM 8! We're certainly running on an openJDK 8 docker image.