### PR TITLE
i1405: Bring over code that generates onetime tokens

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/OneTimeLinkRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/OneTimeLinkRouteConfig.kt
@@ -1,7 +1,6 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.Endpoint
-import org.vaccineimpact.api.app.app_start.json
 import org.vaccineimpact.api.app.app_start.secure
 import org.vaccineimpact.api.app.controllers.OneTimeLinkController
 import spark.route.HttpMethod

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/OneTimeLinkRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/OneTimeLinkRouteConfig.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.Endpoint
+import org.vaccineimpact.api.app.app_start.json
+import org.vaccineimpact.api.app.app_start.secure
 import org.vaccineimpact.api.app.controllers.OneTimeLinkController
 import spark.route.HttpMethod
 
@@ -10,6 +12,11 @@ object OneTimeLinkRouteConfig : RouteConfig
     val url = "/onetime_link/:token/"
 
     override val endpoints = listOf(
+            // This gets new style onetime tokens (like the reporting API)
+            Endpoint("/onetime_token/", controller, "getToken")
+                    .secure(),
+
+            // This consumes old style onetime tokens
             Endpoint(url, controller, "onetimeLink", method = HttpMethod.get),
             Endpoint(url, controller, "onetimeLink", method = HttpMethod.post)
     )

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -1,15 +1,15 @@
 package org.vaccineimpact.api.app.controllers
 
-import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.vaccineimpact.api.app.*
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.errors.InvalidOneTimeLinkToken
+import org.vaccineimpact.api.app.errors.MissingRequiredParameterError
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.security.OneTimeTokenGenerator
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
 import org.vaccineimpact.api.models.helpers.OneTimeAction
@@ -66,6 +66,13 @@ class OneTimeLinkController(
                 redirectWithResult(context, error.asResult(), redirectUrl, e)
             }
         }
