### PR TITLE
i1601 - only validate scope id as modelling group id if that is the scope prefix

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
@@ -76,7 +76,7 @@ class JooqUserRepository(dsl: DSLContext) : JooqRepository(dsl), UserRepository
         val roleId = dsl.getRole(role.name, role.scope.databaseScopePrefix)
                 ?: throw UnknownRoleException(role.name, role.scope.databaseScopePrefix.toString())
 
-        if (role.scope.databaseScopeId.isNotEmpty())
+        if (role.scope.databaseScopePrefix == "modelling-group" && role.scope.databaseScopeId.isNotEmpty())
         {
             dsl.select(MODELLING_GROUP.ID)
                     .from(MODELLING_GROUP)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
@@ -76,7 +76,7 @@ class JooqUserRepository(dsl: DSLContext) : JooqRepository(dsl), UserRepository
         val roleId = dsl.getRole(role.name, role.scope.databaseScopePrefix)
                 ?: throw UnknownRoleException(role.name, role.scope.databaseScopePrefix.toString())
 
-        if (role.scope.databaseScopePrefix == "modelling-group" && role.scope.databaseScopeId.isNotEmpty())
+        if (role.scope.databaseScopePrefix == "modelling-group")
         {
             dsl.select(MODELLING_GROUP.ID)
                     .from(MODELLING_GROUP)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/UserTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/UserTests.kt
@@ -20,7 +20,10 @@ import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.models.AssociateUser
 import org.vaccineimpact.api.models.Scope
 import org.vaccineimpact.api.models.User
-import org.vaccineimpact.api.models.permissions.*
+import org.vaccineimpact.api.models.permissions.AssociateRole
+import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.api.models.permissions.ReifiedRole
+import org.vaccineimpact.api.models.permissions.RoleAssignment
 import org.vaccineimpact.api.security.*
 import java.time.Instant
 
@@ -96,6 +99,29 @@ class UserTests : RepositoryTests<UserRepository>()
         }
     }
 
+    @Test
+    fun `cant add role scoped to modelling group for non-existent group`()
+    {
+        withDatabase { db ->
+            db.addUserWithRoles(username)
+        }
+        withRepo { repo ->
+            assertThatThrownBy {
+                repo.modifyUserRole(username, AssociateRole("add", "member", "modelling-group", "fakegroup"))
+            }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining("modelling-group")
+        }
+    }
+
+    @Test
+    fun `can add role scoped to report`()
+    {
+        withDatabase { db ->
+            db.addUserWithRoles(username)
+        }
+        withRepo { repo ->
+            repo.modifyUserRole(username, AssociateRole("add", "reports-reader", "report", "anyreportname"))
+        }
+    }
 
     @Test
     fun `adds roles to user group`()


### PR DESCRIPTION
Bug fix - when adding a role, don't attempt to validate a scope id as a modelling group id unless `modelling-group` is the scope prefix.