### PR TITLE
i2056: Allow result redirection in burden estimate upload

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.api.app
 
 import org.vaccineimpact.api.app.app_start.stream
 import org.vaccineimpact.api.app.context.ActionContext
-import org.vaccineimpact.api.app.context.MultipartStreamSource
 import org.vaccineimpact.api.app.context.OneTimeLinkActionContext
 import org.vaccineimpact.api.app.controllers.*
 import org.vaccineimpact.api.app.repositories.Repositories
@@ -37,7 +36,7 @@ open class OnetimeLinkResolver(private val repositories: Repositories,
             when (action)
             {
                 OneTimeAction.BURDENS_POPULATE -> GroupBurdenEstimatesController(context, repos, repos.burdenEstimates)
-                        .populateBurdenEstimateSet(MultipartStreamSource("file", context))
+                        .populateBurdenEstimateSet()
                 OneTimeAction.MODEl_RUN_PARAMETERS -> stream(
                         GroupModelRunParametersController(context, repos).getModelRunParameterSet(),
                         context

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -36,9 +36,7 @@ open class OnetimeLinkResolver(private val repositories: Repositories,
         return { context ->
             when (action)
             {
-                OneTimeAction.BURDENS_CREATE -> GroupBurdenEstimatesController(context, repos.burdenEstimates)
-                        .createBurdenEstimateSet()
-                OneTimeAction.BURDENS_POPULATE -> GroupBurdenEstimatesController(context, repos.burdenEstimates)
+                OneTimeAction.BURDENS_POPULATE -> GroupBurdenEstimatesController(context, repos, repos.burdenEstimates)
                         .populateBurdenEstimateSet(MultipartStreamSource("file", context))
                 OneTimeAction.MODEl_RUN_PARAMETERS -> stream(
                         GroupModelRunParametersController(context, repos).getModelRunParameterSet(),

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ResultRedirector.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ResultRedirector.kt
@@ -1,0 +1,60 @@
+package org.vaccineimpact.api.app
+
+import org.vaccineimpact.api.app.context.ActionContext
+import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.models.Result
+import org.vaccineimpact.api.models.ResultStatus
+import org.vaccineimpact.api.security.WebTokenHelper
+
+class ResultRedirector(
+        private val tokenHelper: WebTokenHelper,
+        private val repositories: Repositories,
+        private val redirectValidator: RedirectValidator = MontaguRedirectValidator(),
+        private val errorHandler: ErrorHandler = ErrorHandler()
+)
+{
+    fun <T> redirectIfRequested(context: ActionContext, minimalValue: T, work: (repositories: Repositories) -> T): T
+    {
+        val redirectUrl = context.queryParams("redirectResultTo")
+        return if (redirectUrl != null)
+        {
+            try
+            {
+                redirectValidator.validateRedirectUrl(redirectUrl)
+                repositories.inTransaction { reposInSubTransaction ->
+                    val data = work(reposInSubTransaction)
+                    redirectWithResult(context, data.asSuccessfulResult(), redirectUrl, tokenHelper)
+                }
+            }
+            catch (e: Exception)
+            {
+                val error = errorHandler.logExceptionAndReturnMontaguError(e, context.request)
+                redirectWithResult(context, error.asResult(), redirectUrl, tokenHelper, e)
+            }
+            minimalValue
+        }
+        else
+        {
+            work(repositories)
+        }
+    }
+
+    private fun redirectWithResult(
+            context: ActionContext,
+            result: Result,
+            redirectUrl: String,
+            tokenHelper: WebTokenHelper,
+            exception: Exception? = null)
+    {
+        val encodedResult = tokenHelper.encodeResult(result)
+        context.request.consumeRemainder()
+        // it is recommended to keep urls under 2000 characters
+        // https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers/417184#417184
+        if (encodedResult.length > 1900 && exception != null)
+            throw exception
+
+        context.redirect("$redirectUrl?result=$encodedResult")
+    }
+}
+
+fun Any?.asSuccessfulResult() = Result(ResultStatus.SUCCESS, this, emptyList())

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupBurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupBurdenEstimatesRouteConfig.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.Endpoint
+import org.vaccineimpact.api.app.app_start.csv
 import org.vaccineimpact.api.app.app_start.json
 import org.vaccineimpact.api.app.app_start.secure
 import org.vaccineimpact.api.app.controllers.GroupBurdenEstimatesController
@@ -32,14 +33,12 @@ object GroupBurdenEstimatesRouteConfig : RouteConfig
                     .json()
                     .secure(writePermissions),
 
-            Endpoint("$baseUrl/get_onetime_link/",
-                    OneTimeLinkController::class,
-                    "getTokenForCreateBurdenEstimateSet")
+            // Populate sets
+            Endpoint("$baseUrl/:set-id/", controller, "populateBurdenEstimateSet", method = HttpMethod.post)
                     .json()
                     .secure(writePermissions),
 
-            // Populate sets
-            Endpoint("$baseUrl/:set-id/", controller, "populateBurdenEstimateSet", method = HttpMethod.post)
+            Endpoint("$baseUrl/:set-id/multipart/", controller, "populateBurdenEstimateSetFromMultipartStream", method = HttpMethod.post)
                     .json()
                     .secure(writePermissions),
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupBurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupBurdenEstimatesRouteConfig.kt
@@ -38,10 +38,6 @@ object GroupBurdenEstimatesRouteConfig : RouteConfig
                     .json()
                     .secure(writePermissions),
 
-            Endpoint("$baseUrl/:set-id/multipart/", controller, "populateBurdenEstimateSetFromMultipartStream", method = HttpMethod.post)
-                    .json()
-                    .secure(writePermissions),
-
             Endpoint("$baseUrl/:set-id/get_onetime_link/",
                     OneTimeLinkController::class,
                     "getTokenForPopulateBurdenEstimateSet")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
@@ -6,6 +6,28 @@ import java.io.StringReader
 interface RequestDataSource
 {
     fun getContent(): Reader
+
+    companion object
+    {
+        /**
+         * Automatically determines how to extract the main body of the request - either just the whole request
+         * body or, in the case of a multipart file upload, one of the parts. If it is multipart, uses the
+         * 'partNameToUseForMultipart' parameter to determine which part to use.
+         *
+         * It is recommended that for HTML forms under our control we always use <input name="file" />, and so
+         * the default value for partNameToUseForMultipart will always be correct. However, for compatibility with
+         * 3rd party forms, this value is configurable.
+         */
+        fun fromContentType(context: ActionContext, partNameToUseForMultipart: String = "file"): RequestDataSource
+        {
+            val type = context.contentType().toLowerCase()
+            return when
+            {
+                type.startsWith("multipart/form-data") -> MultipartStreamSource(partNameToUseForMultipart, context)
+                else -> RequestBodySource(context)
+            }
+        }
+    }
 }
 
 class RequestBodySource(private val context: ActionContext) : RequestDataSource

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
@@ -3,7 +3,9 @@ package org.vaccineimpact.api.app.controllers
 import org.vaccineimpact.api.app.ResultRedirector
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.checkAllValuesAreEqual
-import org.vaccineimpact.api.app.context.*
+import org.vaccineimpact.api.app.context.ActionContext
+import org.vaccineimpact.api.app.context.RequestDataSource
+import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -48,9 +50,7 @@ open class GroupBurdenEstimatesController(
         return objectCreation(context, url)
     }
 
-    fun populateBurdenEstimateSet() = populateBurdenEstimateSet(RequestBodySource(context))
-    fun populateBurdenEstimateSetFromMultipartStream() = populateBurdenEstimateSet(MultipartStreamSource("file", context))
-
+    fun populateBurdenEstimateSet() = populateBurdenEstimateSet(RequestDataSource.fromContentType(context))
     fun populateBurdenEstimateSet(source: RequestDataSource): String
     {
         return ResultRedirector(tokenHelper, repositories).redirectIfRequested(context, "") { repos ->

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupBurdenEstimatesController.kt
@@ -1,11 +1,9 @@
 package org.vaccineimpact.api.app.controllers
 
+import org.vaccineimpact.api.app.ResultRedirector
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.checkAllValuesAreEqual
-import org.vaccineimpact.api.app.context.ActionContext
-import org.vaccineimpact.api.app.context.RequestBodySource
-import org.vaccineimpact.api.app.context.RequestDataSource
-import org.vaccineimpact.api.app.context.postData
+import org.vaccineimpact.api.app.context.*
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -14,16 +12,20 @@ import org.vaccineimpact.api.app.requests.PostDataHelper
 import org.vaccineimpact.api.app.requests.csvData
 import org.vaccineimpact.api.app.security.checkEstimatePermissionsForTouchstoneVersion
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.security.KeyHelper
+import org.vaccineimpact.api.security.WebTokenHelper
 import java.time.Instant
 
 open class GroupBurdenEstimatesController(
         context: ActionContext,
+        private val repositories: Repositories,
         private val estimateRepository: BurdenEstimateRepository,
-        private val postDataHelper: PostDataHelper = PostDataHelper()
-) : Controller(context)
+        private val postDataHelper: PostDataHelper = PostDataHelper(),
+        private val tokenHelper: WebTokenHelper = WebTokenHelper(KeyHelper.keyPair)
+        ) : Controller(context)
 {
     constructor(context: ActionContext, repos: Repositories)
-            : this(context, repos.burdenEstimates)
+            : this(context, repos, repos.burdenEstimates)
 
     fun getBurdenEstimates(): List<BurdenEstimateSet>
     {
@@ -47,33 +49,38 @@ open class GroupBurdenEstimatesController(
     }
 
     fun populateBurdenEstimateSet() = populateBurdenEstimateSet(RequestBodySource(context))
+    fun populateBurdenEstimateSetFromMultipartStream() = populateBurdenEstimateSet(MultipartStreamSource("file", context))
 
     fun populateBurdenEstimateSet(source: RequestDataSource): String
     {
-        // First check if we're allowed to see this touchstoneVersion
-        val path = getValidResponsibilityPath(context, estimateRepository)
+        return ResultRedirector(tokenHelper, repositories).redirectIfRequested(context, "") { repos ->
+            val estimateRepository = repos.burdenEstimates
 
-        // Next, get the metadata that will enable us to interpret the CSV
-        val setId = context.params(":set-id").toInt()
-        val metadata = estimateRepository.getBurdenEstimateSet(setId)
+            // First check if we're allowed to see this touchstoneVersion
+            val path = getValidResponsibilityPath(context, estimateRepository)
 
-        // Then add the burden estimates
-        val data = getBurdenEstimateDataFromCSV(metadata, source)
-        estimateRepository.populateBurdenEstimateSet(
-                setId,
-                path.groupId, path.touchstoneVersionId, path.scenarioId,
-                data
-        )
+            // Next, get the metadata that will enable us to interpret the CSV
+            val setId = context.params(":set-id").toInt()
+            val metadata = estimateRepository.getBurdenEstimateSet(setId)
 
-        // Then, maybe close the burden estimate set
-        val keepOpen = context.queryParams("keepOpen")?.toBoolean() ?: false
-        if (!keepOpen)
-        {
-            estimateRepository.closeBurdenEstimateSet(setId,
-                    path.groupId, path.touchstoneVersionId, path.scenarioId)
+            // Then add the burden estimates
+            val data = getBurdenEstimateDataFromCSV(metadata, source)
+            estimateRepository.populateBurdenEstimateSet(
+                    setId,
+                    path.groupId, path.touchstoneVersionId, path.scenarioId,
+                    data
+            )
+
+            // Then, maybe close the burden estimate set
+            val keepOpen = context.queryParams("keepOpen")?.toBoolean() ?: false
+            if (!keepOpen)
+            {
+                estimateRepository.closeBurdenEstimateSet(setId,
+                        path.groupId, path.touchstoneVersionId, path.scenarioId)
+            }
+
+            okayResponse()
         }
-
-        return okayResponse()
     }
 
     fun clearBurdenEstimateSet(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -88,11 +88,6 @@ class OneTimeLinkController(
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.MODEl_RUN_PARAMETERS, context)
     }
 
-    fun getTokenForCreateBurdenEstimateSet(): String
-    {
-        return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.BURDENS_CREATE, context)
-    }
-
     fun getTokenForPopulateBurdenEstimateSet(): String
     {
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.BURDENS_POPULATE, context)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
@@ -228,6 +228,7 @@ class GroupEstimatesControllerTests : MontaguTests()
     {
         return mock {
             on { username } doReturn "username"
+            on { contentType() } doReturn "text/csv"
             on { params(":set-id") } doReturn "1"
             on { params(":group-id") } doReturn "group-1"
             on { params(":touchstone-version-id") } doReturn "touchstone-1"

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.controllers.GroupBurdenEstimatesController
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.SimpleDataSet
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.requests.PostDataHelper
@@ -162,7 +163,7 @@ class GroupEstimatesControllerTests : MontaguTests()
         val repo = mockRepository()
         val mockContext = mockActionContext(keepOpen = keepOpen)
         val mockPostData = mockCSVPostData(normalCSVData)
-        GroupBurdenEstimatesController(mockContext, mock(), repo, postDataHelper = mockPostData).populateBurdenEstimateSet()
+        GroupBurdenEstimatesController(mockContext, mockRepositories(repo), repo, postDataHelper = mockPostData).populateBurdenEstimateSet()
         verify(repo, timesExpected).closeBurdenEstimateSet(defaultEstimateSet.id,
                 "group-1", "touchstone-1", "scenario-1")
     }
@@ -195,7 +196,8 @@ class GroupEstimatesControllerTests : MontaguTests()
                 ))
         )
         val actionContext = mockActionContext()
-        val controller = GroupBurdenEstimatesController(actionContext, mock(), mockRepository(), mockCSVPostData(data))
+        val repo = mockRepository()
+        val controller = GroupBurdenEstimatesController(actionContext, mockRepositories(repo), repo, mockCSVPostData(data))
         assertThatThrownBy {
             controller.populateBurdenEstimateSet()
         }.isInstanceOf(InconsistentDataError::class.java)
@@ -244,7 +246,7 @@ class GroupEstimatesControllerTests : MontaguTests()
         val postDataHelper = mock<PostDataHelper> {
             on { csvData<T>(any(), any()) } doReturn actualData
         }
-        GroupBurdenEstimatesController(actionContext, mock(), repo, postDataHelper = postDataHelper).populateBurdenEstimateSet()
+        GroupBurdenEstimatesController(actionContext, mockRepositories(repo), repo, postDataHelper = postDataHelper).populateBurdenEstimateSet()
         verify(touchstoneVersionSet).get("touchstone-1")
         verify(repo).populateBurdenEstimateSet(eq(1),
                 eq("group-1"), eq("touchstone-1"), eq("scenario-1"),
@@ -278,6 +280,10 @@ class GroupEstimatesControllerTests : MontaguTests()
                 Unit
             }
         }
+    }
+
+    private fun mockRepositories(repo: BurdenEstimateRepository) = mock<Repositories> {
+        on { burdenEstimates } doReturn repo
     }
 
     private val defaultEstimateSet = BurdenEstimateSet(

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupEstimatesControllerTests.kt
@@ -45,7 +45,7 @@ class GroupEstimatesControllerTests : MontaguTests()
             on { params(":touchstone-version-id") } doReturn "touchstone-1"
             on { params(":scenario-id") } doReturn "scenario-1"
         }
-        assertThat(GroupBurdenEstimatesController(context, repo).getBurdenEstimates())
+        assertThat(GroupBurdenEstimatesController(context, mock(), repo).getBurdenEstimates())
                 .hasSameElementsAs(data.toList())
         verify(repo).getBurdenEstimateSets("group-1", "touchstone-1", "scenario-1")
     }
@@ -68,7 +68,7 @@ class GroupEstimatesControllerTests : MontaguTests()
             on { params(":scenario-id") } doReturn "scenario-1"
             on { postData<CreateBurdenEstimateSet>() } doReturn properties
         }
-        val url = GroupBurdenEstimatesController(mockContext, repo).createBurdenEstimateSet()
+        val url = GroupBurdenEstimatesController(mockContext, mock(), repo).createBurdenEstimateSet()
         val after = Instant.now()
         assertThat(url).endsWith("/modelling-groups/group-1/responsibilities/touchstone-1/scenario-1/estimate-sets/1/")
         verify(touchstoneSet).get("touchstone-1")
@@ -162,7 +162,7 @@ class GroupEstimatesControllerTests : MontaguTests()
         val repo = mockRepository()
         val mockContext = mockActionContext(keepOpen = keepOpen)
         val mockPostData = mockCSVPostData(normalCSVData)
-        GroupBurdenEstimatesController(mockContext, repo, postDataHelper = mockPostData).populateBurdenEstimateSet()
+        GroupBurdenEstimatesController(mockContext, mock(), repo, postDataHelper = mockPostData).populateBurdenEstimateSet()
         verify(repo, timesExpected).closeBurdenEstimateSet(defaultEstimateSet.id,
                 "group-1", "touchstone-1", "scenario-1")
     }
@@ -177,7 +177,7 @@ class GroupEstimatesControllerTests : MontaguTests()
             on { params(":touchstone-version-id") } doReturn "touchstone-1"
             on { params(":scenario-id") } doReturn "scenario-1"
         }
-        GroupBurdenEstimatesController(mockContext, repo).closeBurdenEstimateSet()
+        GroupBurdenEstimatesController(mockContext, mock(), repo).closeBurdenEstimateSet()
         verify(repo).closeBurdenEstimateSet(1, "group-1", "touchstone-1", "scenario-1")
     }
 
@@ -195,7 +195,7 @@ class GroupEstimatesControllerTests : MontaguTests()
                 ))
         )
         val actionContext = mockActionContext()
