### PR TITLE
I1838 - Endpoint to get responsibilities in a touchstone

### DIFF
--- a/docs/schemas/ResponsibilitySet.schema.json
+++ b/docs/schemas/ResponsibilitySet.schema.json
@@ -4,12 +4,13 @@
     "properties": {
         "touchstone_version": { "$ref": "StandardIdentifier.schema.json" },
         "status": { "$ref": "ResponsibilitySetStatus.schema.json" },
+        "modelling_group_id": { "type" : "string" },
         "problems": { "type": "string" },
-        "responsibilities": { 
+        "responsibilities": {
             "type": "array",
             "items": { "$ref": "Responsibility.schema.json" }
          }
     },
     "additionalProperties": false,
-    "required": [ "touchstone_version", "status", "problems", "responsibilities" ]
+    "required": [ "touchstone_version", "status", "responsibilities" ]
 }

--- a/docs/schemas/ResponsibilitySets.schema.json
+++ b/docs/schemas/ResponsibilitySets.schema.json
@@ -1,0 +1,5 @@
+{
+    "id": "ResponsibilitySets",
+    "type": "array",
+    "items": { "$ref": "ResponsibilitySet.schema.json" }
+}

--- a/docs/spec/Touchstones.md
+++ b/docs/spec/Touchstones.md
@@ -23,7 +23,71 @@ Schema: [`Touchstones.schema.json`](../schemas/Touchstones.schema.json)
             "status": "open"
         }
     ]
+    
 
+## GET /touchstones/{touchstone-id}/responsibilities/
+Returns all responsibility sets associated with the touchstone.
+
+Required permissions: `touchstones.read`, `responsibilities.read`
+
+Additionally, to view responsibilities for an in-preparation touchstone, `touchstones.prepare` is required.
+
+Schema: [`ResponsibilitySets.schema.json`](../schemas/ResponsibilitySets.schema.json)
+
+### Example
+    [{
+        "touchstone_version": "2017-op-1",
+        "status": "incomplete",
+        "modelling_group_id": "IC-Garske",
+        "responsibilities": [
+            {
+                "scenario": {
+                    "id": "menA-novacc",
+                    "touchstones": [ "2016-op-1", "2017-wuenic-1", "2017-op-1" ],
+                    "description": "Menigitis A, No vaccination",
+                    "disease": "MenA"
+                },
+                "countries": ["AFG", "AGO"],
+                "years": {
+                    "start": 1900,
+                    "end": 2050
+                },
+                "status": "empty",
+                "problems": [ "No burden estimates have been uploaded" ],
+                "current_estimate_set": null
+            },        
+            {
+                "scenario": {
+                    "id": "yf-campaign-reactive-nogavi",
+                    "touchstones": [ "2017-wuenic-1", "2017-op-1" ],
+                    "description": "Yellow Fever, Reactive campaign, SDF coverage without GAVI support",
+                    "disease": "YF"
+                },
+                "countries": ["AFG", "AGO"],
+                "years": {
+                    "start": 1900,
+                    "end": 2050
+                },
+                "status": "invalid",
+                "problems": [
+                    "Missing data for these countries: AFG",
+                    "There are negative burden numbers for some outcomes."
+                ],
+                "current_estimate_set": {                    
+                    "id": 1,                  
+                    "uploaded_on": "2017-10-06T11:18:06Z",
+                    "uploaded_by": "tini.garske",
+                    "type": {
+                        "type": "central-averaged",
+                        "details": "Mean over all stochastic runs"
+                    },
+                    "problems": [],
+                    "status": "complete"
+                }
+            }
+        ]
+    }]
+    
 ## GET /touchstones/{touchstone-id}/scenarios/
 Returns all scenarios associated with the touchstone.
 

--- a/docs/spec/Touchstones.md
+++ b/docs/spec/Touchstones.md
@@ -28,7 +28,7 @@ Schema: [`Touchstones.schema.json`](../schemas/Touchstones.schema.json)
 ## GET /touchstones/{touchstone-id}/responsibilities/
 Returns all responsibility sets associated with the touchstone.
 
-Required permissions: `touchstones.read`, `responsibilities.read`
+Required permissions: `touchstones.read`, `responsibilities.read`, `scenarios.read`.
 
 Additionally, to view responsibilities for an in-preparation touchstone, `touchstones.prepare` is required.
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/ResponsibilityRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/ResponsibilityRouteConfig.kt
@@ -4,12 +4,12 @@ import org.vaccineimpact.api.app.app_start.Endpoint
 import org.vaccineimpact.api.app.app_start.EndpointDefinition
 import org.vaccineimpact.api.app.app_start.json
 import org.vaccineimpact.api.app.app_start.secure
