### PR TITLE
i1322: Isolate annex database tests

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateWriter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateWriter.kt
@@ -20,12 +20,13 @@ import kotlin.concurrent.thread
 
 open class StochasticBurdenEstimateWriter(
         readDatabaseDSL: DSLContext,
-        writeDatabaseDSLPromise: CloseableContext
+        writeDatabaseDSLPromise: CloseableContext = ShortlivedAnnexContext()
 ) : BurdenEstimateWriter(readDatabaseDSL, writeDatabaseDSLPromise, true)
 
-open class BurdenEstimateWriter(private val readDatabaseDSL: DSLContext,
-                                private val writeDatabaseDSLPromise: CloseableContext,
-                                stochastic: Boolean = false)
+open class BurdenEstimateWriter(
+        private val readDatabaseDSL: DSLContext,
+        private val writeDatabaseDSLPromise: CloseableContext = AmbientDSLContext(readDatabaseDSL),
+        stochastic: Boolean = false)
 {
 
     private val table: TableImpl<*> = if (stochastic)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateWriter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateWriter.kt
@@ -20,11 +20,11 @@ import kotlin.concurrent.thread
 
 open class StochasticBurdenEstimateWriter(
         readDatabaseDSL: DSLContext,
-        writeDatabaseDSLPromise: () -> DSLContext = { AnnexJooqContext().dsl }
+        writeDatabaseDSLPromise: CloseableContext
 ) : BurdenEstimateWriter(readDatabaseDSL, writeDatabaseDSLPromise, true)
 
 open class BurdenEstimateWriter(private val readDatabaseDSL: DSLContext,
-                                private val writeDatabaseDSLPromise: () -> DSLContext = { readDatabaseDSL },
+                                private val writeDatabaseDSLPromise: CloseableContext,
                                 stochastic: Boolean = false)
 {
 
@@ -70,37 +70,38 @@ open class BurdenEstimateWriter(private val readDatabaseDSL: DSLContext,
         val outcomeLookup = getOutcomesAsLookup()
         val modelRuns = getModelRunsAsLookup(setId)
         val modelRunParameterId = getModelRunParameterSetId(setId)
-        val writeDatabaseDSL = writeDatabaseDSLPromise()
+        writeDatabaseDSLPromise.inside { writeDatabaseDSL ->
 
-        // The only foreign keys are:
-        // * burden_estimate_set, which is the same for every row, and it's the one we just created and know exists
-        // * country, which we check below, per row of the CSV (and each row represents multiple rows in the database
-        //   so this is an effort saving).
-        // * burden_outcome, which we check below (currently we check for every row, but given these are set in the
-        //   columns and don't vary by row this could be made more efficient)
-        writeDatabaseDSL.withoutCheckingForeignKeyConstraints(table) {
+            // The only foreign keys are:
+            // * burden_estimate_set, which is the same for every row, and it's the one we just created and know exists
+            // * country, which we check below, per row of the CSV (and each row represents multiple rows in the database
+            //   so this is an effort saving).
+            // * burden_outcome, which we check below (currently we check for every row, but given these are set in the
+            //   columns and don't vary by row this could be made more efficient)
+            writeDatabaseDSL.withoutCheckingForeignKeyConstraints(table) {
 
-            PipedOutputStream().use { stream ->
-                // First, let's set up a thread to read from the stream and send
-                // it to the database. This will block if the thread is empty, and keep
-                // going until it sees the Postgres EOF marker.
-                val inputStream = PipedInputStream(stream).buffered()
-                val writeToDatabaseThread = writeStreamToDatabase(inputStream, writeDatabaseDSL)
+                PipedOutputStream().use { stream ->
+                    // First, let's set up a thread to read from the stream and send
+                    // it to the database. This will block if the thread is empty, and keep
+                    // going until it sees the Postgres EOF marker.
+                    val inputStream = PipedInputStream(stream).buffered()
+                    val writeToDatabaseThread = writeStreamToDatabase(inputStream, writeDatabaseDSL)
 
-                // In the main thread, write to piped stream, blocking if we get too far ahead of
-                // the other thread ("too far ahead" meaning the buffer on the input stream is full)
-                writeCopyData(
-                        outcomeLookup,
-                        countries,
-                        modelRuns,
-                        modelRunParameterId,
-                        stream,
-                        estimates,
-                        expectedDisease,
-                        setId)
+                    // In the main thread, write to piped stream, blocking if we get too far ahead of
+                    // the other thread ("too far ahead" meaning the buffer on the input stream is full)
+                    writeCopyData(
+                            outcomeLookup,
+                            countries,
+                            modelRuns,
+                            modelRunParameterId,
+                            stream,
+                            estimates,
+                            expectedDisease,
+                            setId)
 
-                // Wait for the worker thread to finished
-                writeToDatabaseThread.join()
+                    // Wait for the worker thread to finished
+                    writeToDatabaseThread.join()
+                }
             }
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -37,7 +37,7 @@ class JooqBurdenEstimateRepository(
             BurdenEstimateWriter(dsl)
 
     private val stochasticBurdenEstimateWriter: StochasticBurdenEstimateWriter = stochasticBurdenEstimateWriter ?:
-            StochasticBurdenEstimateWriter(dsl, ShortlivedAnnexContext())
+            StochasticBurdenEstimateWriter(dsl)
 
     override fun getModelRunParameterSets(groupId: String, touchstoneId: String): List<ModelRunParameterSet>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.*
 import org.vaccineimpact.api.app.repositories.jooq.mapping.BurdenMappingHelper
 import org.vaccineimpact.api.db.AnnexJooqContext
+import org.vaccineimpact.api.db.ShortlivedAnnexContext
 import org.vaccineimpact.api.db.Tables.*
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.db.joinPath
@@ -36,7 +37,7 @@ class JooqBurdenEstimateRepository(
             BurdenEstimateWriter(dsl)
 
     private val stochasticBurdenEstimateWriter: StochasticBurdenEstimateWriter = stochasticBurdenEstimateWriter ?:
-            StochasticBurdenEstimateWriter(dsl, { AnnexJooqContext().dsl })
+            StochasticBurdenEstimateWriter(dsl, ShortlivedAnnexContext())
 
     override fun getModelRunParameterSets(groupId: String, touchstoneId: String): List<ModelRunParameterSet>
     {

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
@@ -5,10 +5,7 @@ import org.junit.BeforeClass
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 import org.vaccineimpact.api.blackboxTests.tests.*
-import org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates.CreateBurdenEstimateTests
-import org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates.ModelRunParameterTests
-import org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates.RetrieveBurdenEstimateTests
-import org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates.PopulateBurdenEstimateTests
+import org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates.*
 import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper
 
 // Keep these sorted alphabetically, for consistency
@@ -16,6 +13,7 @@ import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper
 @Suite.SuiteClasses(
         AccessLogTests::class,
         AuthenticationTests::class,
+        ClearBurdenEstimateSetTests::class,
         CoverageTests::class,
         CreateBurdenEstimateTests::class,
         CreateUserTests::class,
@@ -42,14 +40,16 @@ class BlackboxTestsSuite
         @JvmStatic
         fun createTemplateDatabase()
         {
-            DatabaseCreationHelper.createTemplateFromDatabase()
+            DatabaseCreationHelper.main.createTemplateFromDatabase()
+            DatabaseCreationHelper.annex.createTemplateFromDatabase()
         }
 
         @AfterClass
         @JvmStatic
         fun restoreDatabaseFromTemplate()
         {
-            DatabaseCreationHelper.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.main.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.annex.restoreDatabaseFromTemplate()
         }
     }
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
@@ -13,7 +13,6 @@ import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper
 @Suite.SuiteClasses(
         AccessLogTests::class,
         AuthenticationTests::class,
-        ClearBurdenEstimateSetTests::class,
         CoverageTests::class,
         CreateBurdenEstimateTests::class,
         CreateUserTests::class,

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -11,6 +11,8 @@ import spark.route.HttpMethod
 
 class PopulateBurdenEstimateTests : BurdenEstimateTests()
 {
+    override val usesAnnex = true
+
     @Test
     fun `can populate central burden estimate`()
     {

--- a/src/blackboxTests/src/test/resources/config.properties
+++ b/src/blackboxTests/src/test/resources/config.properties
@@ -11,5 +11,6 @@ annex.username=${annex_username}
 annex.password=${annex_password}
 
 testdb.template_name=${testdb_template_name}
+annex.template_name=${annex_template_name}
 
 app.url=${app_url}

--- a/src/config/default.properties
+++ b/src/config/default.properties
@@ -18,6 +18,7 @@ testdb_host=localhost
 testdb_port=5432
 testdb_name=montagu
 testdb_template_name=montagu_template
+annex_template_name=annex_template
 
 docker_host=tcp://localhost:2375
 

--- a/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/CloseableContext.kt
+++ b/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/CloseableContext.kt
@@ -1,0 +1,26 @@
+package org.vaccineimpact.api.db
+
+import org.jooq.DSLContext
+
+interface CloseableContext
+{
+    fun inside(work: (DSLContext) -> Unit)
+}
+
+class AmbientDSLContext(val dsl: DSLContext) : CloseableContext
+{
+    override fun inside(work: (DSLContext) -> Unit)
+    {
+        work(dsl)
+    }
+}
+
+open class ShortlivedAnnexContext : CloseableContext
+{
+    override open fun inside(work: (DSLContext) -> Unit)
+    {
+        AnnexJooqContext().use {
+            work(it.dsl)
+        }
+    }
+}

--- a/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/CloseableContext.kt
+++ b/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/CloseableContext.kt
@@ -2,11 +2,17 @@ package org.vaccineimpact.api.db
 
 import org.jooq.DSLContext
 
+// The idea is that we need a database context, and in some cases we
+// want to close the database connection as soon as we're done (a
+// short-lived context) and in others we're just using a pre-existing
+// database context from an outer scope, and we should just leave it
+// open. This interface abstracts away those distinctions.
 interface CloseableContext
 {
     fun inside(work: (DSLContext) -> Unit)
 }
 
+// Just pass the DSL through, don't close it
 class AmbientDSLContext(val dsl: DSLContext) : CloseableContext
 {
     override fun inside(work: (DSLContext) -> Unit)
@@ -15,9 +21,10 @@ class AmbientDSLContext(val dsl: DSLContext) : CloseableContext
     }
 }
 
-open class ShortlivedAnnexContext : CloseableContext
+// Open a new database connection as needed, and then close it again
+class ShortlivedAnnexContext : CloseableContext
 {
-    override open fun inside(work: (DSLContext) -> Unit)
+    override fun inside(work: (DSLContext) -> Unit)
     {
         AnnexJooqContext().use {
             work(it.dsl)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/RepositoryTestSuite.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/RepositoryTestSuite.kt
@@ -45,14 +45,16 @@ class RepositoryTestSuite
         @JvmStatic
         fun createTemplateDatabase()
         {
-            DatabaseCreationHelper.createTemplateFromDatabase()
+            DatabaseCreationHelper.main.createTemplateFromDatabase()
+            DatabaseCreationHelper.annex.createTemplateFromDatabase()
         }
 
         @AfterClass
         @JvmStatic
         fun restoreDatabaseFromTemplate()
         {
-            DatabaseCreationHelper.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.main.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.annex.restoreDatabaseFromTemplate()
         }
     }
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/AnnexTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/AnnexTests.kt
@@ -10,6 +10,8 @@ import org.vaccineimpact.api.test_helpers.DatabaseTest
 
 class AnnexTests : DatabaseTest()
 {
+    override val usesAnnex = true
+
     @Test
     fun `can connect to annex`()
     {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateWriterTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateWriterTests.kt
@@ -14,6 +14,8 @@ import org.vaccineimpact.api.db.direct.addBurdenEstimateSet
 
 class BurdenEstimateWriterTests : BurdenEstimateRepositoryTests()
 {
+    override val usesAnnex = true
+
     private fun createCentralSetWithoutModelRuns(): Int
     {
         return withDatabase { db ->

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -13,6 +13,8 @@ import org.vaccineimpact.api.db.direct.addBurdenEstimateSet
 
 class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
 {
+    override val usesAnnex = true
+
     @Test
     fun `can populate burden estimate set`()
     {

--- a/src/databaseTests/src/test/resources/config.properties
+++ b/src/databaseTests/src/test/resources/config.properties
@@ -11,5 +11,6 @@ annex.username=${annex_username}
 annex.password=${annex_password}
 
 testdb.template_name=${testdb_template_name}
+annex.template_name=${annex_template_name}
 
 docker_host=${docker_host}

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/DatabaseTest.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/DatabaseTest.kt
@@ -2,29 +2,38 @@ package org.vaccineimpact.api.test_helpers
 
 import org.junit.After
 import org.junit.Before
+import org.vaccineimpact.api.db.AnnexJooqContext
 import org.vaccineimpact.api.db.Config
 import org.vaccineimpact.api.db.JooqContext
 
 abstract class DatabaseTest : MontaguTests()
 {
-    private val templateDbName = Config["testdb.template_name"]
-    private val dbName = Config["db.name"]
     private val userName = Config["db.username"]
+    protected open val usesAnnex = false
 
     @Before
     fun createDatabase()
     {
-        JooqContext(dbName = "postgres").use {
-            it.dsl.query("CREATE DATABASE $dbName TEMPLATE $templateDbName;").execute()
+        DatabaseCreationHelper.main.createDatabaseFromTemplate()
+        if (usesAnnex)
+        {
+            DatabaseCreationHelper.annex.createDatabaseFromTemplate()
         }
-        DatabaseCreationHelper.checkDatabaseExists(dbName)
     }
 
     @After
     fun dropDatabase()
     {
-        org.vaccineimpact.api.db.JooqContext(dbName = "postgres").use {
-            it.dsl.query("DROP DATABASE $dbName").execute()
+        DatabaseCreationHelper.main.dropDatabase()
+        if (usesAnnex)
+        {
+            DatabaseCreationHelper.annex.dropDatabase()
         }
     }
 }
+
+data class DatabaseConfig(
+        val factory: (String) -> JooqContext,
+        val name: String,
+        val templateName: String
+)

--- a/src/userCLI/src/test/kotlin/org/vaccineimpact/api/security/UserCLITestSuite.kt
+++ b/src/userCLI/src/test/kotlin/org/vaccineimpact/api/security/UserCLITestSuite.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.security.tests.AddUserToGroupTests
 import org.vaccineimpact.api.security.tests.GroupsTests
 import org.vaccineimpact.api.security.tests.QuestionTests
 import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper
+import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper.Companion.main
 
 // Keep these sorted alphabetically, for consistency
 @RunWith(Suite::class)
@@ -26,14 +27,16 @@ class UserCLITestSuite
         @JvmStatic
         fun createTemplateDatabase()
         {
-            DatabaseCreationHelper.createTemplateFromDatabase()
+            DatabaseCreationHelper.main.createTemplateFromDatabase()
+            DatabaseCreationHelper.annex.createTemplateFromDatabase()
         }
 
         @AfterClass
         @JvmStatic
         fun restoreDatabaseFromTemplate()
         {
-            DatabaseCreationHelper.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.main.restoreDatabaseFromTemplate()
+            DatabaseCreationHelper.annex.restoreDatabaseFromTemplate()
         }
     }
 }

--- a/src/userCLI/src/test/resources/config.properties
+++ b/src/userCLI/src/test/resources/config.properties
@@ -11,5 +11,6 @@ annex.username=${annex_username}
 annex.password=${annex_password}
 
 testdb.template_name=${testdb_template_name}
+annex.template_name=${annex_template_name}
 
 docker_host=${docker_host}


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1322

We need to perform tests on the annex is a separate database each time, as with the central database. Additionally, we were not closing the annex database connection at the end of using it; this becomes obvious when you try and drop the database.