### PR TITLE
i1261: Update API to use hyphens instead of underscores in URLs

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1310,7 +1310,7 @@ Schema: [`CreateModelVersion.schema.json`](CreateModelVersion.schema.json)
         "fingerprint": null
     }
     
-## GET /modelling-groups/{modelling-group-id}/model-run-parameter-sets/{touchstone-id}/
+## GET /modelling-groups/{modelling-group-id}/model-run-parameters/{touchstone-id}/
 Returns a list of model run parameter sets that the given modelling group has uploaded for responsibilities in the 
  given touchstone.
 
@@ -1330,7 +1330,7 @@ Schema: [`ModelRunParameterSets.schema.json`](ModelRunParameterSets.schema.json)
         }
     ]
     
-## POST /modelling-groups/{modelling-group-id}/model-run-parameter-sets/{touchstone-id}/
+## POST /modelling-groups/{modelling-group-id}/model-run-parameters/{touchstone-id}/
 
 Required permissions: Scoped to modelling group: `estimates.write`.
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -71,7 +71,7 @@ Schema: [`Index.schema.json`](Index.schema.json)
     }
 
 # Authentication
-## POST /authenticate
+## POST /authenticate/
 Required permissions: User does not need to be logged in to access this endpoint.
 
 ### Request
@@ -230,7 +230,7 @@ Schema: [`UpdateUser.schema.json`](UpdateUser.schema.json)
         "email": "example@imperial.ac.uk"
     }
 
-## POST /users/{username}/actions/associate_role/
+## POST /users/{username}/actions/associate-role/
 Adds or removes a role from a user.
 
 Required permissions: `roles.write`. If the logged in user only has `roles.write` with a scope `SCOPE_PREFIX/SCOPE_ID` then the following restrictions apply:
@@ -266,13 +266,13 @@ Schema: [`AssociateRole.schema.json`](AssociateRole.schema.json)
 The scope_id is additionally constrained to be a valid ID of the appropriate kind. If the scope_prefix
 is "modelling-group" then the scope_id must be the ID of a modelling group.
 
-## POST /users/{username}/actions/remove_all_access/
+## POST /users/{username}/actions/remove-all-access/
 Removes all roles from a user that match the given scope. If the scope is `*`, all roles are removed.
 
 Required permissions: `roles.write` with scope matching scope in URL.
 
 For example, to remove all permissions from user `martin` for modelling group `IC-YellowFever`, the URL
-would be `/users/martin/actions/remove_all_access/modelling-group:IC-YellowFever/`
+would be `/users/martin/actions/remove-all-access/modelling-group:IC-YellowFever/`
 
 ## POST /password/set/
 Changes the password for the currently logged in user.
@@ -286,7 +286,7 @@ Schema: [`SetPassword.schema.json`](SetPassword.schema.json)
         "password": "new_password"
     }
 
-## POST /password/request_link?email={email}
+## POST /password/request-link/?email={email}
 If the email provided is associated with a user account, sends an email to the 
 provided email address. This email contains a link to the set password page in 
 the portal and includes as a query string parameter a onetime token for the 
@@ -462,7 +462,7 @@ Schema: [`UpdateScenario.schema.json`](UpdateScenario.schema.json)
         "disease": "VALID-DISEASE-ID"
     }
 
-## GET /scenarios/{scenario-id}/responsible_groups/{touchstone-id}
+## GET /scenarios/{scenario-id}/responsible-groups/{touchstone-id}/
 Returns an enumeration (potentially empty) of modelling groups who are responsible for this 
 scenario in the given touchstone.
 
@@ -482,7 +482,7 @@ Schema: [`ModellingGroups.schema.json`](ModellingGroups.schema.json)
         }
     ]
 
-See `POST /modelling-groups/{modelling-group-id}/actions/associate_responsibility` for editing 
+See `POST /modelling-groups/{modelling-group-id}/actions/associate-responsibility/` for editing 
 this data.
 
 # Touchstones
@@ -711,7 +711,7 @@ identify which coverage set a line is from using `scenario` plus `vaccine`,
 `gavi_support` and `activity_type`. Note that we don't expect the modellers to
 need to know which coverage set the data is from.
 
