### PR TITLE
I1567 - return roles with report readers

### DIFF
--- a/docs/spec/Users.md
+++ b/docs/spec/Users.md
@@ -190,7 +190,7 @@ the user being logged in.
 Required permissions: None. You do not need to be logged in to use this endpoint.
 
 ## GET /users/report-readers/{reportname}/
-Returns a list of users who have the `reports-reader` role scoped to the given report.
+Returns a list of users (with roles) who have the `reports-reader` role scoped to the given report.
 
 Required permissions: `roles.read`. 
 
@@ -202,12 +202,36 @@ Schema: [`Users.schema.json`](../schemas/Users.schema.json)
             "username": "tini",
             "name": "Tini Garske",
             "email": "example@imperial.ac.uk",
-            "last_logged_in": "2017-10-06T11:06:22Z"
+            "last_logged_in": "2017-10-06T11:06:22Z",
+            "roles": [ 
+                { 
+                    "name": "user", 
+                    "scope_prefix": null, 
+                    "scope_id": null 
+                },
+                { 
+                    "name": "reports-reader",
+                    "scope_prefix": null,
+                    "scope_id": null
+                }
+            ]
         },
         {
             "username": "alex",
             "name": "Alex Hill",
             "email": "alex@example.com",
-            "last_logged_in": "2017-11-06T11:12:13Z"
+            "last_logged_in": "2017-11-06T11:12:13Z",
+            "roles": [ 
+                { 
+                    "name": "user", 
+                    "scope_prefix": null, 
+                    "scope_id": null 
+                },
+                { 
+                    "name": "reports-reader",
+                    "scope_prefix": "report",
+                    "scope_id": "reportname"
+                }
+            ]
         }
     ]

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
@@ -72,6 +72,7 @@ class UserTests : DatabaseTest()
         } andCheckArray {
             Assertions.assertThat(it).hasSize(1)
             Assertions.assertThat((it[0] as JsonObject)["username"]).isEqualTo("reportreaduser")
+            Assertions.assertThat((it[0] as JsonObject)["roles"]).isNotNull()
         }
     }
 


### PR DESCRIPTION
So the client can distinguish a global report reader from a local one