-        val controller = GroupBurdenEstimatesController(actionContext, mockRepository(), mockCSVPostData(data))
+        val controller = GroupBurdenEstimatesController(actionContext, mock(), mockRepository(), mockCSVPostData(data))
         assertThatThrownBy {
             controller.populateBurdenEstimateSet()
         }.isInstanceOf(InconsistentDataError::class.java)
@@ -244,7 +244,7 @@ class GroupEstimatesControllerTests : MontaguTests()
         val postDataHelper = mock<PostDataHelper> {
             on { csvData<T>(any(), any()) } doReturn actualData
         }
-        GroupBurdenEstimatesController(actionContext, repo, postDataHelper = postDataHelper).populateBurdenEstimateSet()
+        GroupBurdenEstimatesController(actionContext, mock(), repo, postDataHelper = postDataHelper).populateBurdenEstimateSet()
         verify(touchstoneVersionSet).get("touchstone-1")
         verify(repo).populateBurdenEstimateSet(eq(1),
                 eq("group-1"), eq("touchstone-1"), eq("scenario-1"),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/OneTimeLinkControllerTests.kt
@@ -265,7 +265,7 @@ class OneTimeLinkControllerTests : MontaguTests()
     private val claimsWithRedirectUrl =
             mapOf(
                     "sub" to WebTokenHelper.oneTimeActionSubject,
-                    "action" to "burdens-create",
+                    "action" to "coverage",
                     "payload" to ":username=test.user",
                     "query" to "redirectUrl=$redirectUrl",
                     "username" to "test.user"
@@ -274,7 +274,7 @@ class OneTimeLinkControllerTests : MontaguTests()
     private val claimsWithoutRedirectUrl =
             mapOf(
                     "sub" to WebTokenHelper.oneTimeActionSubject,
-                    "action" to "burdens-create",
+                    "action" to "coverage",
                     "payload" to ":username=test.user",
                     "username" to "test.user"
             )

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CreateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CreateBurdenEstimateTests.kt
@@ -59,41 +59,6 @@ class CreateBurdenEstimateTests : BurdenEstimateTests()
         JSONValidator().validateError(response.text, "invalid-field:model_run_parameter_set:missing")
     }
 
-    @Test
-    fun `can create burden estimate via onetime link`()
-    {
-        validate("$setUrl/get_onetime_link/") against "Token" given { db ->
-            setUp(db)
-        } requiringPermissions {
-            requiredWritePermissions
-        } andCheckString { token ->
-            val oneTimeURL = "/onetime_link/$token/"
-            val requestHelper = RequestHelper()
-            val response = requestHelper.post(oneTimeURL, metadataForCreate())
-            createdSetLocation.checkObjectCreation(response)
-
-            val badResponse = requestHelper.get(oneTimeURL)
-            JSONValidator().validateError(badResponse.text, expectedErrorCode = "invalid-token-used")
-        }
-    }
-
-    @Test
-    fun `can create burden estimate via onetime link and redirect`()
-    {
-        validate("$setUrl/get_onetime_link/?redirectUrl=http://localhost/") against "Token" given { db ->
-            setUp(db)
-        } requiringPermissions {
-            requiredWritePermissions
-        } andCheckString { token ->
-            val oneTimeURL = "/onetime_link/$token/"
-            val requestHelper = RequestHelper()
-
-            val response = requestHelper.post(oneTimeURL, metadataForCreate())
-            val resultAsString = response.getResultFromRedirect(checkRedirectTarget = "http://localhost")
-            JSONValidator().validateSuccess(resultAsString)
-        }
-    }
-
     private val createdSetLocation = LocationConstraint(
             "/modelling-groups/group-1/responsibilities/touchstone-1/scenario-1/estimate-sets/", unknownId = true
     )

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -46,7 +46,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
             setUpWithBurdenEstimateSet(it)
         }
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
-        val response = RequestHelper().postFile("$setUrl$setId/multipart/", csvData, token = token)
+        val response = RequestHelper().postFile("$setUrl$setId/", csvData, token = token)
         JSONValidator().validateSuccess(response.text)
     }
 
