### PR TITLE
Don't return access control allow credentials for logins, or on failure

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Endpoint.kt
@@ -24,7 +24,8 @@ data class Endpoint(
         override val method: HttpMethod = HttpMethod.get,
         override val postProcess: ResultProcessor = ::passThrough,
         override val requiredPermissions: List<PermissionRequirement> = listOf(),
-        override val basicAuth: Boolean = false
+        override val basicAuth: Boolean = false,
+        override val accessControlAllowCredentials: Boolean = true
 
 ) : EndpointDefinition
 {
@@ -47,7 +48,11 @@ data class Endpoint(
             setupSecurity(url, repositoryFactory)
         }
 
-        Spark.after(url, contentType, DefaultHeadersFilter("$contentType; charset=utf-8", method))
+        Spark.after(url, contentType, DefaultHeadersFilter(
+                "$contentType; charset=utf-8",
+                method,
+                accessControlAllowCredentials
+        ))
     }
 
     private fun addSecurityFilter(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
@@ -109,6 +114,11 @@ fun Endpoint.csv(): Endpoint
 fun Endpoint.basicAuth(): Endpoint
 {
     return this.copy(basicAuth = true)
+}
+
+fun Endpoint.disableCookies(): Endpoint
+{
+    return this.copy(accessControlAllowCredentials = false)
 }
 
 fun Endpoint.post(): Endpoint

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/EndpointDefinition.kt
@@ -19,6 +19,7 @@ interface EndpointDefinition
     val postProcess: ResultProcessor
     val requiredPermissions: List<PermissionRequirement>
     val basicAuth: Boolean
+    val accessControlAllowCredentials: Boolean
 
     fun additionalSetup(url: String, webTokenHelper: WebTokenHelper, repositoryFactory: RepositoryFactory)
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/AuthenticationRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/AuthenticationRouteConfig.kt
@@ -11,7 +11,8 @@ object AuthenticationRouteConfig : RouteConfig
     override val endpoints: List<EndpointDefinition> = listOf(
             Endpoint("/authenticate/", controller, "authenticate", method = HttpMethod.post)
                     .json()
-                    .basicAuth(),
+                    .basicAuth()
+                    .disableCookies(),
             Endpoint("/set-cookies/", controller, "setCookies")
                     .secure()
                     .json(),

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/MontaguHttpActionAdapter.kt
@@ -22,7 +22,7 @@ abstract class MontaguHttpActionAdapter(private val repositoryFactory: Repositor
 
     protected fun haltWithError(code: Int, context: SparkWebContext, response: String)
     {
-        addDefaultResponseHeaders(context.sparkRequest, context.response)
+        addDefaultResponseHeaders(context.sparkRequest, context.response, accessControlAllowCredentials = false)
         spark.Spark.halt(code, response)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/DefaultHeadersFilterTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/DefaultHeadersFilterTests.kt
@@ -16,7 +16,7 @@ class DefaultHeadersFilterTests : MontaguTests()
     @Test
     fun `filter sets content type`()
     {
-        val filter = DefaultHeadersFilter(contentType, HttpMethod.get)
+        val filter = DefaultHeadersFilter(contentType, HttpMethod.get, true)
         val mockResponse = filter.handleMockRequest(HttpMethod.get)
         verify(mockResponse).contentType = contentType
     }
@@ -24,15 +24,16 @@ class DefaultHeadersFilterTests : MontaguTests()
     @Test
     fun `filter sets headers`()
     {
-        val filter = DefaultHeadersFilter(contentType, HttpMethod.get)
+        val filter = DefaultHeadersFilter(contentType, HttpMethod.get, true)
         val mockResponse = filter.handleMockRequest(HttpMethod.get)
         verify(mockResponse).addHeader("Content-Encoding", "gzip")
+        verify(mockResponse).addHeader("Access-Control-Allow-Credentials", "true")
     }
 
     @Test
     fun `filter doesn't set gzip header if request does not accept it`()
     {
-        val filter = DefaultHeadersFilter(contentType, HttpMethod.get)
+        val filter = DefaultHeadersFilter(contentType, HttpMethod.get, true)
         val mockResponse = filter.handleMockRequest(HttpMethod.get, false)
         verify(mockResponse, never()).addHeader("Content-Encoding", "gzip")
     }
@@ -40,9 +41,18 @@ class DefaultHeadersFilterTests : MontaguTests()
     @Test
     fun `filter is not applied if method does not match`()
     {
-        val filter = DefaultHeadersFilter(contentType, HttpMethod.get)
+        val filter = DefaultHeadersFilter(contentType, HttpMethod.get, true)
         val mockResponse = filter.handleMockRequest(HttpMethod.post)
         verifyZeroInteractions(mockResponse)
+    }
+
+    @Test
+    fun `filter does not set allow credentials header if told not to`()
+    {
+        val filter = DefaultHeadersFilter(contentType, HttpMethod.get, false)
+        val mockResponse = filter.handleMockRequest(HttpMethod.get)
+        verify(mockResponse).addHeader("Content-Encoding", "gzip")
+        verify(mockResponse, never()).addHeader("Access-Control-Allow-Credentials", "true")
     }
 
     private fun DefaultHeadersFilter.handleMockRequest(requestMethod: HttpMethod, gzip: Boolean = true): HttpServletResponse


### PR DESCRIPTION
This turns out not to be needed, adding a PR and closing it so we remember