### PR TITLE
Get single estimate set

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
@@ -12,6 +12,7 @@ interface BurdenEstimateRepository : Repository
                                 properties: CreateBurdenEstimateSet,
                                 uploader: String, timestamp: Instant): Int
 
+    fun getBurdenEstimateSet(setId: Int): BurdenEstimateSet
     fun getBurdenEstimateSets(groupId: String, touchstoneId: String, scenarioId: String): List<BurdenEstimateSet>
 
     @Deprecated("Instead use createBurdenEstimateSet and then populateBurdenEstimateSet")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/mapping/BurdenMappingHelper.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/mapping/BurdenMappingHelper.kt
@@ -2,6 +2,8 @@ package org.vaccineimpact.api.app.repositories.jooq.mapping
 
 import org.jooq.Record
 import org.vaccineimpact.api.db.Tables
+import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE_SET
+import org.vaccineimpact.api.models.BurdenEstimateSet
 import org.vaccineimpact.api.models.BurdenEstimateSetType
 
 class BurdenMappingHelper : MappingHelper()
@@ -13,4 +15,26 @@ class BurdenMappingHelper : MappingHelper()
             )
     fun mapBurdenEstimateSetType(code: String, details: String?) =
             BurdenEstimateSetType(mapEnum(code), details)
+
+    fun mapBurdenEstimateSets(records: List<Record>): List<BurdenEstimateSet>
+    {
+        return records
+                .groupBy { it[BURDEN_ESTIMATE_SET.ID] }
+                .map(this::mapBurdenEstimateSet)
+    }
+
+    fun mapBurdenEstimateSet(group: Map.Entry<Int, List<Record>>): BurdenEstimateSet
+    {
+        val table = BURDEN_ESTIMATE_SET
+        val common = group.value.first()
+        val problems = group.value.mapNotNull { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] }
+        return BurdenEstimateSet(
+                common[table.ID],
+                common[table.UPLOADED_ON].toInstant(),
+                common[table.UPLOADED_BY],
+                mapBurdenEstimateSetType(common),
+                mapEnum(common[table.STATUS]),
+                problems
+        )
+    }
 }

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -96,6 +96,12 @@ subprojects {
         compile "org.slf4j:slf4j-simple:1.7.25"
     }
 
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+
     task copyConfig(type: Copy, dependsOn: ':loadPropertiesTask') {
         from 'src/main/resources'
         include '*'

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/RepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/RepositoryTests.kt
@@ -17,5 +17,17 @@ abstract class RepositoryTests<TRepository: Repository> : DatabaseTest()
         return RepositoryTestConfig(this::makeRepository, populateDatabase = {})
     }
 
+    protected fun <T> withDatabase(doThis: (JooqContext) -> T): T
+    {
+        return JooqContext().use { doThis(it) }
+    }
+    protected fun <T> withRepo(doThis: (TRepository) -> T): T
+    {
+        return JooqContext().use {
+            val repo = makeRepository(it)
+            doThis(repo)
+        }
+    }
+
     protected abstract fun makeRepository(db: JooqContext): TRepository
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
@@ -71,12 +71,12 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
     @Test
     fun `can retrieve single burden estimate set`()
     {
-        var setId = 0
-        given { db ->
+        val setId = withDatabase { db ->
             val ids = setupDatabase(db)
             val modelVersionId = ids.modelVersion!!
-            setId = db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username)
-        } check { repo ->
+            db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username)
+        }
+        withRepo { repo ->
             val set = repo.getBurdenEstimateSet(setId)
             assertThat(set.uploadedBy).isEqualTo(username)
             assertThat(set.problems).isEmpty()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
@@ -68,6 +68,21 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
         }
     }
 
+    @Test
+    fun `can retrieve single burden estimate set`()
+    {
+        var setId = 0
+        given { db ->
+            val ids = setupDatabase(db)
+            val modelVersionId = ids.modelVersion!!
+            setId = db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username)
+        } check { repo ->
+            val set = repo.getBurdenEstimateSet(setId)
+            assertThat(set.uploadedBy).isEqualTo(username)
+            assertThat(set.problems).isEmpty()
+        }
+    }
+
     private fun checkSetHasExpectedType(sets: List<BurdenEstimateSet>, setId: Int, expectedType: BurdenEstimateSetType)
     {
         val set = sets.singleOrNull { it.id == setId }


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-949

We have to be able to retrieve single estimate sets so we know whether they are stochastic or central, so we know what format of CSV to expect.

Note that I came up with a simpler scheme for repository tests that gets rid of the need for ugly `vars`. If you like it, I suggest we refactor existing tests to use it.