### PR TITLE
I1470 - return past touchstones with closed responsibilities

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -155,6 +155,7 @@ class JooqModellingGroupRepository(
                 .fromJoinPath(TOUCHSTONE, RESPONSIBILITY_SET, RESPONSIBILITY)
                 .where(RESPONSIBILITY_SET.MODELLING_GROUP.eq(group.id))
                 .and(RESPONSIBILITY.IS_OPEN)
+                .orNot(TOUCHSTONE.STATUS.eq("open"))
         return query.fetch().map { touchstoneRepository.mapTouchstone(it) }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -156,6 +156,7 @@ class JooqModellingGroupRepository(
                 .where(RESPONSIBILITY_SET.MODELLING_GROUP.eq(group.id))
                 .and(RESPONSIBILITY.IS_OPEN)
                 .orNot(TOUCHSTONE.STATUS.eq("open"))
+                .orderBy(TOUCHSTONE.ID)
         return query.fetch().map { touchstoneRepository.mapTouchstone(it) }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -153,10 +153,9 @@ class JooqModellingGroupRepository(
                         TOUCHSTONE.VERSION
                 )
                 .fromJoinPath(TOUCHSTONE, RESPONSIBILITY_SET, RESPONSIBILITY)
-                .where(RESPONSIBILITY_SET.MODELLING_GROUP.eq(group.id))
-                .and(RESPONSIBILITY.IS_OPEN)
-                .orNot(TOUCHSTONE.STATUS.eq("open"))
-                .orderBy(TOUCHSTONE.ID)
+                .where(RESPONSIBILITY.IS_OPEN).orNot(TOUCHSTONE.STATUS.eq("open"))
+                .and(RESPONSIBILITY_SET.MODELLING_GROUP.eq(group.id))
+
         return query.fetch().map { touchstoneRepository.mapTouchstone(it) }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
@@ -37,9 +37,11 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
             val touchstones = repo.getTouchstonesByGroupId(groupId)
             assertThat(touchstones).isInstanceOf(List::class.java)
             assertThat(touchstones).hasSize(2)
-            assertThat(touchstones[0]).isEqualTo(
-                    Touchstone(touchstoneId, "touchstone", 1, "descr 1", TouchstoneStatus.OPEN)
-            )
+            assertThat(touchstones).hasSameElementsAs(listOf(
+                    Touchstone(touchstoneId, "touchstone", 1, "descr 1", TouchstoneStatus.OPEN),
+                    Touchstone("$touchstone2Name-1", touchstone2Name, 1, "descr 1", TouchstoneStatus.OPEN)
+            ))
+
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
@@ -44,7 +44,7 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
     }
 
     @Test
-    fun `doesnt return touchstone with closed responsibilities`()
+    fun `does not return open touchstone with closed responsibilities`()
     {
         val scenarioId = "scenario-1"
 
@@ -55,6 +55,36 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
         } check { repo ->
             val touchstones = repo.getTouchstonesByGroupId(groupId)
             assertThat(touchstones).hasSize(0)
+        }
+    }
+
+    @Test
+    fun `does return finished touchstone with closed responsibilities`()
+    {
+        val scenarioId = "scenario-1"
+
+        given {
+            setUpDb(it, touchstoneStatus = "finished")
+            addResponsibilitySetWithResponsibility(it, scenarioId, groupId, touchstoneId, open = false)
+
+        } check { repo ->
+            val touchstones = repo.getTouchstonesByGroupId(groupId)
+            assertThat(touchstones).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `does return in prep touchstone with closed responsibilities`()
+    {
+        val scenarioId = "scenario-1"
+
+        given {
+            setUpDb(it, touchstoneStatus = "in-preparation")
+            addResponsibilitySetWithResponsibility(it, scenarioId, groupId, touchstoneId, open = false)
+
+        } check { repo ->
+            val touchstones = repo.getTouchstonesByGroupId(groupId)
+            assertThat(touchstones).hasSize(1)
         }
     }
 
@@ -79,11 +109,11 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
         db.addResponsibility(setId, touchstoneId, scenarioId, open = open)
     }
 
-    private fun setUpDb(db: JooqContext)
+    private fun setUpDb(db: JooqContext, touchstoneStatus: String = "open")
     {
         db.addDisease(diseaseId)
         db.addGroup(groupId)
-        db.addTouchstone(touchstoneName, 1, addName = true, description = "descr 1", status = "open")
+        db.addTouchstone(touchstoneName, 1, addName = true, description = "descr 1", status = touchstoneStatus)
 
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
@@ -37,11 +37,36 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
             val touchstones = repo.getTouchstonesByGroupId(groupId)
             assertThat(touchstones).isInstanceOf(List::class.java)
             assertThat(touchstones).hasSize(2)
-            assertThat(touchstones).hasSameElementsAs(listOf(
-                    Touchstone(touchstoneId, "touchstone", 1, "descr 1", TouchstoneStatus.OPEN),
-                    Touchstone("$touchstone2Name-1", touchstone2Name, 1, "descr 2", TouchstoneStatus.OPEN)
-            ))
+            assertThat(touchstones[0])
+                    .isEqualTo(Touchstone(touchstoneId, "touchstone", 1, "descr 1", TouchstoneStatus.OPEN))
+            assertThat(touchstones[1])
+                    .isEqualTo(Touchstone("$touchstone2Name-1", touchstone2Name, 1, "descr 2", TouchstoneStatus.OPEN)
+            )
 
+        }
+    }
+
+    @Test
+    fun `does not return open touchstone with no responsibilities`()
+    {
+        given {
+            setUpDb(it)
+
+        } check { repo ->
+            val touchstones = repo.getTouchstonesByGroupId(groupId)
+            assertThat(touchstones).hasSize(0)
+        }
+    }
+
+    @Test
+    fun `does not return finished touchstone with no responsibilities`()
+    {
+        given {
+            setUpDb(it, touchstoneStatus = "finished")
+
+        } check { repo ->
+            val touchstones = repo.getTouchstonesByGroupId(groupId)
+            assertThat(touchstones).hasSize(0)
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetTouchstoneTests.kt
@@ -39,7 +39,7 @@ class GetTouchstoneTests : ModellingGroupRepositoryTests()
             assertThat(touchstones).hasSize(2)
             assertThat(touchstones).hasSameElementsAs(listOf(
                     Touchstone(touchstoneId, "touchstone", 1, "descr 1", TouchstoneStatus.OPEN),
-                    Touchstone("$touchstone2Name-1", touchstone2Name, 1, "descr 1", TouchstoneStatus.OPEN)
+                    Touchstone("$touchstone2Name-1", touchstone2Name, 1, "descr 2", TouchstoneStatus.OPEN)
             ))
 
         }


### PR DESCRIPTION
We only want groups to see open touchstones in which they have open responsibilities. But they should be able to see past touchstones in which they have closed responsibilities. It's also fine to return in-prep touchstones with closed responsibilities.