### PR TITLE
i1433: Always wait for write thread to finish

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/burdenestimates/BurdenEstimateWriter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/burdenestimates/BurdenEstimateWriter.kt
@@ -46,20 +46,25 @@ abstract class BurdenEstimateWriter(
                     val inputStream = PipedInputStream(stream).buffered()
                     val writeToDatabaseThread = writeStreamToDatabase(inputStream, writeDatabaseDSL)
 
-                    // In the main thread, write to piped stream, blocking if we get too far ahead of
-                    // the other thread ("too far ahead" meaning the buffer on the input stream is full)
-                    writeCopyData(
-                            outcomeLookup,
-                            countries,
-                            modelRuns,
-                            modelRunParameterId,
-                            stream,
-                            estimates,
-                            expectedDisease,
-                            setId)
-
-                    // Wait for the worker thread to finished
-                    writeToDatabaseThread.join()
+                    try
+                    {
+                        // In the main thread, write to piped stream, blocking if we get too far ahead of
+                        // the other thread ("too far ahead" meaning the buffer on the input stream is full)
+                        writeCopyData(
+                                outcomeLookup,
+                                countries,
+                                modelRuns,
+                                modelRunParameterId,
+                                stream,
+                                estimates,
+                                expectedDisease,
+                                setId)
+                    }
+                    finally
+                    {
+                        // Wait for the worker thread to finished
+                        writeToDatabaseThread.join()
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1433

So the issue here was that in the event that the main thread (which is running `writeCopyData`) throws an exception, we never hit the `writeToDatabaseThread.join()` line. However, when we leave the `use` block inside `writeCopyData` we always cleanly terminate the COPY data with `\.` (see `PostgresCopyWriter.close`).

This means that the write to database thread will always write valid data via the COPY command; it will just write less if the main thread gives up because of an exception.

That's fine, because the transaction will be rolled back.

The normal ordering of events is like this:

1. Main thread writes some data, throws an exception, and writes the terminator character `\.`
1. Write to database thread finishes the COPY command.
1. Exception bubbles up and the transaction is rolled back.

However, there is a race condition here, and this is also a valid ordering of events, which produces the bug:

1. Main thread writes some data, throws an exception, and writes the terminator character `\.`
1. Exception bubbles up and the transaction is rolled back.
1. Write to database thread finishes the COPY command, using the same db connection, but now no longer within the transaction scope.

So this fix just makes sure we always follow the first order of events, by waiting for the write thread to finish before rolling back the transaction.