@@ -129,6 +129,19 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
 
     @Test
     fun `can populate burden estimate via onetime link`()
+    {
+        val requestHelper = RequestHelper()
+        val setId = JooqContext().use {
+            setUpWithBurdenEstimateSet(it)
+        }
+
+        val oneTimeURL = getPopulateOneTimeURL(setId)
+        val response = requestHelper.post(oneTimeURL, csvData)
+        JSONValidator().validateSuccess(response.text)
+    }
+
+    @Test
+    fun `can populate burden estimate via onetime link multipart file upload`()
     {
         val requestHelper = RequestHelper()
         val setId = JooqContext().use {
@@ -234,7 +247,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
 
     private fun getPopulateOneTimeURL(setId: Int, redirect: Boolean = false): String
     {
-        var url = "$setUrl/$setId/multipart/?"
+        var url = "$setUrl/$setId/?"
         if (redirect)
         {
             url += "&redirectResultTo=http://localhost/"

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -30,6 +30,36 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         } withPermissions {
             requiredWritePermissions
         } andCheckHasStatus 200..299
+
+        JooqContext().use { db ->
+            val records = db.dsl.select(BURDEN_ESTIMATE.fieldsAsList())
+                    .from(BURDEN_ESTIMATE)
+                    .fetch()
+            assertThat(records).isNotEmpty
+        }
+    }
+
+    @Test
+    fun `can populate central burden estimate via multipart file upload`()
+    {
+        val setId = JooqContext().use {
+            setUpWithBurdenEstimateSet(it)
+        }
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val response = RequestHelper().postFile("$setUrl$setId/multipart/", csvData, token = token)
+        JSONValidator().validateSuccess(response.text)
+    }
+
+    @Test
+    fun `can populate burden estimate and redirect`()
+    {
+        val setId = JooqContext().use {
+            setUpWithBurdenEstimateSet(it)
+        }
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val response = RequestHelper().post("$setUrl$setId/?redirectResultTo=http://localhost", csvData, token)
+        val resultAsString = response.getResultFromRedirect(checkRedirectTarget = "http://localhost")
+        JSONValidator().validateSuccess(resultAsString)
     }
 
     @Test
@@ -204,15 +234,14 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
 
     private fun getPopulateOneTimeURL(setId: Int, redirect: Boolean = false): String
     {
-        var url = "$setUrl/$setId/get_onetime_link/"
+        var url = "$setUrl/$setId/multipart/?"
         if (redirect)
         {
-            url += "?redirectUrl=http://localhost/"
+            url += "&redirectResultTo=http://localhost/"
         }
         val token = TestUserHelper.getToken(requiredWritePermissions.plus(PermissionSet("*/can-login")))
-        val onetimeTokenResult = RequestHelper().get(url, token)
-        val onetimeToken = onetimeTokenResult.montaguData<String>()!!
-        return "/onetime_link/$onetimeToken/"
+        val oneTimeToken = RequestHelper().getOneTimeToken(url, token)
+        return "$url&access_token=$oneTimeToken"
     }
 
 }


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-2056

One extra change here: We weren't actually using the one time link for *creating* burden estimate sets (as opposed to populating them) so rather than have to refactor that here, I just removed it. This means there's also a [tiny webmodels PR](https://github.com/vimc/montagu-webmodels/pull/61).