-## POST /touchstones/{touchstone-id}/actions/associate_scenario/
+## POST /touchstones/{touchstone-id}/actions/associate-scenario/
 Associate or unassociate a scenario with a touchstone.
 
 Required permissions: `touchstones.prepare`, `scenarios.read`
@@ -822,7 +822,7 @@ The countries set here must:
 * Exist in this touchstone (see `/touchstones/{touchstone-id}/countries/`)
 
 # Coverage data
-## GET /touchstones/{touchstone-id}/coverage_sets/
+## GET /touchstones/{touchstone-id}/coverage-sets/
 Returns the coverage data sets associated with the touchstone
 
 Required permissions: `coverage.read`
@@ -861,19 +861,19 @@ Schema: [`CoverageSets.schema.json`](CoverageSets.schema.json)
 #### scenario
 Optional. Takes a scenario id. Returns only those coverage sets that belong to the given scenario.
 
-Example: `/touchstones/2017-op-1/coverage_sets/?scenario=64`
+Example: `/touchstones/2017-op-1/coverage-sets/?scenario=64`
 
 #### activity_type
 Optional. Takes either 'routine' or 'campaign'. The coverage sets are filtered to the specified coverage type.
 
-Example: `/touchstones/2017-op-1/coverage_sets/?activity_type=campaign`
+Example: `/touchstones/2017-op-1/coverage-sets/?activity_type=campaign`
 
 #### vaccine
 Optional. Takes a valid vaccine identifier. The coverage sets are filtered to the specified vaccine.
 
-Example: `/touchstones/2017-op-1/coverage_sets/?vaccine=MCV1`
+Example: `/touchstones/2017-op-1/coverage-sets/?vaccine=MCV1`
 
-## GET /touchstones/{touchstone-id}/coverage_sets/{coverage-set-id}/
+## GET /touchstones/{touchstone-id}/coverage-sets/{coverage-set-id}/
 Returns a single coverage set and its coverage data.
 
 Required permissions: `coverage.read`
@@ -907,9 +907,9 @@ The second section has `Content-Type: text/csv`, and returns CSV data with heade
 #### countries
 Optional. Takes a list of country codes. The coverage data is filtered to just the specified countries.
 
-Example: `/touchstones/2017-op-1/coverage_sets/189/?countries=AFG,ANG,CHN`
+Example: `/touchstones/2017-op-1/coverage-sets/189/?countries=AFG,ANG,CHN`
 
-## POST /touchstones/{touchstone-id}/coverage_sets/
+## POST /touchstones/{touchstone-id}/coverage-sets/
 Adds a new coverage set to the touchstone
 
 Required permissions: `coverage.write`
@@ -942,7 +942,7 @@ touchstone is in `in-preparation`. An error occurs if the name matches an existi
 coverage set in this touchstone. It then needs to be associated with 1 or more
 scenarios.
 
-## PUT /touchstones/{touchstone-id}/coverage_sets/{coverage-set-id}/
+## PUT /touchstones/{touchstone-id}/coverage-sets/{coverage-set-id}/
 Replaces the data in an existing coverage set.
 
 Required permissions: `coverage.write`
@@ -972,7 +972,7 @@ The second section must have `Content-Type: text\csv` and requires CSV data with
 
 This can only be invoked if the touchstone is in `in-preparation`.
 
-## POST /touchstones/{touchstone-id}/actions/associate_coverage_set/
+## POST /touchstones/{touchstone-id}/actions/associate-coverage-set/
 Associates or unassociates a given scenario and coverage set.
 
 Required permissions: `touchstones.prepare`
@@ -1213,7 +1213,7 @@ Schma: [`Users.schema.json`](Users.schema.json)
         }
     ]
 
-## POST /modelling-groups/{modelling-group-id}/actions/associate_member/
+## POST /modelling-groups/{modelling-group-id}/actions/associate-member/
 Adds or removes a user from a modelling group.
 
 Required permissions: `modelling-groups.manage-members` (scoped to the group or *)
@@ -1296,7 +1296,7 @@ Schema: [`Model.schema.json`](Model.schema.json)
         "modelling_group": "ID-OF-EXISTING-MODELLING-GROUP"
     }
 
-## POST /models/{model-id}/versions
+## POST /models/{model-id}/versions/
 Adds a new version to a model
 
 Required permissions: `models.write` scoped to the modelling group (or *).
