### PR TITLE
coverage logic

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -4,6 +4,7 @@ import org.vaccineimpact.api.app.app_start.stream
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.OneTimeLinkActionContext
 import org.vaccineimpact.api.app.controllers.*
+import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.security.OneTimeTokenGenerator
 import org.vaccineimpact.api.models.helpers.OneTimeAction
@@ -39,6 +40,11 @@ open class OnetimeLinkResolver(private val repositories: Repositories,
                         .populateBurdenEstimateSet()
                 OneTimeAction.MODEl_RUN_PARAMETERS -> stream(
                         GroupModelRunParametersController(context, repos).getModelRunParameterSet(),
+                        context
+                )
+                OneTimeAction.COVERAGE -> stream(
+                        CoverageController(context, repos.modellingGroup,
+                                RepositoriesCoverageLogic(repos)).getCoverageDataForGroup(),
                         context
                 )
                 OneTimeAction.DEMOGRAPHY -> stream(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/OneTimeLink.kt
@@ -41,10 +41,6 @@ open class OnetimeLinkResolver(private val repositories: Repositories,
                         GroupModelRunParametersController(context, repos).getModelRunParameterSet(),
                         context
                 )
-                OneTimeAction.COVERAGE -> stream(
-                        GroupCoverageController(context, repos.modellingGroup).getCoverageData(),
-                        context
-                )
                 OneTimeAction.DEMOGRAPHY -> stream(
                         TouchstoneController(context, repos).getDemographicData(),
                         context

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupCoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/GroupCoverageRouteConfig.kt
@@ -1,14 +1,14 @@
 package org.vaccineimpact.api.app.app_start.route_config
 
 import org.vaccineimpact.api.app.app_start.*
-import org.vaccineimpact.api.app.controllers.GroupCoverageController
+import org.vaccineimpact.api.app.controllers.CoverageController
 import org.vaccineimpact.api.app.controllers.OneTimeLinkController
 import org.vaccineimpact.api.app.app_start.streamed
 
 object GroupCoverageRouteConfig : RouteConfig
 {
     private val baseUrl = "/modelling-groups/:group-id/responsibilities/:touchstone-version-id/:scenario-id"
-    private val controller = GroupCoverageController::class
+    private val controller = CoverageController::class
 
     private val groupScope = "modelling-group:<group-id>"
     val permissions = setOf(
@@ -18,16 +18,16 @@ object GroupCoverageRouteConfig : RouteConfig
     )
 
     override val endpoints: List<EndpointDefinition> = listOf(
-            Endpoint("$baseUrl/coverage-sets/", controller, "getCoverageSets")
+            Endpoint("$baseUrl/coverage-sets/", controller, "getCoverageSetsForGroup")
                     .json()
                     .secure(permissions),
 
-            Endpoint("$baseUrl/coverage/", controller, "getCoverageDataAndMetadata")
+            Endpoint("$baseUrl/coverage/", controller, "getCoverageDataAndMetadataForGroup")
                     // TODO: Return true multipart data and change the data type
                     .json().streamed()
                     .secure(permissions),
 
-            Endpoint("$baseUrl/coverage/", controller, "getCoverageData")
+            Endpoint("$baseUrl/coverage/", controller, "getCoverageDataForGroup")
                     .csv().streamed()
                     .secure(permissions),
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -21,9 +21,7 @@ class CoverageController(
 {
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, repositories.modellingGroup,
-            RepositoriesCoverageLogic(repositories.modellingGroup,
-                    repositories.responsibilities,
-                    repositories.touchstone))
+            RepositoriesCoverageLogic(repositories))
 
     fun getCoverageSetsForGroup(): ScenarioTouchstoneAndCoverageSets
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -1,0 +1,79 @@
+package org.vaccineimpact.api.app.controllers
+
+import org.vaccineimpact.api.app.app_start.Controller
+import org.vaccineimpact.api.app.context.ActionContext
+import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
+import org.vaccineimpact.api.app.logic.CoverageLogic
+import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.Repositories
+import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
+import org.vaccineimpact.api.models.CoverageRow
+import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
+import org.vaccineimpact.api.serialization.SplitData
+import org.vaccineimpact.api.serialization.StreamSerializable
+
+class CoverageController(
+        actionContext: ActionContext,
+        private val repo: ModellingGroupRepository,
+        private val coverageLogic: CoverageLogic
+) : Controller(actionContext)
+{
+    constructor(context: ActionContext, repositories: Repositories)
+            : this(context, repositories.modellingGroup,
+            RepositoriesCoverageLogic(repositories.modellingGroup,
+                    repositories.responsibilities,
+                    repositories.touchstone))
+
+    fun getCoverageSetsForGroup(): ScenarioTouchstoneAndCoverageSets
+    {
+        val path = ResponsibilityPath(context)
+        val data = repo.getCoverageSets(path.groupId, path.touchstoneVersionId, path.scenarioId)
+        context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, data.touchstoneVersion.status)
+        return data
+    }
+
+    fun getCoverageDataForGroup(): StreamSerializable<CoverageRow>
+    {
+        return addAttachmentHeaderAndReturn(getCoverageDataAndMetadataForGroup())
+    }
+
+    fun getCoverageDataForTouchstoneVersion(): StreamSerializable<CoverageRow>
+    {
+        return addAttachmentHeaderAndReturn(getCoverageDataAndMetadataForTouchstoneVersion())
+    }
+
+    private fun addAttachmentHeaderAndReturn(data: SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>)
+            : StreamSerializable<CoverageRow>
+    {
+        val metadata = data.structuredMetadata
+        val filename = "coverage_${metadata.touchstoneVersion.id}_${metadata.scenario.id}.csv"
+        context.addAttachmentHeader(filename)
+        return data.tableData
+    }
+
+    // TODO: https://vimc.myjetbrains.com/youtrack/issue/VIMC-307
+    // Use streams to speed up this process of sending large data
+    fun getCoverageDataAndMetadataForGroup(): SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>
+    {
+        val path = ResponsibilityPath(context)
+        val format = context.queryParams("format")
+        val splitData = coverageLogic.getCoverageDataForGroup(path.groupId,
+                path.touchstoneVersionId, path.scenarioId, format)
+        context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, splitData.structuredMetadata.touchstoneVersion.status)
+        return splitData
+    }
+
+    // TODO: https://vimc.myjetbrains.com/youtrack/issue/VIMC-307
+    // Use streams to speed up this process of sending large data
+    fun getCoverageDataAndMetadataForTouchstoneVersion(): SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>
+    {
+        val touchstoneVersionId = context.params(":touchstone-version-id")
+        val scenarioId = context.params(":scenario-id")
+        val format = context.queryParams("format")
+        val splitData = coverageLogic.getCoverageData(touchstoneVersionId, scenarioId, format)
+        context.checkIsAllowedToSeeTouchstone(touchstoneVersionId, splitData.structuredMetadata.touchstoneVersion.status)
+        return splitData
+    }
+
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -78,6 +78,11 @@ class OneTimeLinkController(
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.DEMOGRAPHY, context)
     }
 
+    fun getTokenForCoverageData(): String
+    {
+        return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.COVERAGE, context)
+    }
+
     fun getTokenForModelRunParameters(): String
     {
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.MODEl_RUN_PARAMETERS, context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/OneTimeLinkController.kt
@@ -78,11 +78,6 @@ class OneTimeLinkController(
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.DEMOGRAPHY, context)
     }
 
-    fun getTokenForCoverageData(): String
-    {
-        return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.COVERAGE, context)
-    }
-
     fun getTokenForModelRunParameters(): String
     {
         return oneTimeTokenGenerator.getOneTimeLinkToken(OneTimeAction.MODEl_RUN_PARAMETERS, context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.api.app.logic
 
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.models.CoverageRow
@@ -24,6 +25,10 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                                 private val responsibilitiesRepository: ResponsibilitiesRepository,
                                 private val touchstoneRepository: TouchstoneRepository) : CoverageLogic
 {
+    constructor(repositories: Repositories) : this(repositories.modellingGroup,
+            repositories.responsibilities,
+            repositories.touchstone)
+
     override fun getCoverageDataForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String,
                                          format: String?)
             : SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupCoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupCoverageControllerTests.kt
@@ -4,7 +4,7 @@ import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
-import org.vaccineimpact.api.app.controllers.GroupCoverageController
+import org.vaccineimpact.api.app.controllers.CoverageController
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.db.nextDecimal
@@ -22,7 +22,7 @@ class GroupCoverageControllerTests : MontaguTests()
     {
         val repo = makeRepoMockingGetCoverageSets(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        GroupCoverageController(context, repo).getCoverageSets()
+        CoverageController(context, repo).getCoverageSetsForGroup()
 
         verify(repo).getCoverageSets(eq("gId"), eq("tId"), eq("sId"))
     }
@@ -33,7 +33,7 @@ class GroupCoverageControllerTests : MontaguTests()
         val repo = makeRepoMockingGetCoverageSets(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(false)
         Assertions.assertThatThrownBy {
-            GroupCoverageController(context, repo).getCoverageSets()
+            CoverageController(context, repo).getCoverageSetsForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -42,7 +42,7 @@ class GroupCoverageControllerTests : MontaguTests()
     {
         val repo = makeRepoMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        GroupCoverageController(context, repo).getCoverageData()
+        CoverageController(context, repo).getCoverageDataForGroup()
         verify(repo).getCoverageData(eq("gId"), eq("tId"), eq("sId"))
     }
 
@@ -58,8 +58,8 @@ class GroupCoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = GroupCoverageController(context, repo)
-                .getCoverageData().data
+        val data = CoverageController(context, repo)
+                .getCoverageDataForGroup().data
         Assertions.assertThat(data.first() is LongCoverageRow).isTrue()
     }
 
@@ -69,8 +69,8 @@ class GroupCoverageControllerTests : MontaguTests()
         val repo = makeRepoMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
 
-        val data = GroupCoverageController(context, repo)
-                .getCoverageData().data
+        val data = CoverageController(context, repo)
+                .getCoverageDataForGroup().data
 
         // test data includes 5 years
         // there are 7 other variable properties, test data includes 2 of each
@@ -98,8 +98,8 @@ class GroupCoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = GroupCoverageController(context, repo)
-                .getCoverageData().data
+        val data = CoverageController(context, repo)
+                .getCoverageDataForGroup().data
 
         Assertions.assertThat(data.first() is WideCoverageRow).isTrue()
 
@@ -136,8 +136,8 @@ class GroupCoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = GroupCoverageController(context, repo)
-                .getCoverageData().data
+        val data = CoverageController(context, repo)
+                .getCoverageDataForGroup().data
 
         Assertions.assertThat(data.count()).isEqualTo(0)
     }
@@ -157,7 +157,7 @@ class GroupCoverageControllerTests : MontaguTests()
         }
 
         Assertions.assertThatThrownBy {
-            GroupCoverageController(context, repo).getCoverageData()
+            CoverageController(context, repo).getCoverageDataForGroup()
         }.isInstanceOf(BadRequest::class.java)
     }
 
@@ -168,7 +168,7 @@ class GroupCoverageControllerTests : MontaguTests()
         val context = mockContextForSpecificResponsibility(false)
 
         Assertions.assertThatThrownBy {
-            GroupCoverageController(context, repo).getCoverageData()
+            CoverageController(context, repo).getCoverageDataForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
@@ -10,7 +10,6 @@ import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
-import org.vaccineimpact.api.app.repositories.SimpleDataSet
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.repositories.inmemory.InMemoryDataSet
 import org.vaccineimpact.api.db.nextDecimal

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
@@ -1,0 +1,179 @@
+package org.vaccineimpact.api.tests.logic
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
+import org.vaccineimpact.api.app.repositories.SimpleDataSet
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.app.repositories.inmemory.InMemoryDataSet
+import org.vaccineimpact.api.db.nextDecimal
+import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.responsibilities.Responsibility
+import org.vaccineimpact.api.models.responsibilities.ResponsibilityAndTouchstone
+import org.vaccineimpact.api.models.responsibilities.ResponsibilityStatus
+import org.vaccineimpact.api.serialization.DataTable
+import org.vaccineimpact.api.serialization.SplitData
+import java.math.BigDecimal
+import java.util.*
+
+class CoverageLogicTests
+{
+    private val fakeScenario = Scenario("sId", "scDesc", "disease", listOf("t-1"))
+    private val touchstoneVersion = TouchstoneVersion("touchstone-1", "touchstone", 1, "open", TouchstoneStatus.OPEN)
+    private fun responsibilityRepo() = mock<ResponsibilitiesRepository> {
+        on { getResponsibility(any(), any(), any()) } doReturn ResponsibilityAndTouchstone(1,
+                Responsibility(
+                        fakeScenario,
+                        ResponsibilityStatus.EMPTY, emptyList(), null
+                ),
+                touchstoneVersion)
+    }
+
+    private fun mockCoverageSetsData() = ScenarioAndCoverageSets(
+            fakeScenario,
+            listOf(
+                    CoverageSet(1, "tId", "name", "vaccine", GAVISupportLevel.WITH, ActivityType.CAMPAIGN)
+            )
+    )
+
+    private fun touchstoneRepo(
+            testYear: Int = 1970,
+            target: BigDecimal = BigDecimal(123.123),
+            coverage: BigDecimal = BigDecimal(456.456)): TouchstoneRepository
+    {
+        val coverageSets = mockCoverageSetsData()
+        val fakeRows = generateCoverageRows(testYear, target, coverage)
+        val data = SplitData(coverageSets, DataTable.new(fakeRows.asSequence()))
+        return mock {
+            on { getScenarioAndCoverageData(any(), any()) } doReturn data
+            on { touchstoneVersions } doReturn InMemoryDataSet(listOf(touchstoneVersion))
+        }
+    }
+
+    @Test
+    fun `getCoverageDataForGroup throws error if supplied format param is invalid`()
+    {
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+
+        Assertions.assertThatThrownBy {
+            sut.getCoverageDataForGroup("gId", "tId", "s1", "bad-format")
+        }.isInstanceOf(BadRequest::class.java)
+    }
+
+    @Test
+    fun `getCoverageDataForGroup checks groups exists`()
+    {
+        val groupRepo = mock<ModellingGroupRepository>()
+        val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo())
+
+        sut.getCoverageDataForGroup("gId", "tId", "s1", null)
+        verify(groupRepo).getModellingGroup("gId")
+    }
+
+    @Test
+    fun `getCoverageDataForGroup gets responsibility for group`()
+    {
+        val repo = responsibilityRepo()
+        val sut = RepositoriesCoverageLogic(mock(), repo, touchstoneRepo())
+
+        sut.getCoverageDataForGroup("gId", "tId", "s1", null)
+        verify(repo).getResponsibility("gId", "tId", "s1")
+    }
+
+    @Test
+    fun `can getCoverageData`()
+    {
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+        sut.getCoverageData("touchstone-1", "s1", null)
+    }
+
+    @Test
+    fun `getCoverageDataForGroup returns wide format if format=wide`()
+    {
+        val testYear = 1970
+        val testTarget = BigDecimal(123.123)
+        val testCoverage = BigDecimal(456.456)
+
+        val data = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+                .getCoverageDataForGroup("gId", "tId", "s1", "wide").data
+
+        Assertions.assertThat(data.first() is WideCoverageRow).isTrue()
+
+        // there are 7 variable properties, test data includes 2 of each
+        val expectedRowCount = Math.pow(2.toDouble(), 7.toDouble())
+        Assertions.assertThat(data.count()).isEqualTo(expectedRowCount.toInt())
+
+        val expectedHeaders = listOf("target_$testYear", "coverage_$testYear",
+                "coverage_1985", "coverage_1990", "coverage_1995", "coverage_2000",
+                "target_1985", "target_1990", "target_1995", "target_2000")
+
+        val firstRow = (data.first() as WideCoverageRow)
+        val headers = firstRow.coverageAndTargetPerYear.keys
+
+        Assertions.assertThat(headers).hasSameElementsAs(expectedHeaders)
+        Assertions.assertThat(firstRow.coverageAndTargetPerYear["target_$testYear"] == testTarget)
+        Assertions.assertThat(firstRow.coverageAndTargetPerYear["coverage_$testYear"] == testCoverage)
+    }
+
+    private val years = listOf(1985, 1990, 1995, 2000)
+
+    private val random = Random(0)
+
+    private fun generateCoverageRows(testYear: Int, target: BigDecimal, coverage: BigDecimal): List<LongCoverageRow>
+    {
+        val countries = listOf("ABC", "DEF")
+        val setNames = listOf("set1", "set2")
+        val vaccines = listOf("vaccine1", "vaccine2")
+        val supportLevels = listOf(GAVISupportLevel.WITHOUT, GAVISupportLevel.WITH)
+        val ageFroms = listOf(BigDecimal.ZERO, BigDecimal(5))
+        val ageTos = listOf(BigDecimal.TEN, BigDecimal(5))
+        val activityTypes = listOf(ActivityType.CAMPAIGN, ActivityType.NONE)
+
+        val listToReturn = mutableListOf<LongCoverageRow>()
+
+        for (country in countries)
+        {
+            for (set in setNames)
+            {
+                for (vaccine in vaccines)
+                {
+                    for (support in supportLevels)
+                    {
+                        for (ageFrom in ageFroms)
+                        {
+                            for (ageTo in ageTos)
+                            {
+                                for (activity in activityTypes)
+                                {
+                                    for (year in years)
+                                    {
+                                        listToReturn.add(LongCoverageRow("sId", set, vaccine, support, activity,
+                                                country, "$country-Name", year, ageFrom, ageTo, "$ageFrom-$ageTo",
+                                                random.nextDecimal(1000, 10000, numberOfDecimalPlaces = 2),
+                                                random.nextDecimal(1000, 10000, numberOfDecimalPlaces = 2)))
+                                    }
+
+                                    listToReturn.add(LongCoverageRow("sId", set, vaccine, support, activity,
+                                            country, "$country-Name", testYear, ageFrom, ageTo, "$ageFrom-$ageTo",
+                                            target,
+                                            coverage))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // sort these randomly to emulate how they come out of the db
+        return listToReturn.sortedBy { random.nextInt() }
+    }
+
+}


### PR DESCRIPTION
This PR introduces a `CoverageLogic` class that pulls the logic out of the controller, and a bit of refactoring so that it can be shared between retrieving coverage sets for a particular group and for retrieving coverage sets more generally.

This add the logic for getting coverage sets without a group id, but one more PR needed to add the new endpoint itself.