### PR TITLE
trim single quotes from all cell values

### DIFF
--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
@@ -7,7 +7,6 @@ import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import java.io.Reader
 import java.io.StringReader
-import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KType
@@ -25,6 +24,9 @@ open class DataTableDeserializer<out T>(
     private val headerCount = headerDefinitions.size
     protected open val extraHeadersAllowed = false
 
+    private fun shouldTrim(char: Char): Boolean
+            = char.isWhitespace() || char == '\''
+
     fun deserialize(stream: Reader): Sequence<T>
     {
         val reader = CSVReader(stream)
@@ -36,7 +38,7 @@ open class DataTableDeserializer<out T>(
             throw ValidationException(listOf(ErrorInfo("csv-empty", "CSV was empty - no rows or headers were found")))
         }
 
-        val actualHeaderNames = headerRow.map({it.trim().trim('\'')}).toList()
+        val actualHeaderNames = headerRow.map({ it.trim(::shouldTrim) }).toList()
         checkHeaders(actualHeaderNames)
         val actualHeaders = getActualHeaderDefinitions(actualHeaderNames)
 
@@ -76,7 +78,7 @@ open class DataTableDeserializer<out T>(
                             row: Int, column: String,
                             problems: MutableList<ErrorInfo>): Any?
     {
-        val trimmed = raw.trim().trim('\'')
+        val trimmed = raw.trim(::shouldTrim)
         checkValueIsPresentIfRequired(trimmed, targetType, row, column, problems)
 
         return try

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
@@ -7,6 +7,7 @@ import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import java.io.Reader
 import java.io.StringReader
+import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KType
@@ -35,7 +36,7 @@ open class DataTableDeserializer<out T>(
             throw ValidationException(listOf(ErrorInfo("csv-empty", "CSV was empty - no rows or headers were found")))
         }
 
-        val actualHeaderNames = headerRow.toList()
+        val actualHeaderNames = headerRow.map({it.trim().trim('\'')}).toList()
         checkHeaders(actualHeaderNames)
         val actualHeaders = getActualHeaderDefinitions(actualHeaderNames)
 
@@ -75,7 +76,7 @@ open class DataTableDeserializer<out T>(
                             row: Int, column: String,
                             problems: MutableList<ErrorInfo>): Any?
     {
-        val trimmed = raw.trim()
+        val trimmed = raw.trim().trim('\'')
         checkValueIsPresentIfRequired(trimmed, targetType, row, column, problems)
 
         return try

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DataTableTests.kt
@@ -91,12 +91,40 @@ free text,in-preparation""")
 
 
     @Test
-    fun `can deserialize CSV`()
+    fun `can deserialize CSV with single quote delimiter`()
+    {
+        val csv = """
+            'text','int','dec'
+            'joe',1,6.53
+            'bob',2,2.0"""
+        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
+        assertThat(rows).containsExactlyElementsOf(listOf(
+                MixedTypes("joe", 1, 6.53F),
+                MixedTypes("bob", 2,2.0F)
+        ))
+    }
+
+    @Test
+    fun `can deserialize CSV with double quote delimiter`()
+    {
+        val csv = """
+            "text","int","dec"
+            "joe",1,6.53
+            "bob",2,2.0"""
+        val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
+        assertThat(rows).containsExactlyElementsOf(listOf(
+                MixedTypes("joe", 1, 6.53F),
+                MixedTypes("bob", 2,2.0F)
+        ))
+    }
+
+    @Test
+    fun `can deserialize CSV with no quote delimiter`()
     {
         val csv = """
             text,int,dec
-            "joe",1,6.53
-            "bob",2,2.0"""
+            joe,1,6.53
+            bob,2,2.0"""
         val rows = DataTableDeserializer.deserialize(csv, MixedTypes::class, MontaguSerializer.instance).toList()
         assertThat(rows).containsExactlyElementsOf(listOf(
                 MixedTypes("joe", 1, 6.53F),
@@ -190,7 +218,35 @@ free text,in-preparation""")
     }
 
     @Test
-    fun `can deserialize CSV with flexible headers`()
+    fun `can deserialize CSV with single quoted flexible headers`()
+    {
+        val csv = """
+            'a','b','x','y','z'
+            1,"joe",1,2,3
+            2,"bob",4,5,6"""
+        val rows = DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
+        assertThat(rows).containsExactlyElementsOf(listOf(
+                Flexible(1, "joe", mapOf("x" to 1, "y" to 2, "z" to 3)),
+                Flexible(2, "bob", mapOf("x" to 4, "y" to 5, "z" to 6))
+        ))
+    }
+
+    @Test
+    fun `can deserialize CSV with double quoted flexible headers`()
+    {
+        val csv = """
+            "a","b","x","y","z"
+            1,"joe",1,2,3
+            2,"bob",4,5,6"""
+        val rows = DataTableDeserializer.deserialize(csv, Flexible::class, MontaguSerializer.instance).toList()
+        assertThat(rows).containsExactlyElementsOf(listOf(
+                Flexible(1, "joe", mapOf("x" to 1, "y" to 2, "z" to 3)),
+                Flexible(2, "bob", mapOf("x" to 4, "y" to 5, "z" to 6))
+        ))
+    }
+
+    @Test
+    fun `can deserialize CSV with no quoted flexible headers`()
     {
         val csv = """
             a,b,x,y,z

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DeserializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DeserializerTests.kt
@@ -39,4 +39,5 @@ class DeserializerTests : MontaguTests()
         assertThatThrownBy { deserializer.parseEnum<TouchstoneStatus>("bad-value") }
                 .isInstanceOf(UnknownEnumValue::class.java)
     }
+
 }

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/SerializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/SerializerTests.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 import java.time.Month
 import java.time.ZoneId
 
-class SerializerTests : MontaguTests()
+class   SerializerTests : MontaguTests()
 {
     private val serializer = MontaguSerializer.instance
 


### PR DESCRIPTION
The `opencsv` parser only accepts a single character as a cell separator, there's no way to specify a regex. So this change trims any single quotes around the parsed cell values.