### PR TITLE
I1265 - only return touchstones that have open responsibilities

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -144,7 +144,7 @@ class JooqModellingGroupRepository(
     override fun getTouchstonesByGroupId(groupId: String): List<Touchstone>
     {
         val group = getModellingGroup(groupId)
-        var query = dsl
+        val query = dsl
                 .select(
                         TOUCHSTONE.ID,
                         TOUCHSTONE.TOUCHSTONE_NAME,
@@ -152,8 +152,9 @@ class JooqModellingGroupRepository(
                         TOUCHSTONE.DESCRIPTION,
                         TOUCHSTONE.VERSION
                 )
-                .fromJoinPath(TOUCHSTONE, RESPONSIBILITY_SET, joinType = JoinType.JOIN)
+                .fromJoinPath(TOUCHSTONE, RESPONSIBILITY_SET, RESPONSIBILITY)
                 .where(RESPONSIBILITY_SET.MODELLING_GROUP.eq(group.id))
+                .and(RESPONSIBILITY.IS_OPEN)
         return query.fetch().map { touchstoneRepository.mapTouchstone(it) }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -145,7 +145,7 @@ class JooqModellingGroupRepository(
     {
         val group = getModellingGroup(groupId)
         val query = dsl
-                .select(
+                .selectDistinct(
                         TOUCHSTONE.ID,
                         TOUCHSTONE.TOUCHSTONE_NAME,
                         TOUCHSTONE.STATUS,

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
@@ -75,11 +75,7 @@ class ResponsibilityTests : DatabaseTest()
     fun `can get touchstones by group id`()
     {
         validate("/modelling-groups/$groupId/responsibilities/") against "Touchstones" given {
-            it.addGroup(groupId)
-            it.addTouchstoneName("touchstone", "description")
-            it.addTouchstone("touchstone", 1, description = "descr 1", status = "open")
-            it.addTouchstone("touchstone", 2)
-            it.addResponsibilitySet(groupId, touchstoneId)
+            addResponsibilities(it, touchstoneStatus = "open")
         } requiringPermissions {
             PermissionSet("*/touchstones.read", "$groupScope/responsibilities.read")
         } andCheckArray {
@@ -89,7 +85,7 @@ class ResponsibilityTests : DatabaseTest()
                                 "id" to touchstoneId,
                                 "name" to "touchstone",
                                 "version" to 1,
-                                "description" to "descr 1",
+                                "description" to "description",
                                 "status" to "open"
 
                         )

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
@@ -3,32 +3,37 @@ package org.vaccineimpact.api.databaseTests.tests.modellingGroupRepository
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.*
 
 class GetTouchstoneTests : ModellingGroupRepositoryTests()
 {
+    private val diseaseId = "d1"
+    private val groupId = "group-1"
+    private val touchstoneName = "touchstone"
+    private val touchstoneId = "touchstone-1"
 
     @Test
     fun `can get touchstones list for modelling group`()
     {
-        var groupId = "group-1"
-        var groupId2 = "group-2"
-        val touchstoneId = "touchstone-1"
+        val groupId2 = "group-2"
+        val touchstone2Name = "touchstone-2"
+        val touchstone3Name = "touchstone-3"
+
         given {
-            it.addGroup(groupId)
+            setUpDb(it)
+
             it.addGroup(groupId2)
-            it.addTouchstoneName("touchstone", "description")
-            it.addTouchstone("touchstone", 1, description = "descr 1", status = "open")
-            it.addTouchstoneName("touchstone2", "description2")
-            it.addTouchstone("touchstone2", 1, description = "descr 2", status = "open")
-            it.addTouchstoneName("touchstone3", "description3")
-            it.addTouchstone("touchstone3", 1, description = "descr 3", status = "open")
-            it.addResponsibilitySet(groupId, touchstoneId)
-            it.addResponsibilitySet(groupId, "touchstone2-1")
-            it.addResponsibilitySet(groupId2, "touchstone3-1")
-        } check {
-            repo ->
+
+            it.addTouchstone(touchstone2Name, 1, addName = true, description = "descr 2", status = "open")
+            it.addTouchstone(touchstone3Name, 1, addName = true, description = "descr 3", status = "open")
+
+            addResponsibilitySetWithResponsibility(it, "scenario-1", groupId, touchstoneId, open = true)
+            addResponsibilitySetWithResponsibility(it, "scenario-2", groupId, "$touchstone2Name-1", open = true)
+            addResponsibilitySetWithResponsibility(it, "scenario-3", groupId2, "$touchstone3Name-1", open = true)
+
+        } check { repo ->
             val touchstones = repo.getTouchstonesByGroupId(groupId)
             assertThat(touchstones).isInstanceOf(List::class.java)
             assertThat(touchstones).hasSize(2)
@@ -39,21 +44,47 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
     }
 
     @Test
+    fun `doesnt return touchstone with closed responsibilities`()
+    {
+        val scenarioId = "scenario-1"
+
+        given {
+            setUpDb(it)
+            addResponsibilitySetWithResponsibility(it, scenarioId, groupId, touchstoneId, open = false)
+
+        } check { repo ->
+            val touchstones = repo.getTouchstonesByGroupId(groupId)
+            assertThat(touchstones).hasSize(0)
+        }
+    }
+
+    @Test
     fun `exception is thrown if tries to get touchstones by non-existent modelling group ID`()
     {
-        var groupId = "group-1"
-        var groupId2 = "group-2"
-        val touchstoneId = "touchstone-1"
-        given {
-            it.addGroup(groupId)
-            it.addTouchstoneName("touchstone", "description")
-            it.addTouchstone("touchstone", 1, description = "descr 1", status = "open")
-            it.addResponsibilitySet(groupId, touchstoneId)
-        } check {
-            repo ->
+        withRepo { repo ->
             Assertions.assertThatThrownBy {
-                repo.getTouchstonesByGroupId(groupId2)
+                repo.getTouchstonesByGroupId("bad-id")
             }.isInstanceOf(org.vaccineimpact.api.app.errors.UnknownObjectError::class.java)
         }
     }
+
+    private fun addResponsibilitySetWithResponsibility(db: JooqContext,
+                                                       scenarioId: String,
+                                                       groupId: String,
+                                                       touchstoneId: String,
+                                                       open: Boolean = true)
+    {
+        val setId = db.addResponsibilitySet(groupId, touchstoneId)
+        db.addScenarioDescription(scenarioId, "description 1", diseaseId, addDisease = false)
+        db.addResponsibility(setId, touchstoneId, scenarioId, open = open)
+    }
+
+    private fun setUpDb(db: JooqContext)
+    {
+        db.addDisease(diseaseId)
+        db.addGroup(groupId)
+        db.addTouchstone(touchstoneName, 1, addName = true, description = "descr 1", status = "open")
+
+    }
+
 }


### PR DESCRIPTION
When returning touchstones for a group, only return ones where they have a responsibility set AND that set has open responsibilities in it.