### PR TITLE
I2216 - burden estimate upload hangs on duplicate rows

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/burdenestimates/BurdenEstimateWriter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/burdenestimates/BurdenEstimateWriter.kt
@@ -214,6 +214,7 @@ abstract class BurdenEstimateWriter(
             }
             catch (e: Exception)
             {
+                inputStream.close()
                 e
             }
         })

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -195,6 +195,12 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         }
         val token = TestUserHelper.getToken(requiredWritePermissions, includeCanLogin = true)
         val helper = RequestHelper()
+        val longDuplicateData = duplicateCsvData + (1..10000).map {
+            """
+                |"Hib3",   1997,    50,     "AGO",       "Angola",          6000,     1200,      NA,    5870
+                |""".trimMargin()
+        }.joinToString("")
+
         val response = helper.post("$setUrl/$setId/", duplicateCsvData, token = token)
         JSONValidator()
                 .validateError(response.text, "duplicate-key:burden_estimate_set,country,year,age,burden_outcome")

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -201,7 +201,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
                 |""".trimMargin()
         }.joinToString("")
 
-        val response = helper.post("$setUrl/$setId/", duplicateCsvData, token = token)
+        val response = helper.post("$setUrl/$setId/", longDuplicateData, token = token)
         JSONValidator()
                 .validateError(response.text, "duplicate-key:burden_estimate_set,country,year,age,burden_outcome")
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -163,7 +163,10 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
         val setId = withDatabase {
             setupDatabaseWithBurdenEstimateSet(it)
         }
-        val estimates = sequenceOf(estimateObject(), estimateObject())
+        val estimates = (1..10000).map {
+            estimateObject()
+        }.asSequence()
+
         withRepo { repo ->
             assertThatThrownBy {
                 repo.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, estimates)


### PR DESCRIPTION
With larger file sizes the buffer on the input stream was filled up, causing the main thread to block and the function to never return. Manually closing the stream on an exception in the other thread causes the function to return as we want.