@@ -1310,7 +1310,7 @@ Schema: [`CreateModelVersion.schema.json`](CreateModelVersion.schema.json)
         "fingerprint": null
     }
     
-## GET /modelling-groups/{modelling-group-id}/model_run_parameter_sets/{touchstone-id}/
+## GET /modelling-groups/{modelling-group-id}/model-run-parameter-sets/{touchstone-id}/
 Returns a list of model run parameter sets that the given modelling group has uploaded for responsibilities in the 
  given touchstone.
 
@@ -1330,7 +1330,7 @@ Schema: [`ModelRunParameterSets.schema.json`](ModelRunParameterSets.schema.json)
         }
     ]
     
-## POST /modelling-groups/{modelling-group-id}/model_run_parameter_sets/{touchstone-id}/
+## POST /modelling-groups/{modelling-group-id}/model-run-parameter-sets/{touchstone-id}/
 
 Required permissions: Scoped to modelling group: `estimates.write`.
 
@@ -1514,7 +1514,7 @@ Schema: [`ResponsibilityAndTouchstone.schema.json`](ResponsibilityAndTouchstone.
         }
     }
 
-## GET /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/coverage_sets/
+## GET /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/coverage-sets/
 Returns metadata for the coverage sets associated with the responsibility.
 
 Required permissions: Global scope: `scenarios.read`. Scoped to modelling group: `responsibilities.read` and `coverage.read`.  Additionally, to view coverage sets for an `in-preparation` touchstone, the user needs the `touchstones.prepare` permission.
@@ -1657,7 +1657,7 @@ This endpoint requires the same permissions as getting the coverage directly.
 It returns a onetime token that can be used to get the coverage data in CSV 
 format without authentication. See [Onetime Link](onetime-link-spec.md).
 
-## POST /modelling-groups/{modelling-group-id}/actions/associate_responsibility
+## POST /modelling-groups/{modelling-group-id}/actions/associate-responsibility/
 Adds or removes a responsibility for a given modelling group, scenario, and touchstone.
 
 Required permissions: `responsibilities.write`

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupCoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupCoverageRouteConfig.kt
@@ -18,7 +18,7 @@ object GroupCoverageRouteConfig : RouteConfig
     )
 
     override val endpoints: List<EndpointDefinition> = listOf(
-            Endpoint("$baseUrl/coverage_sets/", controller, "getCoverageSets")
+            Endpoint("$baseUrl/coverage-sets/", controller, "getCoverageSets")
                     .json()
                     .secure(permissions),
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/PasswordRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/PasswordRouteConfig.kt
@@ -16,7 +16,7 @@ object PasswordRouteConfig : RouteConfig
             Endpoint("$urlBase/set/", controller, "setPassword", method = HttpMethod.post)
                     .json()
                     .secure(),
-            Endpoint("$urlBase/request_link/", controller, "requestResetPasswordLink", method = HttpMethod.post)
+            Endpoint("$urlBase/request-link/", controller, "requestResetPasswordLink", method = HttpMethod.post)
                     .json()
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/UserRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/UserRouteConfig.kt
@@ -28,7 +28,7 @@ object UserRouteConfig : RouteConfig
             Endpoint(urlBase, controller, "createUser", method = HttpMethod.post)
                     .json()
                     .secure(createUsers),
-            Endpoint("$urlBase:username/actions/associate_role/", controller, "modifyUserRole", method = HttpMethod.post)
+            Endpoint("$urlBase:username/actions/associate-role/", controller, "modifyUserRole", method = HttpMethod.post)
                     .json()
                     .secure()
     )

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ModellingGroupController.kt
@@ -52,11 +52,11 @@ open class ModellingGroupController(context: ControllerContext)
                 oneRepoEndpoint("$responsibilitiesURL/", this::getResponsibilities, repos, repo).secured(responsibilityPermissions),
                 oneRepoEndpoint("$touchstonesURL/", this::getTouchstones, repos, repo).secured(touchtonePermissions),
                 oneRepoEndpoint("$scenarioURL/", this::getResponsibility, repos, repo).secured(responsibilityPermissions),