+    }
+
+    fun getToken(): String
+    {
+        val url = context.queryParams("url") ?: throw MissingRequiredParameterError("url")
+        val profile = context.userProfile!!
+        return oneTimeTokenGenerator.getNewStyleOneTimeLinkToken(url, profile)
     }
 
     fun getTokenForDemographicData(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -9,7 +9,6 @@ import org.vaccineimpact.api.app.errors.MissingRequiredParameterError
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TokenRepository
 import org.vaccineimpact.api.app.security.OneTimeTokenGenerator
-import org.vaccineimpact.api.app.security.montaguPermissions
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
 import org.vaccineimpact.api.models.helpers.OneTimeAction

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/OneTimeTokenGenerator.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/OneTimeTokenGenerator.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.app.security
 
+import org.pac4j.core.profile.CommonProfile
 import org.vaccineimpact.api.app.MontaguRedirectValidator
 import org.vaccineimpact.api.app.RedirectValidator
 import org.vaccineimpact.api.app.context.ActionContext
@@ -50,5 +51,15 @@ open class OneTimeTokenGenerator(
                 context.redirectUrl,
                 context.username!!,
                 duration)
+    }
+
+    open fun getNewStyleOneTimeLinkToken(url: String, profile: CommonProfile): String
+    {
+        val attributes = profile.attributes
+        val permissions = attributes["permissions"].toString()
+        val roles = attributes["roles"].toString()
+        val token = tokenHelper.generateNewStyleOnetimeActionToken(url, permissions, roles)
+        tokenRepository.storeToken(token)
+        return token
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.pac4j.core.profile.CommonProfile
-import org.pac4j.core.profile.UserProfile
 import org.vaccineimpact.api.app.ErrorHandler
 import org.vaccineimpact.api.app.OnetimeLinkResolver
 import org.vaccineimpact.api.app.RedirectValidator
@@ -161,7 +160,7 @@ class OneTimeLinkControllerTests : MontaguTests()
         val longMessage = org.apache.commons.lang3.StringUtils.repeat('a', 1901)
         val tokenHelper = mock<WebTokenHelper> {
             on(it.encodeResult(argThat { status == ResultStatus.FAILURE })) doReturn longMessage
-            on (it.verify(any())) doReturn claimsWithRedirectUrl
+            on(it.verify(any())) doReturn claimsWithRedirectUrl
         }
         val mockErrorHandler = mock<ErrorHandler> {
             on { logExceptionAndReturnMontaguError(any(), any()) } doReturn

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/OneTimeTokenGeneratorTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/OneTimeTokenGeneratorTests.kt
@@ -1,0 +1,35 @@
+package org.vaccineimpact.api.tests.security
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Test
+import org.pac4j.core.profile.CommonProfile
+import org.vaccineimpact.api.app.repositories.TokenRepository
+import org.vaccineimpact.api.app.security.OneTimeTokenGenerator
+import org.vaccineimpact.api.security.WebTokenHelper
+import org.vaccineimpact.api.test_helpers.MontaguTests
+
+// There are other tests for this class in TokenGeneratorTests. Those
+// are for the old style onetime tokens, and will be removed eventually
+class OneTimeTokenGeneratorTests : MontaguTests()
+{
+    @Test
+    fun `can generate token`()
+    {
+        val attributes = mapOf(
+                "permissions" to "a,b,c",
+                "roles" to "x,y,z"
+        )
+        val profile = mock<CommonProfile> {
+            on { this.attributes } doReturn attributes
+        }
+        val helper = mock<WebTokenHelper>()
+
+        val repo = mock<TokenRepository>()
+        val sut = OneTimeTokenGenerator(repo, helper)
+        val token = sut.getNewStyleOneTimeLinkToken("/some/url/", profile)
+        verify(repo).storeToken(token)
+        verify(helper).generateNewStyleOnetimeActionToken("/some/url/", "a,b,c", "x,y,z")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -127,6 +127,22 @@ class WebTokenHelperTests : MontaguTests()
     }
 
     @Test
+    fun `can generate new style onetime action token`()
+    {
+        val permissions = "*/can-login,modelling-group:IC-Garske/estimates.read"
+        val roles = "*/user,modelling-group:IC-Garske/member"
+        val token = sut.generateNewStyleOnetimeActionToken("/some/url/", permissions, roles)
+        val claims = sut.verify(token)
+        assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
+        assertThat(claims["sub"]).isEqualTo("onetime_link")
+        assertThat(claims["exp"] as Date).isAfter(Date.from(Instant.now()))
+        assertThat(claims["permissions"]).isEqualTo(permissions)
+        assertThat(claims["roles"]).isEqualTo(roles)
+        assertThat(claims["url"]).isEqualTo("/some/url/")
+        assertThat(claims["nonce"]).isNotNull()
+    }
+
+    @Test
     fun `token fails validation when issuer is wrong`()
     {
         val claims = sut.claims(InternalUser(properties, roles, permissions))

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/BlackboxTestsSuite.kt
@@ -24,6 +24,7 @@ import org.vaccineimpact.api.test_helpers.DatabaseCreationHelper
         ModellingGroupTests::class,
         ModelRunParameterTests::class,
         ModelTests::class,
+        OneTimeTokenTests::class,
         PasswordTests::class,
         PopulateBurdenEstimateTests::class,
         ResponsibilityTests::class,

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/OneTimeTokenTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/OneTimeTokenTests.kt
@@ -1,0 +1,18 @@
+package org.vaccineimpact.api.blackboxTests.tests
+
+import org.junit.Test
+import org.vaccineimpact.api.blackboxTests.helpers.validate
+import org.vaccineimpact.api.models.permissions.PermissionSet
+import org.vaccineimpact.api.test_helpers.DatabaseTest
+
+class OneTimeTokenTests : DatabaseTest()
+{
+    @Test
+    fun `can get new style onetime token`()
+    {
+        validate("/onetime_token/?url=http://localhost/test") against "Token" given {
+        } requiringPermissions {
+            PermissionSet("*/can-login")
+        }
+    }
+}

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -47,6 +47,24 @@ open class WebTokenHelper(keyPair: KeyPair,
         ))
     }
 
+
+    open fun generateNewStyleOnetimeActionToken(
+            url: String,
+            permissions: String,
+            roles: String
+    ): String
+    {
+        return generator.generate(mapOf(
+                "iss" to issuer,
+                "sub" to oneTimeActionSubject,
+                "exp" to Date.from(Instant.now().plus(oneTimeLinkLifeSpan)),
+                "permissions" to permissions,
+                "roles" to roles,
+                "url" to url,
+                "nonce" to getNonce()
+        ))
+    }
+
     open fun encodeResult(result: Result): String
     {
         val json = serializer.toJson(result)

--- a/src/security/src/test/kotlin/SodiumTests.kt
+++ b/src/security/src/test/kotlin/SodiumTests.kt
@@ -1,8 +1,9 @@
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.api.security.SodiumPasswordEncoder
+import org.vaccineimpact.api.test_helpers.MontaguTests
 
-class SodiumTests
+class SodiumTests : MontaguTests()
 {
     @Test
     fun `same password that was hashed verifies`()


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1405

This adds a new endpoint for generating onetime tokens in the same way as the reporting API. Currently this is not useful for anything, as there isn't a corresponding security filter.