-import org.vaccineimpact.api.app.controllers.ResponsibilityController
+import org.vaccineimpact.api.app.controllers.GroupResponsibilityController
 
 object ResponsibilityRouteConfig : RouteConfig
 {
     private val baseUrl = "/modelling-groups/:group-id/responsibilities"
-    private val controller = ResponsibilityController::class
+    private val controller = GroupResponsibilityController::class
 
     private val groupScope = "modelling-group:<group-id>"
     private val permissions = setOf(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
@@ -13,11 +13,16 @@ object TouchstoneRouteConfig : RouteConfig
     private val permissions = setOf("*/touchstones.read")
     private val scenarioPermissions = permissions + setOf("*/scenarios.read", "*/coverage.read")
     private val demographicPermissions = permissions + setOf("*/demographics.read")
+    private val responsibilityPermissions = scenarioPermissions + setOf("*/responsibilities.read")
 
     override val endpoints: List<EndpointDefinition> = listOf(
             Endpoint(baseUrl, controller, "getTouchstones")
                     .json()
                     .secure(permissions),
+
+            Endpoint("$baseUrl:touchstone-version-id/responsibilities/", controller, "getResponsibilities")
+                    .json()
+                    .secure(responsibilityPermissions),
 
             Endpoint("$baseUrl:touchstone-version-id/scenarios/", controller, "getScenarios")
                     .json()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/TouchstoneRouteConfig.kt
@@ -13,7 +13,7 @@ object TouchstoneRouteConfig : RouteConfig
     private val permissions = setOf("*/touchstones.read")
     private val scenarioPermissions = permissions + setOf("*/scenarios.read", "*/coverage.read")
     private val demographicPermissions = permissions + setOf("*/demographics.read")
-    private val responsibilityPermissions = scenarioPermissions + setOf("*/responsibilities.read")
+    private val responsibilityPermissions = permissions + setOf("*/scenarios.read", "*/responsibilities.read")
 
     override val endpoints: List<EndpointDefinition> = listOf(
             Endpoint(baseUrl, controller, "getTouchstones")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupResponsibilityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupResponsibilityController.kt
@@ -13,7 +13,7 @@ import org.vaccineimpact.api.models.Responsibilities
 import org.vaccineimpact.api.models.ResponsibilityAndTouchstone
 import org.vaccineimpact.api.models.TouchstoneVersion
 
-class ResponsibilityController(
+class GroupResponsibilityController(
         context: ActionContext,
         private val modellingGroupRepo: ModellingGroupRepository,
         private val responsibilitiesRepo: ResponsibilitiesRepository

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ResponsibilityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ResponsibilityController.kt
@@ -37,6 +37,7 @@ class ResponsibilityController(
         val touchstoneVersionId = context.params(":touchstone-version-id")
         val filterParameters = ScenarioFilterParameters.fromContext(context)
 
+        modellingGroupRepo.getModellingGroup(groupId)
         val data = responsibilitiesRepo
                 .getResponsibilitiesForGroupAndTouchstone(groupId, touchstoneVersionId, filterParameters)
         context.checkIsAllowedToSeeTouchstone(touchstoneVersionId, data.touchstoneStatus)
@@ -46,6 +47,7 @@ class ResponsibilityController(
     fun getResponsibility(): ResponsibilityAndTouchstone
     {
         val path = ResponsibilityPath(context)
+        modellingGroupRepo.getModellingGroup(path.groupId)
         val data = responsibilitiesRepo.getResponsibility(path.groupId, path.touchstoneVersionId, path.scenarioId)
         context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, data.touchstoneVersion.status)
         return data

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ResponsibilityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ResponsibilityController.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
 import org.vaccineimpact.api.app.security.isAllowedToSeeTouchstone
 import org.vaccineimpact.api.models.Responsibilities
@@ -14,17 +15,18 @@ import org.vaccineimpact.api.models.TouchstoneVersion
 
 class ResponsibilityController(
         context: ActionContext,
-        private val repo: ModellingGroupRepository
-) : Controller(context)
+        private val modellingGroupRepo: ModellingGroupRepository,
+        private val responsibilitiesRepo: ResponsibilitiesRepository
+        ) : Controller(context)
 {
     constructor(context: ActionContext, repositories: Repositories)
-            : this(context, repositories.modellingGroup)
+            : this(context, repositories.modellingGroup, repositories.responsibilities)
 
     fun getResponsibleTouchstones(): List<TouchstoneVersion>
     {
         val groupId = groupId(context)
 
-        var touchstones = repo.getTouchstonesByGroupId(groupId)
+        var touchstones = modellingGroupRepo.getTouchstonesByGroupId(groupId)
         touchstones = touchstones.filter { context.isAllowedToSeeTouchstone(it.status) }
         return touchstones
     }
@@ -35,7 +37,8 @@ class ResponsibilityController(
         val touchstoneVersionId = context.params(":touchstone-version-id")
         val filterParameters = ScenarioFilterParameters.fromContext(context)
 
-        val data = repo.getResponsibilities(groupId, touchstoneVersionId, filterParameters)
+        val data = responsibilitiesRepo
+                .getResponsibilitiesForGroupAndTouchstone(groupId, touchstoneVersionId, filterParameters)
         context.checkIsAllowedToSeeTouchstone(touchstoneVersionId, data.touchstoneStatus)
         return data.responsibilities
     }
@@ -43,7 +46,7 @@ class ResponsibilityController(
     fun getResponsibility(): ResponsibilityAndTouchstone
     {
         val path = ResponsibilityPath(context)
-        val data = repo.getResponsibility(path.groupId, path.touchstoneVersionId, path.scenarioId)
+        val data = responsibilitiesRepo.getResponsibility(path.groupId, path.touchstoneVersionId, path.scenarioId)
         context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, data.touchstoneVersion.status)
         return data
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
@@ -1,11 +1,13 @@
 package org.vaccineimpact.api.app.repositories
 
+import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.SplitData
 
 interface ModellingGroupRepository : Repository
 {
     fun getModellingGroups(): Iterable<ModellingGroup>
+    @Throws(UnknownObjectError::class)
     fun getModellingGroup(id: String): ModellingGroup
     fun getModellingGroupDetails(groupId: String): ModellingGroupDetails
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.api.app.repositories
 
-import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.SplitData
 
@@ -9,11 +8,6 @@ interface ModellingGroupRepository : Repository
     fun getModellingGroups(): Iterable<ModellingGroup>
     fun getModellingGroup(id: String): ModellingGroup
     fun getModellingGroupDetails(groupId: String): ModellingGroupDetails
-
-    fun getResponsibilities(groupId: String, touchstoneVersionId: String,
-                            scenarioFilterParameters: ScenarioFilterParameters): ResponsibilitiesAndTouchstoneStatus
-
-    fun getResponsibility(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityAndTouchstone
 
     fun getTouchstonesByGroupId(groupId: String): List<TouchstoneVersion>
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repositories.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/Repositories.kt
@@ -43,8 +43,11 @@ open class Repositories(val dsl: DSLContext)
     open val scenario: ScenarioRepository by lazy {
         JooqScenarioRepository(dsl)
     }
+    open val responsibilities: ResponsibilitiesRepository by lazy {
+        JooqResponsibilitiesRepository(dsl, scenario, touchstone)
+    }
     open val modellingGroup: ModellingGroupRepository by lazy {
-        JooqModellingGroupRepository(dsl, touchstone, scenario)
+        JooqModellingGroupRepository(dsl, responsibilities, touchstone)
     }
     open val burdenEstimates: BurdenEstimateRepository by lazy {
         JooqBurdenEstimateRepository(dsl, scenario, touchstone, modellingGroup)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ResponsibilitiesRepository.kt
@@ -1,0 +1,16 @@
+package org.vaccineimpact.api.app.repositories
+
+import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
+import org.vaccineimpact.api.db.tables.records.ResponsibilitySetRecord
+import org.vaccineimpact.api.models.*
+
+interface ResponsibilitiesRepository: Repository {
+    fun getResponsibilitiesForTouchstone(touchstoneVersionId: String): List<ResponsibilitySet>
+    fun getResponsibilities(responsibilitySet: ResponsibilitySetRecord?,
+                            scenarioFilterParameters: ScenarioFilterParameters,
+                            touchstoneVersionId: String): Responsibilities
+    fun getResponsibility(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityAndTouchstone
+    fun getResponsibilitiesForGroupAndTouchstone(groupId: String, touchstoneVersionId: String,
+                                                 scenarioFilterParameters: ScenarioFilterParameters): ResponsibilitiesAndTouchstoneStatus
+    fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ResponsibilitiesRepository.kt
@@ -12,5 +12,4 @@ interface ResponsibilitiesRepository: Repository {
     fun getResponsibility(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityAndTouchstone
     fun getResponsibilitiesForGroupAndTouchstone(groupId: String, touchstoneVersionId: String,
                                                  scenarioFilterParameters: ScenarioFilterParameters): ResponsibilitiesAndTouchstoneStatus
-    fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -5,6 +5,7 @@ import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.filters.whereMatchesFilter
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.repositories.jooq.mapping.BurdenMappingHelper
@@ -19,9 +20,8 @@ import org.vaccineimpact.api.serialization.SplitData
 
 class JooqModellingGroupRepository(
         dsl: DSLContext,
-        private val touchstoneRepository: TouchstoneRepository,
-        private val scenarioRepository: ScenarioRepository,
-        private val mapper: BurdenMappingHelper = BurdenMappingHelper()
+        private val responsibilitiesRepository: ResponsibilitiesRepository,
+        private val touchstoneRepository: TouchstoneRepository
 ) : JooqRepository(dsl), ModellingGroupRepository
 {
 
@@ -89,40 +89,11 @@ class JooqModellingGroupRepository(
         return ModellingGroupDetails(group.id, group.description, models, users)
     }
 
-    override fun getResponsibilities(groupId: String, touchstoneVersionId: String,
-                                     scenarioFilterParameters: ScenarioFilterParameters): ResponsibilitiesAndTouchstoneStatus
-    {
-        getModellingGroup(groupId)
-        val touchstone = getTouchstone(touchstoneVersionId)
-        val responsibilitySet = getResponsibilitySet(groupId, touchstoneVersionId)
-        val responsibilities = getResponsibilities(responsibilitySet, scenarioFilterParameters, touchstoneVersionId)
-        return ResponsibilitiesAndTouchstoneStatus(responsibilities, touchstone.status)
-    }
-
-    override fun getResponsibility(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityAndTouchstone
-    {
-        getModellingGroup(groupId)
-        val touchstone = getTouchstone(touchstoneVersionId)
-        val responsibilitySet = getResponsibilitySet(groupId, touchstoneVersionId)
-        if (responsibilitySet != null)
-        {
-            val responsibility = getResponsibilitiesInResponsibilitySet(
-                    responsibilitySet,
-                    { this.and(SCENARIO_DESCRIPTION.ID.eq(scenarioId)) }
-            ).singleOrNull() ?: throw UnknownObjectError(scenarioId, "responsibility")
-            return ResponsibilityAndTouchstone(touchstone, responsibility)
-        }
-        else
-        {
-            throw UnknownObjectError(scenarioId, "responsibility")
-        }
-    }
-
     override fun getCoverageSets(groupId: String, touchstoneVersionId: String, scenarioId: String): ScenarioTouchstoneAndCoverageSets
     {
         // We don't use the returned responsibility, but by using this method we check that the group exists
         // and that the group is responsible for the given scenario in the given touchstoneVersion
-        val responsibilityAndTouchstone = getResponsibility(groupId, touchstoneVersionId, scenarioId)
+        val responsibilityAndTouchstone = responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
         val scenario = touchstoneRepository.getScenario(touchstoneVersionId, scenarioId)
         return ScenarioTouchstoneAndCoverageSets(
                 responsibilityAndTouchstone.touchstoneVersion,
@@ -132,7 +103,7 @@ class JooqModellingGroupRepository(
 
     override fun getCoverageData(groupId: String, touchstoneVersionId: String, scenarioId: String): SplitData<ScenarioTouchstoneAndCoverageSets, LongCoverageRow>
     {
-        val responsibilityAndTouchstone = getResponsibility(groupId, touchstoneVersionId, scenarioId)
+        val responsibilityAndTouchstone = responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
         val scenarioAndData = touchstoneRepository.getScenarioAndCoverageData(touchstoneVersionId, scenarioId)
         return SplitData(ScenarioTouchstoneAndCoverageSets(
                 responsibilityAndTouchstone.touchstoneVersion,
@@ -159,121 +130,6 @@ class JooqModellingGroupRepository(
         return query.fetch().map { touchstoneRepository.mapTouchstone(it) }
     }
 
-    private fun convertScenarioToResponsibility(scenario: Scenario, responsibilityId: Int): Responsibility
-    {
-        val burdenEstimateSet = getCurrentBurdenEstimate(responsibilityId)
-        val problems: MutableList<String> = mutableListOf()
-        val status = if (burdenEstimateSet == null)
-        {
-            ResponsibilityStatus.EMPTY
-        }
-        else
-        {
-            if (burdenEstimateSet.problems.any())
-            {
-                problems.addAll(burdenEstimateSet.problems)
-                ResponsibilityStatus.INVALID
-            }
-            else
-            {
-                ResponsibilityStatus.VALID
-            }
-        }
-        return Responsibility(scenario, status, problems, burdenEstimateSet)
-    }
-
-    private fun getCurrentBurdenEstimate(responsibilityId: Int): BurdenEstimateSet?
-    {
-        val table = BURDEN_ESTIMATE_SET
-        val records = dsl.select(BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM)
-                .select(
-                        table.UPLOADED_ON,
-                        table.UPLOADED_BY,
-                        table.SET_TYPE,
-                        table.SET_TYPE_DETAILS,
-                        table.STATUS,
-                        table.ID
-                )
-                .fromJoinPath(table, BURDEN_ESTIMATE_SET_PROBLEM, joinType = JoinType.LEFT_OUTER_JOIN)
-                .join(RESPONSIBILITY)
-                .on(RESPONSIBILITY.CURRENT_BURDEN_ESTIMATE_SET.eq(BURDEN_ESTIMATE_SET.ID))
-                .where(RESPONSIBILITY.ID.eq(responsibilityId))
-                .fetch()
-
-        return mapBurdenEstimateSet(records)
-    }
-
-    private fun mapBurdenEstimateSet(input: List<Record>): BurdenEstimateSet?
-    {
-        if (!input.any())
-        {
-            return null
-        }
-
-        val first = input.first()
-        val uploadedOn = first[BURDEN_ESTIMATE_SET.UPLOADED_ON].toInstant()
-        return BurdenEstimateSet(
-                id = first[BURDEN_ESTIMATE_SET.ID],
-                uploadedBy = first[BURDEN_ESTIMATE_SET.UPLOADED_BY],
-                uploadedOn = uploadedOn,
-                type = mapper.mapBurdenEstimateSetType(first),
-                status = mapper.mapEnum(first[BURDEN_ESTIMATE_SET.STATUS]),
-                problems = input.filter { it[BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] != null }
-                        .map { it[BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] }
-        )
-    }
-
-    private fun getResponsibilities(responsibilitySet: ResponsibilitySetRecord?,
-                                    scenarioFilterParameters: ScenarioFilterParameters,
-                                    touchstoneVersionId: String): Responsibilities
-    {
-        if (responsibilitySet != null)
-        {
-            val responsibilities = getResponsibilitiesInResponsibilitySet(
-                    responsibilitySet,
-                    { this.whereMatchesFilter(JooqScenarioFilter(), scenarioFilterParameters) }
-            )
-            val status = mapper.mapEnum<ResponsibilitySetStatus>(responsibilitySet.status)
-            return Responsibilities(touchstoneVersionId, "", status, responsibilities)
-        }
-        else
-        {
-            return Responsibilities(touchstoneVersionId, "", ResponsibilitySetStatus.NOT_APPLICABLE, emptyList())
-        }
-    }
-
-    private fun getResponsibilitiesInResponsibilitySet(
-            responsibilitySet: ResponsibilitySetRecord,
-            applyWhereFilter: SelectConditionStep<Record2<String, Int>>.() -> SelectConditionStep<Record2<String, Int>>)
-            : List<Responsibility>
-    {
-        val records = dsl
-                .select(SCENARIO_DESCRIPTION.ID, RESPONSIBILITY.ID)
-                .fromJoinPath(RESPONSIBILITY_SET, RESPONSIBILITY, SCENARIO, SCENARIO_DESCRIPTION)
-                .where(RESPONSIBILITY.RESPONSIBILITY_SET.eq(responsibilitySet.id))
-                // TODO remove this once VIMC-1240 is done
-                // this check is needed for the situation where a group has a responsibility set with
-                // multiple diseases, but we want to 'close' some and not others for a touchstoneVersion
-                // it will be obsolete when we refactor responsibility sets to be single disease only
-                .and(RESPONSIBILITY.IS_OPEN)
-                .applyWhereFilter()
-                .fetch()
-                .intoMap(SCENARIO_DESCRIPTION.ID)
-
-        val scenarioIds = records.keys
-        val scenarios = scenarioRepository.getScenarios(scenarioIds)
-        return scenarios.map {
-            convertScenarioToResponsibility(it, records[it.id]!![RESPONSIBILITY.ID])
-        }
-    }
-
-    private fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
-    {
-        return dsl.fetchAny(RESPONSIBILITY_SET,
-                RESPONSIBILITY_SET.MODELLING_GROUP.eq(groupId).and(RESPONSIBILITY_SET.TOUCHSTONE.eq(touchstoneVersionId)))
-    }
-
     private fun mapModellingGroup(x: ModellingGroupRecord) = ModellingGroup(x.id, x.description)
 
-    private fun getTouchstone(touchstoneVersionId: String) = touchstoneRepository.touchstones.get(touchstoneVersionId)
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -91,6 +91,7 @@ class JooqModellingGroupRepository(
 
     override fun getCoverageSets(groupId: String, touchstoneVersionId: String, scenarioId: String): ScenarioTouchstoneAndCoverageSets
     {
+        getModellingGroup(groupId)
         // We don't use the returned responsibility, but by using this method we check that the group exists
         // and that the group is responsible for the given scenario in the given touchstoneVersion
         val responsibilityAndTouchstone = responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
@@ -103,6 +104,7 @@ class JooqModellingGroupRepository(
 
     override fun getCoverageData(groupId: String, touchstoneVersionId: String, scenarioId: String): SplitData<ScenarioTouchstoneAndCoverageSets, LongCoverageRow>
     {
+        getModellingGroup(groupId)
         val responsibilityAndTouchstone = responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
         val scenarioAndData = touchstoneRepository.getScenarioAndCoverageData(touchstoneVersionId, scenarioId)
         return SplitData(ScenarioTouchstoneAndCoverageSets(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
@@ -150,7 +150,7 @@ class JooqResponsibilitiesRepository(
             val responsibilities = getResponsibilitiesInResponsibilitySet(id,
                     { this })
 
-            ResponsibilitySet(it[Tables.MODELLING_GROUP.ID],
+            ResponsibilitySet(it[Tables.MODELLING_GROUP.ID], touchstoneVersionId,
                     mapper.mapEnum(it[Tables.RESPONSIBILITY_SET.STATUS]), responsibilities)
         })
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
@@ -1,0 +1,185 @@
+package org.vaccineimpact.api.app.repositories.jooq
+
+import org.jooq.*
+import org.vaccineimpact.api.app.errors.UnknownObjectError
+import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
+import org.vaccineimpact.api.app.filters.whereMatchesFilter
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
+import org.vaccineimpact.api.app.repositories.ScenarioRepository
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.app.repositories.jooq.mapping.BurdenMappingHelper
+import org.vaccineimpact.api.db.Tables
+import org.vaccineimpact.api.db.fromJoinPath
+import org.vaccineimpact.api.db.tables.records.ResponsibilitySetRecord
+import org.vaccineimpact.api.models.*
+
+class JooqResponsibilitiesRepository(
+        dsl: DSLContext,
+        private val scenarioRepository: ScenarioRepository,
+        private val touchstoneRepository: TouchstoneRepository,
+        private val mapper: BurdenMappingHelper = BurdenMappingHelper()
+) : JooqRepository(dsl), ResponsibilitiesRepository
+{
+
+    private fun convertScenarioToResponsibility(scenario: Scenario, responsibilityId: Int): Responsibility
+    {
+        val burdenEstimateSet = getCurrentBurdenEstimate(responsibilityId)
+        val problems: MutableList<String> = mutableListOf()
+        val status = if (burdenEstimateSet == null)
+        {
+            ResponsibilityStatus.EMPTY
+        }
+        else
+        {
+            if (burdenEstimateSet.problems.any())
+            {
+                problems.addAll(burdenEstimateSet.problems)
+                ResponsibilityStatus.INVALID
+            }
+            else
+            {
+                ResponsibilityStatus.VALID
+            }
+        }
+        return Responsibility(scenario, status, problems, burdenEstimateSet)
+    }
+
+    private fun getCurrentBurdenEstimate(responsibilityId: Int): BurdenEstimateSet?
+    {
+        val table = Tables.BURDEN_ESTIMATE_SET
+        val records = dsl.select(Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM)
+                .select(
+                        table.UPLOADED_ON,
+                        table.UPLOADED_BY,
+                        table.SET_TYPE,
+                        table.SET_TYPE_DETAILS,
+                        table.STATUS,
+                        table.ID
+                )
+                .fromJoinPath(table, Tables.BURDEN_ESTIMATE_SET_PROBLEM, joinType = JoinType.LEFT_OUTER_JOIN)
+                .join(Tables.RESPONSIBILITY)
+                .on(Tables.RESPONSIBILITY.CURRENT_BURDEN_ESTIMATE_SET.eq(Tables.BURDEN_ESTIMATE_SET.ID))
+                .where(Tables.RESPONSIBILITY.ID.eq(responsibilityId))
+                .fetch()
+
+        return mapBurdenEstimateSet(records)
+    }
+
+
+    private fun mapBurdenEstimateSet(input: List<Record>): BurdenEstimateSet?
+    {
+        if (!input.any())
+        {
+            return null
+        }
+
+        val first = input.first()
+        val uploadedOn = first[Tables.BURDEN_ESTIMATE_SET.UPLOADED_ON].toInstant()
+        return BurdenEstimateSet(
+                id = first[Tables.BURDEN_ESTIMATE_SET.ID],
+                uploadedBy = first[Tables.BURDEN_ESTIMATE_SET.UPLOADED_BY],
+                uploadedOn = uploadedOn,
+                type = mapper.mapBurdenEstimateSetType(first),
+                status = mapper.mapEnum(first[Tables.BURDEN_ESTIMATE_SET.STATUS]),
+                problems = input.filter { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] != null }
+                        .map { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] }
+        )
+    }
+
+    override fun getResponsibilities(responsibilitySet: ResponsibilitySetRecord?,
+                                     scenarioFilterParameters: ScenarioFilterParameters,
+                                     touchstoneVersionId: String): Responsibilities
+    {
+        if (responsibilitySet != null)
+        {
+            val responsibilities = getResponsibilitiesInResponsibilitySet(
+                    responsibilitySet.id,
+                    { this.whereMatchesFilter(JooqScenarioFilter(), scenarioFilterParameters) }
+            )
+            val status = mapper.mapEnum<ResponsibilitySetStatus>(responsibilitySet.status)
+            return Responsibilities(touchstoneVersionId, "", status, responsibilities)
+        }
+        else
+        {
+            return Responsibilities(touchstoneVersionId, "", ResponsibilitySetStatus.NOT_APPLICABLE, emptyList())
+        }
+    }
+
+    override fun getResponsibility(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityAndTouchstone
+    {
+        val touchstone = getTouchstone(touchstoneVersionId)
+        val responsibilitySet = getResponsibilitySet(groupId, touchstoneVersionId)
+        if (responsibilitySet != null)
+        {
+            val responsibility = getResponsibilitiesInResponsibilitySet(
+                    responsibilitySet.id,
+                    { this.and(Tables.SCENARIO_DESCRIPTION.ID.eq(scenarioId)) }
+            ).singleOrNull() ?: throw UnknownObjectError(scenarioId, "responsibility")
+            return ResponsibilityAndTouchstone(touchstone, responsibility)
+        }
+        else
+        {
+            throw UnknownObjectError(scenarioId, "responsibility")
+        }
+    }
+
+    override fun getResponsibilitiesForGroupAndTouchstone(groupId: String, touchstoneVersionId: String,
+                                                          scenarioFilterParameters: ScenarioFilterParameters): ResponsibilitiesAndTouchstoneStatus
+    {
+        val touchstone = getTouchstone(touchstoneVersionId)
+        val responsibilitySet = getResponsibilitySet(groupId, touchstoneVersionId)
+        val responsibilities = getResponsibilities(responsibilitySet, scenarioFilterParameters, touchstoneVersionId)
+        return ResponsibilitiesAndTouchstoneStatus(responsibilities, touchstone.status)
+    }
+
+    override fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
+    {
+        return dsl.fetchAny(Tables.RESPONSIBILITY_SET,
+                Tables.RESPONSIBILITY_SET.MODELLING_GROUP.eq(groupId).and(Tables.RESPONSIBILITY_SET.TOUCHSTONE.eq(touchstoneVersionId)))
+    }
+
+    override fun getResponsibilitiesForTouchstone(touchstoneVersionId: String): List<ResponsibilitySet>
+    {
+        val results = this.dsl.select(Tables.RESPONSIBILITY_SET.ID, Tables.RESPONSIBILITY_SET.STATUS, Tables.MODELLING_GROUP.ID)
+                .fromJoinPath(Tables.RESPONSIBILITY_SET, Tables.MODELLING_GROUP)
+                .where(Tables.RESPONSIBILITY_SET.TOUCHSTONE.eq(touchstoneVersionId))
+                .fetch()
+
+        return results.map({
+            val id = it[Tables.RESPONSIBILITY_SET.ID] as Int
+            val responsibilities = getResponsibilitiesInResponsibilitySet(id,
+                    { this })
+
+            ResponsibilitySet(it[Tables.MODELLING_GROUP.ID],
+                    mapper.mapEnum(it[Tables.RESPONSIBILITY_SET.STATUS]), responsibilities)
+        })
+    }
+
+    private fun getTouchstone(touchstoneVersionId: String) = touchstoneRepository.touchstones.get(touchstoneVersionId)
+
+    private fun getResponsibilitiesInResponsibilitySet(
+            responsibilitySetId: Int,
+            applyWhereFilter: SelectConditionStep<Record2<String, Int>>.() -> SelectConditionStep<Record2<String, Int>>)
+            : List<Responsibility>
+    {
+        val records = dsl
+                .select(Tables.SCENARIO_DESCRIPTION.ID, Tables.RESPONSIBILITY.ID)
+                .fromJoinPath(Tables.RESPONSIBILITY_SET, Tables.RESPONSIBILITY, Tables.SCENARIO, Tables.SCENARIO_DESCRIPTION)
+                .where(Tables.RESPONSIBILITY.RESPONSIBILITY_SET.eq(responsibilitySetId))
+                // TODO remove this once VIMC-1240 is done
+                // this check is needed for the situation where a group has a responsibility set with
+                // multiple diseases, but we want to 'close' some and not others for a touchstoneVersion
+                // it will be obsolete when we refactor responsibility sets to be single disease only
+                .and(Tables.RESPONSIBILITY.IS_OPEN)
+                .applyWhereFilter()
+                .fetch()
+                .intoMap(Tables.SCENARIO_DESCRIPTION.ID)
+
+        val scenarioIds = records.keys
+        val scenarios = scenarioRepository.getScenarios(scenarioIds)
+        return scenarios.map {
+            convertScenarioToResponsibility(it, records[it.id]!![Tables.RESPONSIBILITY.ID])
+        }
+    }
+
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
@@ -132,7 +132,7 @@ class JooqResponsibilitiesRepository(
         return ResponsibilitiesAndTouchstoneStatus(responsibilities, touchstone.status)
     }
 
-    override fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
+    private fun getResponsibilitySet(groupId: String, touchstoneVersionId: String): ResponsibilitySetRecord?
     {
         return dsl.fetchAny(Tables.RESPONSIBILITY_SET,
                 Tables.RESPONSIBILITY_SET.MODELLING_GROUP.eq(groupId).and(Tables.RESPONSIBILITY_SET.TOUCHSTONE.eq(touchstoneVersionId)))

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -6,7 +6,6 @@ import org.jooq.impl.DSL.*
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.filters.whereMatchesFilter
-import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.SimpleDataSet
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -6,6 +6,7 @@ import org.jooq.impl.DSL.*
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.app.filters.whereMatchesFilter
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.SimpleDataSet
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
-import org.vaccineimpact.api.app.controllers.ResponsibilityController
+import org.vaccineimpact.api.app.controllers.GroupResponsibilityController
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
@@ -27,7 +27,7 @@ class ResponsibilityControllerTests : MontaguTests()
             on { params(":group-id") } doReturn groupId
             on { hasPermission(ReifiedPermission.parse("*/touchstones.prepare")) } doReturn true
         }
-        val data = ResponsibilityController(context, repo, mock()).getResponsibleTouchstones()
+        val data = GroupResponsibilityController(context, repo, mock()).getResponsibleTouchstones()
         assertThat(data.count()).isEqualTo(2)
     }
 
@@ -43,7 +43,7 @@ class ResponsibilityControllerTests : MontaguTests()
             on { params(":group-id") } doReturn groupId
             on { hasPermission(ReifiedPermission.parse("*/touchstones.prepare")) } doReturn false
         }
-        val data = ResponsibilityController(context, repo, mock()).getResponsibleTouchstones()
+        val data = GroupResponsibilityController(context, repo, mock()).getResponsibleTouchstones()
         assertThat(data.count()).isEqualTo(1)
     }
 
@@ -63,7 +63,7 @@ class ResponsibilityControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        ResponsibilityController(context, mock(), repo).getResponsibilities()
+        GroupResponsibilityController(context, mock(), repo).getResponsibilities()
 
         verify(repo).getResponsibilitiesForGroupAndTouchstone(eq("gId"), eq("tId"), any())
     }
@@ -85,7 +85,7 @@ class ResponsibilityControllerTests : MontaguTests()
         }
 
         Assertions.assertThatThrownBy {
-            ResponsibilityController(context, mock(), repo).getResponsibilities()
+            GroupResponsibilityController(context, mock(), repo).getResponsibilities()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -102,7 +102,7 @@ class ResponsibilityControllerTests : MontaguTests()
         }
 
         Assertions.assertThatThrownBy {
-            ResponsibilityController(context, repo, mock()).getResponsibilities()
+            GroupResponsibilityController(context, repo, mock()).getResponsibilities()
         }.hasMessageContaining("Unknown modelling-group")
     }
 
@@ -112,7 +112,7 @@ class ResponsibilityControllerTests : MontaguTests()
         val repo = makeRepoMockingGetResponsibility(TouchstoneStatus.OPEN)
         val context = mockContextForSpecificResponsibility(true)
 
-        ResponsibilityController(context, mock(), repo).getResponsibility()
+        GroupResponsibilityController(context, mock(), repo).getResponsibility()
 
         verify(repo).getResponsibility(eq("gId"), eq("tId"), eq("sId"))
     }
@@ -123,7 +123,7 @@ class ResponsibilityControllerTests : MontaguTests()
         val repo = makeRepoMockingGetResponsibility(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(false)
         Assertions.assertThatThrownBy {
-            ResponsibilityController(context, mock(), repo).getResponsibility()
+            GroupResponsibilityController(context, mock(), repo).getResponsibility()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -136,7 +136,7 @@ class ResponsibilityControllerTests : MontaguTests()
         val context = mockContextForSpecificResponsibility(true)
 
         Assertions.assertThatThrownBy {
-            ResponsibilityController(context, repo, mock()).getResponsibility()
+            GroupResponsibilityController(context, repo, mock()).getResponsibility()
         }.hasMessageContaining("Unknown modelling-group")
 
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
@@ -37,7 +37,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val controller = TouchstoneController(context, repo)
+        val controller = TouchstoneController(context, mock(), repo)
         assertThat(controller.getTouchstones()).hasSameElementsAs(touchstones)
     }
 
@@ -54,12 +54,12 @@ class TouchstoneControllerTests : MontaguTests()
         val permissiveContext = mock<ActionContext> {
             on { hasPermission(any()) } doReturn true
         }
-        assertThat(TouchstoneController(permissiveContext, repo).getTouchstones()).hasSize(2)
+        assertThat(TouchstoneController(permissiveContext, mock(), repo).getTouchstones()).hasSize(2)
 
         val limitedContext = mock<ActionContext> {
             on { hasPermission(any()) } doReturn false
         }
-        assertThat(TouchstoneController(limitedContext, repo).getTouchstones()).hasSize(1)
+        assertThat(TouchstoneController(limitedContext, mock(), repo).getTouchstones()).hasSize(1)
     }
 
     @Test
@@ -79,7 +79,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { params(":scenario-id") } doReturn scenario.id
         }
 
-        val data = TouchstoneController(context, repo).getScenario()
+        val data = TouchstoneController(context, mock(), repo).getScenario()
 
         verify(repo).getScenario(eq(openTouchstone.id), eq(scenario.id))
         assertThat(data.touchstoneVersion).isEqualTo(openTouchstone)
@@ -98,7 +98,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { params(":touchstone-version-id") } doReturn inPrepTouchstone.id
             on { params(":scenario-id") } doReturn scenario.id
         }
-        TouchstoneController(context, repo).getScenario()
+        TouchstoneController(context, mock(), repo).getScenario()
         verify(context).requirePermission(ReifiedPermission("touchstones.prepare", Scope.Global()))
     }
 
@@ -122,7 +122,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { params(":source-code") } doReturn source
         }
 
-        val data = TouchstoneController(context, repo).getDemographicDataAndMetadata()
+        val data = TouchstoneController(context, mock(), repo).getDemographicDataAndMetadata()
         assertThat(data.structuredMetadata).isEqualTo(demographicMetadata)
     }
 
@@ -139,7 +139,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { queryParams("format") } doReturn "wide"
         }
 
-        val data = TouchstoneController(context, repo)
+        val data = TouchstoneController(context, mock(), repo)
                 .getDemographicDataAndMetadata()
                 .data.toList()
 
@@ -170,7 +170,7 @@ class TouchstoneControllerTests : MontaguTests()
             on { queryParams("format") } doReturn "long"
         }
 
-        val data = TouchstoneController(context, repo)
+        val data = TouchstoneController(context, mock(), repo)
                 .getDemographicDataAndMetadata().data
 
         Assertions.assertThat(data.first() is LongDemographicRow).isTrue()
@@ -190,7 +190,7 @@ class TouchstoneControllerTests : MontaguTests()
         }
 
         Assertions.assertThatThrownBy {
-            TouchstoneController(context, repo).getDemographicDataAndMetadata()
+            TouchstoneController(context, mock(), repo).getDemographicDataAndMetadata()
         }.isInstanceOf(BadRequest::class.java)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
@@ -54,12 +54,12 @@ class TouchstoneControllerTests : MontaguTests()
         val permissiveContext = mock<ActionContext> {
             on { hasPermission(any()) } doReturn true
         }
-        assertThat(TouchstoneController(permissiveContext, repo).getTouchstones()).isEqualTo(listOf(touchstone))
+        assertThat(TouchstoneController(permissiveContext, mock(), repo).getTouchstones()).isEqualTo(listOf(touchstone))
 
         val limitedContext = mock<ActionContext> {
             on { hasPermission(any()) } doReturn false
         }
-        assertThat(TouchstoneController(limitedContext, repo).getTouchstones()).isEqualTo(listOf(Touchstone(
+        assertThat(TouchstoneController(limitedContext, mock(), repo).getTouchstones()).isEqualTo(listOf(Touchstone(
                 id = "t",
                 description = "touchstone description",
                 comment = "comment",

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ResponsibilityTests.kt
@@ -211,6 +211,39 @@ class ResponsibilityTests : DatabaseTest()
         )
     }
 
+    @Test
+    fun `can get responsibilities for touchstone`()
+    {
+        validate("/touchstones/$touchstoneVersionId/responsibilities/") against "ResponsibilitySets" given {
+            addResponsibilities(it, touchstoneStatus = "open")
+        } requiringPermissions {
+            PermissionSet("*/touchstones.read", "*/responsibilities.read", "*/scenarios.read")
+        } andCheckArray {
+            val responsibilitySet = it[0] as JsonObject
+            assertThat(responsibilitySet["touchstone_version"]).isEqualTo(touchstoneVersionId)
+            assertThat(responsibilitySet["status"]).isEqualTo("submitted")
+            assertThat(responsibilitySet["problems"]).isNull()
+            assertThat(responsibilitySet["modelling_group_id"]).isEqualTo(groupId)
+
+            @Suppress("UNCHECKED_CAST")
+            val responsibilities = responsibilitySet["responsibilities"] as JsonArray<JsonObject>
+            val responsibility = responsibilities[0]
+            val scenario = responsibility["scenario"]
+            assertThat(scenario).isEqualTo(json {
+                obj(
+                        "id" to scenarioId,
+                        "description" to
+                                "description 1",
+                        "disease" to "disease-1",
+                        "touchstones" to array("touchstone-1")
+                )
+            })
+            assertThat(responsibility["status"]).isEqualTo("invalid")
+            assertThat(responsibility["problems"]).isEqualTo(json { array("problem") })
+            assertThat(responsibility["current_estimate_set"]).isNotNull()
+        }
+    }
+
     private fun addUserGroupAndTouchstone(db: JooqContext, touchstoneStatus: String)
     {
         db.addUserForTesting("model.user")

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/UserTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/UserTests.kt
@@ -6,10 +6,7 @@ import org.junit.Test
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.models.CreateUser
 import org.vaccineimpact.api.app.repositories.UserRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqModellingGroupRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqScenarioRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqTouchstoneRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqUserRepository
+import org.vaccineimpact.api.app.repositories.jooq.*
 import org.vaccineimpact.api.databaseTests.RepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables
@@ -33,8 +30,11 @@ class UserTests : RepositoryTests<UserRepository>()
     val username = "test.user"
     val email = "test@example.com"
     override fun makeRepository(db: JooqContext) = JooqUserRepository(db.dsl)
+
     fun makeGroupRepository(db: JooqContext) = JooqModellingGroupRepository(db.dsl,
-            JooqTouchstoneRepository(db.dsl, JooqScenarioRepository(db.dsl)), JooqScenarioRepository(db.dsl))
+            JooqResponsibilitiesRepository(db.dsl, JooqScenarioRepository(db.dsl),
+                    JooqTouchstoneRepository(db.dsl, JooqScenarioRepository(db.dsl))),
+            JooqTouchstoneRepository(db.dsl, JooqScenarioRepository(db.dsl)))
 
     private fun addTestUser(db: JooqContext)
     {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateRepositoryTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.databaseTests.tests
+package org.vaccineimpact.api.databaseTests.tests.burdenEstimateRepository
 
 import org.assertj.core.api.Assertions
 import org.jooq.Record
@@ -6,10 +6,7 @@ import org.jooq.Result
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.burdenestimates.CentralBurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.burdenestimates.StochasticBurdenEstimateWriter
-import org.vaccineimpact.api.app.repositories.jooq.JooqBurdenEstimateRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqModellingGroupRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqScenarioRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqTouchstoneRepository
+import org.vaccineimpact.api.app.repositories.jooq.*
 import org.vaccineimpact.api.app.repositories.jooq.mapping.BurdenMappingHelper
 import org.vaccineimpact.api.databaseTests.RepositoryTests
 import org.vaccineimpact.api.db.*
@@ -27,8 +24,9 @@ abstract class BurdenEstimateRepositoryTests : RepositoryTests<BurdenEstimateRep
     {
         val scenario = JooqScenarioRepository(db.dsl)
         val touchstone = JooqTouchstoneRepository(db.dsl, scenario)
+        val responsibilities = JooqResponsibilitiesRepository(db.dsl, scenario, touchstone)
 
-        val modellingGroup = JooqModellingGroupRepository(db.dsl, touchstone, scenario)
+        val modellingGroup = JooqModellingGroupRepository(db.dsl, responsibilities, touchstone)
         return JooqBurdenEstimateRepository(db.dsl, scenario, touchstone, modellingGroup)
     }
 
@@ -40,8 +38,9 @@ abstract class BurdenEstimateRepositoryTests : RepositoryTests<BurdenEstimateRep
     {
         val scenario = JooqScenarioRepository(db.dsl)
         val touchstone = JooqTouchstoneRepository(db.dsl, scenario)
+        val responsibilities = JooqResponsibilitiesRepository(db.dsl, scenario, touchstone)
 
-        val modellingGroup = JooqModellingGroupRepository(db.dsl, touchstone, scenario)
+        val modellingGroup = JooqModellingGroupRepository(db.dsl, responsibilities, touchstone)
         return JooqBurdenEstimateRepository(db.dsl, scenario, touchstone, modellingGroup, BurdenMappingHelper(),
                 centralEstimateWriter, stochasticBurdenEstimateWriter)
     }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateWriterTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/BurdenEstimateWriterTests.kt
@@ -9,7 +9,6 @@ import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.errors.UnknownRunIdError
 import org.vaccineimpact.api.app.repositories.burdenestimates.CentralBurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.burdenestimates.StochasticBurdenEstimateWriter
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.AnnexJooqContext
 import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.direct.addBurdenEstimate

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ClearBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ClearBurdenEstimateSetTests.kt
@@ -13,7 +13,6 @@ import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.burdenestimates.CentralBurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.burdenestimates.StochasticBurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.jooq.JooqBurdenEstimateRepository
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE_SET
 import org.vaccineimpact.api.db.direct.addBurdenEstimateSet

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/CloseBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/CloseBurdenEstimateSetTests.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE_SET
 import org.vaccineimpact.api.db.direct.*
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/CreateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/CreateBurdenEstimateSetTests.kt
@@ -8,7 +8,6 @@ import org.vaccineimpact.api.app.errors.DatabaseContentsError
 import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.RESPONSIBILITY
 import org.vaccineimpact.api.models.BurdenEstimateSetType

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
@@ -7,7 +7,6 @@ import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.DatabaseContentsError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.fromJoinPath

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -10,6 +10,7 @@ import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.burdenestimates.CentralBurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.burdenestimates.StochasticBurdenEstimateWriter
+import org.vaccineimpact.api.databaseTests.tests.burdenEstimateRepository.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE
 import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE_STOCHASTIC
@@ -17,7 +18,6 @@ import org.vaccineimpact.api.db.direct.addBurdenEstimateSet
 import org.vaccineimpact.api.db.direct.addResponsibility
 import org.vaccineimpact.api.db.direct.addScenarioDescription
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
-import java.math.BigDecimal
 
 class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
 {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
@@ -3,7 +3,6 @@ package org.vaccineimpact.api.databaseTests.tests.burdenEstimateRepository
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.databaseTests.tests.BurdenEstimateRepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.direct.addBurdenEstimateProblem
 import org.vaccineimpact.api.db.direct.addBurdenEstimateSet

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilitiesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilitiesTests.kt
@@ -5,30 +5,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
-import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqResponsibilitiesRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqScenarioRepository
-import org.vaccineimpact.api.app.repositories.jooq.JooqTouchstoneRepository
-import org.vaccineimpact.api.databaseTests.RepositoryTests
 import org.vaccineimpact.api.databaseTests.tests.responsibilitiesRepository.ResponsibilitiesRepositoryTests
-import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.*
 
 class GetResponsibilitiesTests : ResponsibilitiesRepositoryTests()
 {
-
-    @Test
-    fun `getResponsibilities throws error for unknown modelling group`()
-    {
-        given {
-            it.addTouchstoneVersion("touchstone", 1, "description", "open", addTouchstone = true)
-        } check { repo ->
-            assertThatThrownBy { repo.getResponsibilitiesForGroupAndTouchstone("group", "touchstone-1", ScenarioFilterParameters()) }
-                    .isInstanceOf(UnknownObjectError::class.java)
-                    .hasMessageContaining("modelling-group")
-        }
-    }
 
     @Test
     fun `getResponsibilities checks that touchstone exists`()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilitiesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilitiesTests.kt
@@ -109,6 +109,47 @@ class GetResponsibilitiesTests : ResponsibilitiesRepositoryTests()
     }
 
     @Test
+    fun `can get responsibilities for touchstone`()
+    {
+        given {
+            it.addGroup("group", "description")
+            it.addGroup("group2", "description")
+            it.addScenarioDescription("scenario-1", "description 1", "disease 1", addDisease = true)
+            it.addScenarioDescription("scenario-2", "description 2", "disease 2", addDisease = true)
+            it.addTouchstoneVersion("touchstone", 1, "description", "open", addTouchstone = true)
+            val setId = it.addResponsibilitySet("group", "touchstone-1", "submitted")
+            it.addResponsibility(setId, "touchstone-1", "scenario-1")
+            it.addResponsibility(setId, "touchstone-1", "scenario-2")
+
+            it.addResponsibilitySet("group2", "touchstone-1", "submitted")
+
+        } check { repo ->
+            val sets = repo.getResponsibilitiesForTouchstone( "touchstone-1")
+            assertThat(sets.count()).isEqualTo(2)
+
+            val set = sets[0]
+            assertThat(set.touchstoneVersion).isEqualTo("touchstone-1")
+            assertThat(set.status).isEqualTo(ResponsibilitySetStatus.SUBMITTED)
+            assertThat(set.responsibilities).hasSameElementsAs(listOf(
+                    Responsibility(
+                            Scenario("scenario-1", "description 1", "disease 1", listOf("touchstone-1")),
+                            ResponsibilityStatus.EMPTY,
+                            emptyList(),
+                            null
+                    ),
+                    Responsibility(
+                            Scenario("scenario-2", "description 2", "disease 2", listOf("touchstone-1")),
+                            ResponsibilityStatus.EMPTY,
+                            emptyList(),
+                            null
+                    )
+            ))
+
+            assertThat(sets[1].responsibilities.count()).isEqualTo(0)
+        }
+    }
+
+    @Test
     fun `only gets open responsibilities`()
     {
         given {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityCoverageSetsTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityCoverageSetsTests.kt
@@ -36,6 +36,19 @@ class GetResponsibilityCoverageSetsTests : ModellingGroupRepositoryTests()
     }
 
     @Test
+    fun `get coverage sets throws exception if group doesn't exist`()
+    {
+        given {
+            createGroupAndSupportingObjects(it)
+            giveCoverageSetsToResponsibility(it)
+        } check {
+            assertThatThrownBy { it.getCoverageSets("badId", touchstoneVersionId, scenarioId) }
+                    .isInstanceOf(org.vaccineimpact.api.app.errors.UnknownObjectError::class.java)
+                    .hasMessageContaining("Unknown modelling-group")
+        }
+    }
+
+    @Test
     fun `can get ordered coverage sets`()
     {
         given {
@@ -57,6 +70,19 @@ class GetResponsibilityCoverageSetsTests : ModellingGroupRepositoryTests()
             assertThatThrownBy { it.getCoverageData(groupId, touchstoneVersionId, scenarioId) }
                     .isInstanceOf(org.vaccineimpact.api.app.errors.UnknownObjectError::class.java)
                     .hasMessageContaining("responsibility")
+        }
+    }
+
+    @Test
+    fun `getCoverageData throws exception if group doesn't exist`()
+    {
+        given {
+            createGroupAndSupportingObjects(it)
+            giveCoverageSetsToResponsibility(it)
+        } check {
+            assertThatThrownBy { it.getCoverageData("badId", touchstoneVersionId, scenarioId) }
+                    .isInstanceOf(org.vaccineimpact.api.app.errors.UnknownObjectError::class.java)
+                    .hasMessageContaining("Unknown modelling-group")
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetResponsibilityTests.kt
@@ -3,10 +3,12 @@ package org.vaccineimpact.api.databaseTests.tests.modellingGroupRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
+import org.vaccineimpact.api.databaseTests.tests.responsibilitiesRepository.ResponsibilitiesRepositoryTests
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.*
 
-class GetResponsibilityTests : ModellingGroupRepositoryTests()
+class GetResponsibilityTests : ResponsibilitiesRepositoryTests()
 {
     @org.junit.Test
     fun `getResponsibility throws error for unknown modelling group`()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/ModellingGroupRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/ModellingGroupRepositoryTests.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.api.databaseTests.tests.modellingGroupRepository
 
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.jooq.JooqModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.jooq.JooqResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.jooq.JooqScenarioRepository
 import org.vaccineimpact.api.app.repositories.jooq.JooqTouchstoneRepository
 import org.vaccineimpact.api.databaseTests.RepositoryTests
@@ -13,7 +14,9 @@ abstract class ModellingGroupRepositoryTests : RepositoryTests<ModellingGroupRep
     {
         val scenarioRepository = JooqScenarioRepository(db.dsl)
         val touchstoneRepository = JooqTouchstoneRepository(db.dsl, scenarioRepository)
+        val responsibilitiesRepository = JooqResponsibilitiesRepository(db.dsl, scenarioRepository,
+                touchstoneRepository)
 
-        return JooqModellingGroupRepository(db.dsl, touchstoneRepository, scenarioRepository)
+        return JooqModellingGroupRepository(db.dsl, responsibilitiesRepository, touchstoneRepository)
     }
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/ResponsibilitiesRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/ResponsibilitiesRepositoryTests.kt
@@ -1,0 +1,19 @@
+package org.vaccineimpact.api.databaseTests.tests.responsibilitiesRepository
+
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
+import org.vaccineimpact.api.app.repositories.jooq.JooqResponsibilitiesRepository
+import org.vaccineimpact.api.app.repositories.jooq.JooqScenarioRepository
+import org.vaccineimpact.api.app.repositories.jooq.JooqTouchstoneRepository
+import org.vaccineimpact.api.databaseTests.RepositoryTests
+import org.vaccineimpact.api.db.JooqContext
+
+abstract class ResponsibilitiesRepositoryTests : RepositoryTests<ResponsibilitiesRepository>()
+{
+    override fun makeRepository(db: JooqContext): ResponsibilitiesRepository
+    {
+        val scenarioRepository = JooqScenarioRepository(db.dsl)
+        val touchstoneRepository = JooqTouchstoneRepository(db.dsl, scenarioRepository)
+        return JooqResponsibilitiesRepository(db.dsl, scenarioRepository,
+                touchstoneRepository)
+  }
+}


### PR DESCRIPTION
Involved some refactoring - pulled out methods from the `ModellingGroupRepository` into a `ResponsibilitiesRepository` so they could be re-used. Reminded me that we should really think about adding a logic layer between the controllers and the repos!

1 webmodels PR along with this one: https://github.com/vimc/montagu-webmodels/pull/49