### PR TITLE
Change allowed_shiny claim to be a string

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -71,7 +71,7 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
         assertThat(claims["sub"]).isEqualTo("test.user")
         assertThat(claims["exp"]).isInstanceOf(Date::class.java)
-        assertThat(claims["allowed_shiny"]).isEqualTo(false)
+        assertThat(claims["allowed_shiny"]).isEqualTo("false")
     }
 
     @Test
@@ -86,7 +86,7 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
         assertThat(claims["sub"]).isEqualTo("test.user")
         assertThat(claims["exp"]).isInstanceOf(Date::class.java)
-        assertThat(claims["allowed_shiny"]).isEqualTo(true)
+        assertThat(claims["allowed_shiny"]).isEqualTo("true")
     }
 
     @Test

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/AuthenticationTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/AuthenticationTests.kt
@@ -69,7 +69,7 @@ class AuthenticationTests : DatabaseTest()
         val shinyToken = cookie.substring(cookie.indexOf("=") + 1, cookie.indexOf(";"))
         val claims = JWT.decode(shinyToken)
         val allowedShiny = claims.getClaim("allowed_shiny")
-        assertThat(allowedShiny.asBoolean()).isTrue()
+        assertThat(allowedShiny.asString()).isEqualTo("true")
     }
 
     @Test

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -68,14 +68,14 @@ open class WebTokenHelper(keyPair: KeyPair,
         )
     }
 
-    fun shinyClaims(user: InternalUser): Map<String, Any>
+    private fun shinyClaims(user: InternalUser): Map<String, Any>
     {
         val allowedShiny = user.permissions.contains(ReifiedPermission("reports.review", Scope.Global()))
         return mapOf(
                 "iss" to issuer,
                 "sub" to user.username,
                 "exp" to Date.from(Instant.now().plus(lifeSpan)),
-                "allowed_shiny" to allowedShiny
+                "allowed_shiny" to allowedShiny.toString()
         )
     }
 


### PR DESCRIPTION
It seems the Caddy jwt middleware can't match a boolean 