-                oneRepoEndpoint("$scenarioURL/coverage_sets/", this::getCoverageSets, repos, repo).secured(coveragePermissions),
+                oneRepoEndpoint("$scenarioURL/coverage-sets/", this::getCoverageSets, repos, repo).secured(coveragePermissions),
                 oneRepoEndpoint("$coverageURL/", this::getCoverageDataAndMetadata.streamed(), repos, repo, contentType = "application/json").secured(coveragePermissions),
                 oneRepoEndpoint("$coverageURL/", this::getCoverageData.streamed(), repos, repo, contentType = "text/csv").secured(coveragePermissions),
                 oneRepoEndpoint("$coverageURL/get_onetime_link/", { c, r -> getOneTimeLinkToken(c, r, OneTimeAction.COVERAGE) }, repos, { it.token }).secured(coveragePermissions),
-                oneRepoEndpoint("/:group-id/actions/associate_member/", this::modifyMembership, repos, { it.user }, method = HttpMethod.post).secured(),
+                oneRepoEndpoint("/:group-id/actions/associate-member/", this::modifyMembership, repos, { it.user }, method = HttpMethod.post).secured(),
 
                 oneRepoEndpoint("$parametersURL/", this::getModelRunParameterSets, repos, { it.burdenEstimates })
                         .secured(setOf("$groupScope/estimates.write", "$groupScope/responsibilities.read")),

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ModellingGroupTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ModellingGroupTests.kt
@@ -76,7 +76,7 @@ class ModellingGroupTests : DatabaseTest()
     @Test
     fun `can modify membership`()
     {
-        validate("/modelling-groups/IC-Garske/actions/associate_member/", HttpMethod.post) given {
+        validate("/modelling-groups/IC-Garske/actions/associate-member/", HttpMethod.post) given {
             it.addUserWithRoles("testuser", ReifiedRole("user", Scope.Global()))
             it.addGroup("IC-Garske")
         } withPermissions {

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/PasswordTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/PasswordTests.kt
@@ -36,7 +36,7 @@ class PasswordTests : DatabaseTest()
         val requestHelper = RequestHelper()
 
         // Request the link via (fake) email
-        val url = "/password/request_link/?email=${TestUserHelper.email}"
+        val url = "/password/request-link/?email=${TestUserHelper.email}"
         val response = requestHelper.post(url, null)
         val data = response.montaguData<String>()
         assertThat(data).isEqualTo("OK")

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
@@ -161,7 +161,7 @@ class ResponsibilityTests : DatabaseTest()
     fun `get coverage sets matches schema`()
     {
         val coverageSetId = 1
-        validate("/modelling-groups/$groupId/responsibilities/$touchstoneId/$scenarioId/coverage_sets/") against "ScenarioAndCoverageSets" given {
+        validate("/modelling-groups/$groupId/responsibilities/$touchstoneId/$scenarioId/coverage-sets/") against "ScenarioAndCoverageSets" given {
             addResponsibilities(it, touchstoneStatus = "open")
             it.addCoverageSet(touchstoneId, "coverage set name", "vaccine-1", "without", "routine", coverageSetId,
                     addVaccine = true)
@@ -200,7 +200,7 @@ class ResponsibilityTests : DatabaseTest()
     @Test
     fun `only touchstone preparer can see in-preparation coverage sets`()
     {
-        val url = "/modelling-groups/$groupId/responsibilities/$touchstoneId/$scenarioId/coverage_sets/"
+        val url = "/modelling-groups/$groupId/responsibilities/$touchstoneId/$scenarioId/coverage-sets/"
         val minimumPermissions = PermissionSet("*/can-login", "*/scenarios.read", "$groupScope/responsibilities.read", "$groupScope/coverage.read")
         val permissionUnderTest = "*/touchstones.prepare"
         val checker = PermissionChecker(url, minimumPermissions + permissionUnderTest)

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
@@ -62,7 +62,7 @@ class UserTests : DatabaseTest()
     @Test
     fun `can add user role`()
     {
-        validate("/users/testuser/actions/associate_role/", HttpMethod.post) given {
+        validate("/users/testuser/actions/associate-role/", HttpMethod.post) given {
             it.addUserForTesting("testuser")
             it.addGroup("IC-Garske")
         } withPermissions {
@@ -82,7 +82,7 @@ class UserTests : DatabaseTest()
     @Test
     fun `can remove user role`()
     {
-        validate("/users/testuser/actions/associate_role/", HttpMethod.post) given {
+        validate("/users/testuser/actions/associate-role/", HttpMethod.post) given {
             it.addUserForTesting("testuser")
             it.addGroup("IC-Garske")
         } withPermissions {
@@ -102,7 +102,7 @@ class UserTests : DatabaseTest()
     @Test
     fun `can remove global user role`()
     {
-        validate("/users/testuser/actions/associate_role/", HttpMethod.post) given {
+        validate("/users/testuser/actions/associate-role/", HttpMethod.post) given {
             it.addUserWithRoles("testuser", ReifiedRole("user", Scope.Global()))
             it.addGroup("IC-Garske")
         } withPermissions {

--- a/src/validateSchema/build.gradle
+++ b/src/validateSchema/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile "com.github.fge:json-schema-validator:2.2.8"
 
     testCompile "junit:junit:4.12"
+    testCompile "org.assertj:assertj-core:3.8.0"
 }
 
 test.dependsOn 'copySpec'

--- a/src/validateSchema/src/main/kotlin/org/vaccineimpact/api/validateSchema/Endpoint.kt
+++ b/src/validateSchema/src/main/kotlin/org/vaccineimpact/api/validateSchema/Endpoint.kt
@@ -5,7 +5,12 @@ import org.commonmark.node.IndentedCodeBlock
 import org.commonmark.node.Link
 import org.commonmark.node.Node
 
-class Endpoint(val method: String, val urlTemplate: String, contents: List<Node>)
+class Endpoint(
+        val method: String,
+        val urlTemplate: String,
+        val isMetaBlock: Boolean,
+        contents: List<Node>
+)
 {
     val requestSchemas: List<SchemaDefinition>
 
@@ -53,11 +58,13 @@ class Endpoint(val method: String, val urlTemplate: String, contents: List<Node>
                 {
                     val method = match.groups["method"]!!.value
                     val urlTemplate = match.groups["urlTemplate"]!!.value
-                    return Endpoint(method, urlTemplate, contents.toList())
+                    return Endpoint(method, urlTemplate,
+                            isMetaBlock = false, contents = contents.toList())
                 }
                 else if (headingText == "Standard response format")
                 {
-                    return Endpoint("", "<Standard response format>", contents.toList())
+                    return Endpoint("", "<Standard response format>",
+                            isMetaBlock = true, contents = contents.toList())
                 }
             }
             return null

--- a/src/validateSchema/src/test/kotlin/org/vaccineimpact/api/validateSchema/SchemaValidator.kt
+++ b/src/validateSchema/src/test/kotlin/org/vaccineimpact/api/validateSchema/SchemaValidator.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.validateSchema
 
+import org.assertj.core.api.Assertions.assertThat
 import org.commonmark.parser.Parser
 import org.junit.Test
 
@@ -14,15 +15,35 @@ class SchemaValidator
         }
 
         val validator = JSONValidator()
+        val urlRegex = buildUrlRegex()
+
         val endpoints = spec.children().map { Endpoint.asEndpoint(it) }.filterNotNull()
         for (endpoint in endpoints)
         {
             println("Checking $endpoint:")
+
+            if (!endpoint.isMetaBlock)
+            {
+                assertThat(urlRegex.matches(endpoint.urlTemplate))
+                        .`as`("'${endpoint.urlTemplate}' did not match expected regex. URL must consist only of " +
+                                "letters, hyphens, and slashes, and must begin and end with a slash. Full " +
+                                "regex: $urlRegex  ")
+                        .isTrue()
+            }
             for (requestSchema in endpoint.requestSchemas)
             {
                 println("- Checking [${requestSchema.schemaPath}] against ${requestSchema.example}")
                 validator.validateExampleAgainstSchema(requestSchema.example, requestSchema.schema)
             }
         }
+        println("☺️\n")
+    }
+
+    private fun buildUrlRegex(): Regex
+    {
+        val lettersOrHyphen = "[a-z-]+"
+        val urlChunk = """(?:$lettersOrHyphen|\{$lettersOrHyphen\})\/"""
+        val queryString = """\?.+"""    // We don't check the format of the query string
+        return Regex("""\/(?:$urlChunk)*(?:$queryString)?""")
     }
 }


### PR DESCRIPTION
I also implemented https://vimc.myjetbrains.com/youtrack/issue/VIMC-1277 because that was the easiest way for me to check I was getting this right.