### PR TITLE
I1419 - browser hangs with long redirect url

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestExtensions.kt
@@ -13,9 +13,8 @@ fun Request.consumeRemainder()
     if (inputStream != null)
     {
         val buffer = ByteArray(8096)
-        while (!inputStream.isFinished)
+        while (inputStream.read(buffer) > 0)
         {
-            inputStream.read(buffer)
             //keep going
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/RequestExtensions.kt
@@ -13,8 +13,9 @@ fun Request.consumeRemainder()
     if (inputStream != null)
     {
         val buffer = ByteArray(8096)
-        while (inputStream.read(buffer) > 0)
+        while (!inputStream.isFinished)
         {
+            inputStream.read(buffer)
             //keep going
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -98,6 +98,8 @@ class OneTimeLinkController(
     {
         val encodedResult = tokenHelper.encodeResult(result)
         context.request.consumeRemainder()
+        // it is recommended to keep urls under 2000 characters
+        // https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers/417184#417184
         if (encodedResult.length > 1900 && exception != null)
             throw exception
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -98,7 +98,7 @@ class OneTimeLinkController(
     {
         val encodedResult = tokenHelper.encodeResult(result)
         context.request.consumeRemainder()
-        if (encodedResult.length > 2000 && exception != null)
+        if (encodedResult.length > 1900 && exception != null)
             throw exception
 
         context.redirect("$redirectUrl?result=$encodedResult")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -98,7 +98,7 @@ class OneTimeLinkController(
     {
         val encodedResult = tokenHelper.encodeResult(result)
         context.request.consumeRemainder()
-        if (encodedResult.length > 5000 && exception != null)
+        if (encodedResult.length > 2000 && exception != null)
             throw exception
 
         context.redirect("$redirectUrl?result=$encodedResult")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.app.controllers
 
+import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.vaccineimpact.api.app.*
 import org.vaccineimpact.api.app.app_start.Controller
@@ -8,6 +9,7 @@ import org.vaccineimpact.api.app.errors.InvalidOneTimeLinkToken
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.security.OneTimeTokenGenerator
+import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
 import org.vaccineimpact.api.models.helpers.OneTimeAction
@@ -61,7 +63,7 @@ class OneTimeLinkController(
             catch (e: Exception)
             {
                 val error = errorHandler.logExceptionAndReturnMontaguError(e, context.request)
-                redirectWithResult(context, error.asResult(), redirectUrl)
+                redirectWithResult(context, error.asResult(), redirectUrl, e)
             }
         }
     }
@@ -91,10 +93,14 @@ class OneTimeLinkController(
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.BURDENS_POPULATE, context)
     }
 
-    private fun redirectWithResult(context: ActionContext, result: Result, redirectUrl: String)
+    private fun redirectWithResult(context: ActionContext, result: Result, redirectUrl: String,
+                                   exception: Exception? = null)
     {
         val encodedResult = tokenHelper.encodeResult(result)
         context.request.consumeRemainder()
+        if (encodedResult.length > 5000 && exception != null)
+            throw exception
+
         context.redirect("$redirectUrl?result=$encodedResult")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -153,9 +153,9 @@ class OneTimeLinkControllerTests : MontaguTests()
     }
 
     @Test
-    fun `rethrows error if redirect url query parameter is longer than 5000 chars`()
+    fun `rethrows error if redirect url query parameter is longer than 1900 chars`()
     {
-        val longMessage = org.apache.commons.lang3.StringUtils.repeat('a', 2000)
+        val longMessage = org.apache.commons.lang3.StringUtils.repeat('a', 1901)
         val tokenHelper = mock<WebTokenHelper> {
             on(it.encodeResult(argThat { status == ResultStatus.FAILURE })) doReturn longMessage
             on (it.verify(any())) doReturn claimsWithRedirectUrl

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -155,7 +155,7 @@ class OneTimeLinkControllerTests : MontaguTests()
     @Test
     fun `rethrows error if redirect url query parameter is longer than 5000 chars`()
     {
-        val longMessage = org.apache.commons.lang3.StringUtils.repeat('a', 5001)
+        val longMessage = org.apache.commons.lang3.StringUtils.repeat('a', 2000)
         val tokenHelper = mock<WebTokenHelper> {
             on(it.encodeResult(argThat { status == ResultStatus.FAILURE })) doReturn longMessage
             on (it.verify(any())) doReturn claimsWithRedirectUrl


### PR DESCRIPTION
Solution is to re-throw errors rather than encoding them and redirecting if the encoded result is longer than 2000 chars.

I'm quite puzzled because my best googling can't turn up any stack overflow questions, browser specs, or any form of documentation about this phenomenon. From testing found that the breakpoint (with chrome) is somewhere around the 8000 character mark, but chose 1900 because I did find that IE has a url length limit, and keeping the query string under 1900 characters will keep us just within that limit: https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer

As I write this, it occurs to me that I don't think it is a browser issue at all. I think it is the Spark server failing to issue the redirect. I'm going to try debugging a little further, but either way seems like it's a limitation we probably can't (and shouldn't need to) overcome.

Further subtasks to prevent a request ever getting to this stage, i.e. checking that the POST-ed file is text and not binary data.