### PR TITLE
i1389: Add TeamCity service messages

### DIFF
--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/TeamCityHelper.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/TeamCityHelper.kt
@@ -1,0 +1,77 @@
+package org.vaccineimpact.api.test_helpers
+
+import java.io.PrintWriter
+import java.io.StringWriter
+
+object TeamCityHelper
+{
+    fun startSuite(name: String)
+    {
+        println("##teamcity[testSuiteStarted name='${escape(name)}']")
+    }
+
+    fun endSuite(name: String)
+    {
+        println("##teamcity[testSuiteFinished name='${escape(name)}']")
+    }
+
+    fun startTest(name: String)
+    {
+        println("##teamcity[testStarted name='${escape(name)}']")
+    }
+
+    fun finishTest(name: String)
+    {
+        println("##teamcity[testFinished name='${escape(name)}']")
+    }
+
+    fun failTest(e: Throwable, name: String)
+    {
+        val stackTrace = StringWriter().use {
+            e.printStackTrace(PrintWriter(it))
+            it.toString()
+        }
+        println("##teamcity[testFailed name='${escape(name)}' " +
+                "message='${escape(e.message)}' " +
+                "details='${escape(stackTrace)}']")
+    }
+
+    fun <T> asSuite(name: String, work: () -> T): T
+    {
+        startSuite(name)
+        return try
+        {
+            work()
+        }
+        finally
+        {
+            endSuite(name)
+        }
+    }
+
+    fun <T> asTest(name: String, work: () -> T): T
+    {
+        startTest(name)
+        return try
+        {
+            work()
+        }
+        catch (e: Exception)
+        {
+            failTest(e, name)
+            throw e
+        }
+        finally
+        {
+            finishTest(name)
+        }
+    }
+
+    private fun escape(text: String?) = text
+            ?.replace("|", "||")
+            ?.replace("'", "|'")
+            ?.replace("\r", "|r")
+            ?.replace("\n", "|n")
+            ?.replace("[", "|[")
+            ?.replace("]", "|]")
+}

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/TeamCityIntegration.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/TeamCityIntegration.kt
@@ -1,29 +1,20 @@
 package org.vaccineimpact.api.test_helpers
 
-import java.io.PrintWriter
-import java.io.StringWriter
-
 class TeamCityIntegration : org.junit.rules.TestWatcher()
 {
     override fun starting(description: org.junit.runner.Description)
     {
-        println("##teamcity[testStarted name='${escape(description.name())}']")
+        TeamCityHelper.startTest(description.name())
     }
 
     override fun finished(description: org.junit.runner.Description)
     {
-        println("##teamcity[testFinished name='${escape(description.name())}']")
+        TeamCityHelper.finishTest(description.name())
     }
 
     override fun failed(e: Throwable, description: org.junit.runner.Description)
     {
-        val stackTrace = StringWriter().use {
-            e.printStackTrace(PrintWriter(it))
-            it.toString()
-        }
-        println("##teamcity[testFailed name='${escape(description.name())}' " +
-                "message='${escape(e.message)}' " +
-                "details='${escape(stackTrace)}']")
+        TeamCityHelper.failTest(e, description.name())
     }
 
     private fun org.junit.runner.Description.name() = "${this.className}.${this.methodName}"

--- a/src/validateSchema/build.gradle
+++ b/src/validateSchema/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:3.8.0"
+    testCompile project(":testHelpers")
 }
 
 test.dependsOn 'copySpec'

--- a/src/validateSchema/src/test/kotlin/org/vaccineimpact/api/validateSchema/SchemaValidator.kt
+++ b/src/validateSchema/src/test/kotlin/org/vaccineimpact/api/validateSchema/SchemaValidator.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.api.validateSchema
 import org.assertj.core.api.Assertions.assertThat
 import org.commonmark.parser.Parser
 import org.junit.Test
+import org.vaccineimpact.api.test_helpers.TeamCityHelper
 
 class SchemaValidator
 {
@@ -21,19 +22,20 @@ class SchemaValidator
         for (endpoint in endpoints)
         {
             println("Checking $endpoint:")
-
-            if (!endpoint.isMetaBlock)
-            {
-                assertThat(urlRegex.matches(endpoint.urlTemplate))
-                        .`as`("'${endpoint.urlTemplate}' did not match expected regex. URL must consist only of " +
-                                "letters, hyphens, and slashes, and must begin and end with a slash. Full " +
-                                "regex: $urlRegex  ")
-                        .isTrue()
-            }
-            for (requestSchema in endpoint.requestSchemas)
-            {
-                println("- Checking [${requestSchema.schemaPath}] against ${requestSchema.example}")
-                validator.validateExampleAgainstSchema(requestSchema.example, requestSchema.schema)
+            TeamCityHelper.asTest(endpoint.toString().replace(":", "")) {
+                if (!endpoint.isMetaBlock)
+                {
+                    assertThat(urlRegex.matches(endpoint.urlTemplate))
+                            .`as`("'${endpoint.urlTemplate}' did not match expected regex. URL must consist only of " +
+                                    "letters, hyphens, and slashes, and must begin and end with a slash. Full " +
+                                    "regex: $urlRegex  ")
+                            .isTrue()
+                }
+                for (requestSchema in endpoint.requestSchemas)
+                {
+                    println("- Checking [${requestSchema.schemaPath}] against ${requestSchema.example}")
+                    validator.validateExampleAgainstSchema(requestSchema.example, requestSchema.schema)
+                }
             }
         }
         println("☺️\n")


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1389

This allows us to clearly see in TeamCity how many endpoints are being tested currently. This gives us confidence that when we reorganize the schema in the main pull request, that we haven't lost any by accident.