### PR TITLE
I1326 - model run parameters csv download preparations

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -48,7 +48,7 @@ open class OnetimeLinkResolver(private val controllers: MontaguControllers,
                             repos.burdenEstimates,
                             RequestBodySource.HTMLMultipart("file")
                     )
-                    OneTimeAction.MODEl_RUN_PARAMETERS -> GroupModelRunParametersController(context, repos).getModelRunParameterSet()
+                    OneTimeAction.MODEl_RUN_PARAMETERS -> stream(GroupModelRunParametersController(context, repos).getModelRunParameterSet(), context)
                     OneTimeAction.COVERAGE -> stream(GroupCoverageController(context, repos.modellingGroup).getCoverageData(), context)
                     OneTimeAction.DEMOGRAPHY -> stream(TouchstoneController(context, repos).getDemographicData(), context)
                     OneTimeAction.SET_PASSWORD -> PasswordController(context, repos.user, OneTimeTokenGenerator(repos.token, webTokenHelper)).setPasswordForUser(context.params("username"))

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -11,11 +11,13 @@ import org.vaccineimpact.api.app.repositories.RepositoryFactory
 import org.vaccineimpact.api.models.AuthenticationResponse
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.StreamSerializable
 import spark.Request
 import spark.Route
 import spark.Spark
 import spark.route.HttpMethod
 import java.lang.reflect.InvocationTargetException
+import javax.activation.UnsupportedDataTypeException
 
 class Router(val config: RouteConfig,
              val serializer: Serializer,
@@ -41,6 +43,7 @@ class Router(val config: RouteConfig,
     private fun transform(x: Any) = when (x)
     {
         is AuthenticationResponse -> serializer.gson.toJson(x)!!
+        is StreamSerializable<*> -> throw Exception("Streamable content is not expected here")
         else -> serializer.toResult(x)
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupModelRunParametersRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupModelRunParametersRouteConfig.kt
@@ -32,7 +32,7 @@ object GroupModelRunParametersRouteConfig : RouteConfig
                     .json()
                     .secure(permissions),
 
-            Endpoint("$baseUrl/get_onetime_link/",
+            Endpoint("$baseUrl/:model-run-parameter-set-id/get_onetime_link/",
                     NewStyleOneTimeLinkController::class, "getTokenForModelRunParameters")
                     .json()
                     .secure(permissions)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/endpoints/Endpoint.kt
@@ -7,6 +7,7 @@ import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.models.AuthenticationResponse
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.serialization.Serializer
+import org.vaccineimpact.api.serialization.StreamSerializable
 import spark.Route
 import spark.Spark
 import spark.route.HttpMethod
@@ -40,6 +41,7 @@ data class Endpoint<TRoute>(
     override fun transform(x: Any) = when (x)
     {
         is AuthenticationResponse -> serializer.gson.toJson(x)!!
+        is StreamSerializable<*> -> throw Exception("Streamable content is not expected here")
         else -> serializer.toResult(x)
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/ModelRunParameterTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/ModelRunParameterTests.kt
@@ -8,7 +8,9 @@ import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
 import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
 import org.vaccineimpact.api.blackboxTests.helpers.getResultFromRedirect
 import org.vaccineimpact.api.blackboxTests.helpers.validate
+import org.vaccineimpact.api.blackboxTests.schemas.CSVSchema
 import org.vaccineimpact.api.db.JooqContext
+import org.vaccineimpact.api.models.helpers.ContentTypes
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.validateSchema.JSONValidator
 import java.io.StringReader
@@ -147,7 +149,39 @@ class ModelRunParameterTests : BurdenEstimateTests()
         Assertions.assertThat(secondRow[0]).isEqualTo("2")
         Assertions.assertThat(secondRow[1]).isEqualTo("cc")
         Assertions.assertThat(secondRow[2]).isEqualTo("dd")
+    }
 
+    @Test
+    fun `can download model run parameter set via onetime link`()
+    {
+        validate("$modelRunParameterUrl/1/get_onetime_link/") against "Token" given { db->
+            setupDatabaseWithModelRunParameterSetValues(db)
+        } requiringPermissions { requiredWritePermissions } andCheckString { token ->
+            val oneTimeURL = "/onetime_link/$token/"
+            val requestHelper = RequestHelper()
+            val response = requestHelper.get(oneTimeURL)
+
+            Assertions.assertThat(response.statusCode).isEqualTo(200)
+
+            val csv = StringReader(response.text)
+                    .use { CSVReader(it).readAll() }
+
+            val headers = csv.first().toList()
+            val firstRow = csv.drop(1).first().toList()
+
+            val expectedHeaders = listOf("run_id", "<param_1>", "<param_2>")
+
+            headers.forEachIndexed { index, h ->
+                Assertions.assertThat(h).isEqualTo(expectedHeaders[index])
+            }
+
+            Assertions.assertThat(firstRow[0]).isEqualTo("1")
+            Assertions.assertThat(firstRow[1]).isEqualTo("aa")
+            Assertions.assertThat(firstRow[2]).isEqualTo("bb")
+
+            val badResponse = requestHelper.get(oneTimeURL)
+            JSONValidator().validateError(badResponse.text, expectedErrorCode = "invalid-token-used")
+        }
     }
 
 }


### PR DESCRIPTION
* throw an exception in a router if endpoint is not expected to be streamable
* blacbox test for model run csv download endpoint
* add parameter to one time link for model run parameter csv