### PR TITLE
I2257 - only serve coverage data for expected countries

### DIFF
--- a/docs/spec/Coverage.md
+++ b/docs/spec/Coverage.md
@@ -46,6 +46,8 @@ Schema: [`ScenarioAndCoverageSets.schema.json`](../schemas/ScenarioAndCoverageSe
 
 ## GET /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/coverage/
 Returns the amalgamated coverage data of all the coverage sets associated with this responsibility.
+By default we only return coverage data for countries that we expect this group to provide burden estimates for, 
+but this can be overriden by setting the query parameter `all-countries=true`.
 
 Required permissions: Global scope: `scenarios.read`. Scoped to modelling group: `responsibilities.read` and `coverage.read`.  Additionally, to view coverage data for an `in-preparation` touchstone, the user needs the `touchstones.prepare` permission.
 
@@ -135,9 +137,15 @@ Example wide format:
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campaign",   "AFG",    0,         2,                    NA,                      NA,            87.5,          93.4             98.2
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campign",    "AFG",    0,         1,                    NA,                      NA,            88.5,          90.6             98.1
     
-    
+  
+### all-countries
+Optional. By default we only serve coverage data for those countries that we expect burden estimates for. Passing 
+`all-countries=true` returns coverage data for all countries.
+
 ## GET /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/coverage/csv/
-Returns the amalgamated coverage data of all the coverage sets associated with this responsibility in csv format.
+Returns the amalgamated coverage data of all the coverage sets associated with this responsibility in csv format. 
+By default we only return coverage data for countries that we expect this group to provide burden estimates for, 
+but this can be overriden by setting the query parameter `all-countries=true`.
 
 Required permissions: Global scope: `scenarios.read`. Scoped to modelling group: `responsibilities.read` and `coverage.read`.  Additionally, to view coverage data for an `in-preparation` touchstone, the user needs the `touchstones.prepare` permission.
 
@@ -181,6 +189,9 @@ Example wide format:
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campaign",   "AFG",    0,         2,                    NA,                      NA,            87.5,          93.4             98.2
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campign",    "AFG",    0,         1,                    NA,                      NA,            88.5,          90.6             98.1
     
+### all-countries
+Optional. By default we only return coverage data for countries that we expect this group to provide
+ burden estimates for. Passing `all-countries=true` returns coverage data for all countries.
         
 ## GET /touchstones/{touchstone-id}/{scenario-id}/coverage/
 Returns the amalgamated coverage data of all the coverage sets associated with this scenario.

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -53,8 +53,9 @@ class CoverageController(
     {
         val path = ResponsibilityPath(context)
         val format = context.queryParams("format")
+        val allCountries = context.queryParams("all-countries")?.toBoolean()?: false
         val splitData = coverageLogic.getCoverageDataForGroup(path.groupId,
-                path.touchstoneVersionId, path.scenarioId, format = format, filterToExpectations = false)
+                path.touchstoneVersionId, path.scenarioId, format = format, allCountries = allCountries)
         context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, splitData.structuredMetadata.touchstoneVersion.status)
         return splitData
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -54,7 +54,7 @@ class CoverageController(
         val path = ResponsibilityPath(context)
         val format = context.queryParams("format")
         val splitData = coverageLogic.getCoverageDataForGroup(path.groupId,
-                path.touchstoneVersionId, path.scenarioId, format)
+                path.touchstoneVersionId, path.scenarioId, format = format, filterToExpectations = false)
         context.checkIsAllowedToSeeTouchstone(path.touchstoneVersionId, splitData.structuredMetadata.touchstoneVersion.status)
         return splitData
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -1,14 +1,14 @@
 package org.vaccineimpact.api.app.logic
 
 import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.models.CoverageRow
-import org.vaccineimpact.api.models.LongCoverageRow
-import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
-import org.vaccineimpact.api.models.WideCoverageRow
+import org.vaccineimpact.api.db.Tables
+import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.serialization.DataTable
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import org.vaccineimpact.api.serialization.SplitData
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -18,7 +18,7 @@ interface CoverageLogic
             : SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>
 
     fun getCoverageDataForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String,
-                                filterToExpectations: Boolean, format: String?)
+                                allCountries: Boolean, format: String?)
             : SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>
 
     fun getCoverageSetsForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String):
@@ -49,23 +49,23 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
             repositories.touchstone)
 
     override fun getCoverageDataForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String,
-                                         filterToExpectations: Boolean, format: String?)
+                                         allCountries: Boolean, format: String?)
             : SplitData<ScenarioTouchstoneAndCoverageSets, CoverageRow>
     {
         modellingGroupRepository.getModellingGroup(groupId)
         val responsibilityAndTouchstone =
                 responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
 
-        val scenarioAndData = if (filterToExpectations)
+        val scenarioAndData = if (allCountries)
+        {
+            touchstoneRepository.getScenarioAndCoverageData(touchstoneVersionId, scenarioId)
+        }
+        else
         {
             touchstoneRepository.getScenarioAndCoverageDataForResponsibility(
                     responsibilityAndTouchstone.responsibilityId,
                     touchstoneVersionId,
                     scenarioId)
-        }
-        else
-        {
-            touchstoneRepository.getScenarioAndCoverageData(touchstoneVersionId, scenarioId)
         }
 
         val splitData = SplitData(ScenarioTouchstoneAndCoverageSets(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -1,14 +1,10 @@
 package org.vaccineimpact.api.app.logic
 
 import org.vaccineimpact.api.app.errors.BadRequest
-import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
-import org.vaccineimpact.api.app.repositories.Repositories
-import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
-import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.models.CoverageRow
-import org.vaccineimpact.api.models.LongCoverageRow
-import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
-import org.vaccineimpact.api.models.WideCoverageRow
+import org.vaccineimpact.api.app.repositories.*
+import org.vaccineimpact.api.db.Tables
+import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.serialization.DataTable
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import org.vaccineimpact.api.serialization.SplitData
 
@@ -28,7 +24,8 @@ interface CoverageLogic
 
 class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingGroupRepository,
                                 private val responsibilitiesRepository: ResponsibilitiesRepository,
-                                private val touchstoneRepository: TouchstoneRepository) : CoverageLogic
+                                private val touchstoneRepository: TouchstoneRepository,
+                                private val scenarioRepository: ScenarioRepository) : CoverageLogic
 {
     override fun getCoverageSetsForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String):
             ScenarioTouchstoneAndCoverageSets
@@ -46,7 +43,8 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
 
     constructor(repositories: Repositories) : this(repositories.modellingGroup,
             repositories.responsibilities,
-            repositories.touchstone)
+            repositories.touchstone,
+            repositories.scenario)
 
     override fun getCoverageDataForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String,
                                          allCountries: Boolean, format: String?)
@@ -56,23 +54,31 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
         val responsibilityAndTouchstone =
                 responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
 
-        val scenarioAndData = if (allCountries)
+        val responsibilityId = responsibilityAndTouchstone.responsibilityId
+        val scenario = scenarioRepository.getScenarioForResponsibility(touchstoneVersionId,
+                scenarioId,
+                responsibilityId)
+
+        val coverageSets = touchstoneRepository.getCoverageSetsForScenario(touchstoneVersionId, scenarioId)
+
+        val data = if (allCountries)
         {
-            touchstoneRepository.getScenarioAndCoverageData(touchstoneVersionId, scenarioId)
+            touchstoneRepository.getCoverageDataForScenario(touchstoneVersionId, scenarioId)
+
         }
         else
         {
-            touchstoneRepository.getScenarioAndCoverageDataForResponsibility(
-                    responsibilityAndTouchstone.responsibilityId,
+            touchstoneRepository.getCoverageDataForResponsibility(
                     touchstoneVersionId,
-                    scenarioId)
+                    responsibilityId,
+                    scenario.id)
         }
 
         val splitData = SplitData(ScenarioTouchstoneAndCoverageSets(
                 responsibilityAndTouchstone.touchstoneVersion,
-                scenarioAndData.structuredMetadata.scenario,
-                scenarioAndData.structuredMetadata.coverageSets
-        ), scenarioAndData.tableData)
+                scenario,
+                coverageSets
+        ), DataTable.new(data))
 
         return getDatatable(splitData, format)
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -54,23 +54,18 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
         val responsibilityAndTouchstone =
                 responsibilitiesRepository.getResponsibility(groupId, touchstoneVersionId, scenarioId)
 
-        val responsibilityId = responsibilityAndTouchstone.responsibilityId
-        val scenario = scenarioRepository.getScenarioForResponsibility(touchstoneVersionId,
-                scenarioId,
-                responsibilityId)
-
+        val scenario = scenarioRepository.getScenarioForTouchstone(touchstoneVersionId, scenarioId)
         val coverageSets = touchstoneRepository.getCoverageSetsForScenario(touchstoneVersionId, scenarioId)
 
         val data = if (allCountries)
         {
             touchstoneRepository.getCoverageDataForScenario(touchstoneVersionId, scenarioId)
-
         }
         else
         {
             touchstoneRepository.getCoverageDataForResponsibility(
                     touchstoneVersionId,
-                    responsibilityId,
+                    responsibilityAndTouchstone.responsibilityId,
                     scenario.id)
         }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
@@ -14,4 +14,8 @@ interface ScenarioRepository : Repository
             List<Scenario>
 
     fun getScenarioForTouchstone(touchstoneVersionId: String, scenarioDescriptionId: String): Scenario
+
+    fun getScenarioForResponsibility(touchstoneVersionId: String,
+                                     scenarioDescriptionId: String,
+                                     responsibilityId: Int): Scenario
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
@@ -15,7 +15,4 @@ interface ScenarioRepository : Repository
 
     fun getScenarioForTouchstone(touchstoneVersionId: String, scenarioDescriptionId: String): Scenario
 
-    fun getScenarioForResponsibility(touchstoneVersionId: String,
-                                     scenarioDescriptionId: String,
-                                     responsibilityId: Int): Scenario
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -13,6 +13,8 @@ interface TouchstoneRepository : Repository
     fun getScenariosAndCoverageSets(touchstoneVersionId: String, filterParams: ScenarioFilterParameters): List<ScenarioAndCoverageSets>
     fun getScenarioAndCoverageSets(touchstoneVersionId: String, scenarioDescId: String): ScenarioAndCoverageSets
     fun getScenarioAndCoverageData(touchstoneVersionId: String, scenarioDescId: String): SplitData<ScenarioAndCoverageSets, LongCoverageRow>
+    fun getScenarioAndCoverageDataForResponsibility(responsibilityId:Int, touchstoneVersionId: String, scenarioDescId: String): SplitData<ScenarioAndCoverageSets, LongCoverageRow>
+
     fun getDemographicDatasets(touchstoneVersionId: String): List<DemographicDataset>
     fun getDemographicData(statisticTypeCode: String, source: String, touchstoneVersionId: String, gender: String = "both"): SplitData<DemographicDataForTouchstone, LongDemographicRow>
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.api.app.repositories
 
 import org.jooq.Record
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
+import org.vaccineimpact.api.db.tables.Coverage
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.SplitData
 
@@ -13,7 +14,22 @@ interface TouchstoneRepository : Repository
     fun getScenariosAndCoverageSets(touchstoneVersionId: String, filterParams: ScenarioFilterParameters): List<ScenarioAndCoverageSets>
     fun getScenarioAndCoverageSets(touchstoneVersionId: String, scenarioDescId: String): ScenarioAndCoverageSets
     fun getScenarioAndCoverageData(touchstoneVersionId: String, scenarioDescId: String): SplitData<ScenarioAndCoverageSets, LongCoverageRow>
-    fun getScenarioAndCoverageDataForResponsibility(responsibilityId:Int, touchstoneVersionId: String, scenarioDescId: String): SplitData<ScenarioAndCoverageSets, LongCoverageRow>
+
+    fun getCoverageDataForResponsibility(
+            touchstoneVersionId: String,
+            responsibilityId: Int,
+            scenarioDescriptionId: String
+    ): Sequence<LongCoverageRow>
+
+    fun getCoverageDataForScenario(
+            touchstoneVersionId: String,
+            scenarioDescriptionId: String
+    ): Sequence<LongCoverageRow>
+
+    fun getCoverageSetsForScenario(
+            touchstoneVersionId: String,
+            scenarioDescriptionId: String)
+            : List<CoverageSet>
 
     fun getDemographicDatasets(touchstoneVersionId: String): List<DemographicDataset>
     fun getDemographicData(statisticTypeCode: String, source: String, touchstoneVersionId: String, gender: String = "both"): SplitData<DemographicDataForTouchstone, LongDemographicRow>

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
@@ -73,6 +73,30 @@ class JooqScenarioRepository(dsl: DSLContext,
                 .where(SCENARIO.SCENARIO_DESCRIPTION.eq(scenarioDescriptionId))
                 .fetch()
 
+        if (!scenarios.any())
+        {
+            throw UnknownObjectError(scenarioDescriptionId, "scenario")
+        }
+
+        val scenario = mapScenario(scenarios)
+
+        if (!scenario.touchstones.contains(touchstoneVersionId))
+            throw UnknownObjectError(scenarioDescriptionId, "scenario")
+
+        return scenario
+    }
+
+    override fun getScenarioForResponsibility(touchstoneVersionId: String,
+                                              scenarioDescriptionId: String,
+                                              responsibilityId: Int): Scenario
+    {
+        val scenarios = dsl.select(SCENARIO_DESCRIPTION.fieldsAsList())
+                .select(SCENARIO.TOUCHSTONE)
+                .fromJoinPath(SCENARIO_DESCRIPTION, SCENARIO, RESPONSIBILITY)
+                .where(RESPONSIBILITY.ID.eq(responsibilityId))
+                .and(SCENARIO.SCENARIO_DESCRIPTION.eq(scenarioDescriptionId))
+                .fetch()
+
         val scenario = mapScenario(scenarios)
 
         if (!scenario.touchstones.contains(touchstoneVersionId))

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioRepository.kt
@@ -86,25 +86,6 @@ class JooqScenarioRepository(dsl: DSLContext,
         return scenario
     }
 
-    override fun getScenarioForResponsibility(touchstoneVersionId: String,
-                                              scenarioDescriptionId: String,
-                                              responsibilityId: Int): Scenario
-    {
-        val scenarios = dsl.select(SCENARIO_DESCRIPTION.fieldsAsList())
-                .select(SCENARIO.TOUCHSTONE)
-                .fromJoinPath(SCENARIO_DESCRIPTION, SCENARIO, RESPONSIBILITY)
-                .where(RESPONSIBILITY.ID.eq(responsibilityId))
-                .and(SCENARIO.SCENARIO_DESCRIPTION.eq(scenarioDescriptionId))
-                .fetch()
-
-        val scenario = mapScenario(scenarios)
-
-        if (!scenario.touchstones.contains(touchstoneVersionId))
-            throw UnknownObjectError(scenarioDescriptionId, "scenario")
-
-        return scenario
-    }
-
     private fun mapScenarioWithFocalActivityType(input: List<Record>): ScenarioAndFocalActivityType
     {
         val first = input.first()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -203,15 +203,14 @@ class JooqTouchstoneRepository(
                 .select(TOUCHSTONE.ID)
                 .select(COVERAGE.fieldsAsList())
                 .select(COUNTRY.ID, COUNTRY.NAME)
-                .fromJoinPath(TOUCHSTONE, SCENARIO, RESPONSIBILITY)
+                .fromJoinPath(TOUCHSTONE, SCENARIO)
                 .joinPath(SCENARIO, SCENARIO_DESCRIPTION)
                 // We don't mind if there are no coverage sets, so do a left join
                 .joinPath(SCENARIO, SCENARIO_COVERAGE_SET, COVERAGE_SET, joinType = JoinType.LEFT_OUTER_JOIN)
                 .joinPath(COVERAGE_SET, COVERAGE, joinType = JoinType.LEFT_OUTER_JOIN)
                 .joinPath(COVERAGE, COUNTRY, joinType = JoinType.LEFT_OUTER_JOIN)
                 .where(TOUCHSTONE.ID.eq(touchstoneVersionId))
-                .and(RESPONSIBILITY.ID.eq(responsibilityId))
-                .and(COUNTRY.ID.`in`(expectedCountries))
+                .and(COUNTRY.ID.isNull.or(COUNTRY.ID.`in`(expectedCountries)))
                 .orderBy(COVERAGE_SET.VACCINE, COVERAGE_SET.ACTIVITY_TYPE,
                         COVERAGE.COUNTRY, COVERAGE.YEAR, COVERAGE.AGE_FROM, COVERAGE.AGE_TO)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -185,7 +185,7 @@ class JooqTouchstoneRepository(
                 .joinPath(SCENARIO, SCENARIO_COVERAGE_SET, COVERAGE_SET)
                 .where(TOUCHSTONE.ID.eq(touchstoneVersionId))
                 .and(SCENARIO.SCENARIO_DESCRIPTION.eq(scenarioDescriptionId))
-                .orderBy(COVERAGE_SET.VACCINE, COVERAGE_SET.ACTIVITY_TYPE)
+                .orderBy(SCENARIO_COVERAGE_SET.ORDER)
                 .fetch()
 
         return records.map { mapCoverageSet(it) }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -203,13 +203,14 @@ class JooqTouchstoneRepository(
                 .select(TOUCHSTONE.ID)
                 .select(COVERAGE.fieldsAsList())
                 .select(COUNTRY.ID, COUNTRY.NAME)
-                .fromJoinPath(TOUCHSTONE, SCENARIO)
+                .fromJoinPath(TOUCHSTONE, SCENARIO, RESPONSIBILITY)
                 .joinPath(SCENARIO, SCENARIO_DESCRIPTION)
                 // We don't mind if there are no coverage sets, so do a left join
                 .joinPath(SCENARIO, SCENARIO_COVERAGE_SET, COVERAGE_SET, joinType = JoinType.LEFT_OUTER_JOIN)
                 .joinPath(COVERAGE_SET, COVERAGE, joinType = JoinType.LEFT_OUTER_JOIN)
                 .joinPath(COVERAGE, COUNTRY, joinType = JoinType.LEFT_OUTER_JOIN)
                 .where(TOUCHSTONE.ID.eq(touchstoneVersionId))
+                .and(RESPONSIBILITY.ID.eq(responsibilityId))
                 .and(COUNTRY.ID.isNull.or(COUNTRY.ID.`in`(expectedCountries)))
                 .orderBy(COVERAGE_SET.VACCINE, COVERAGE_SET.ACTIVITY_TYPE,
                         COVERAGE.COUNTRY, COVERAGE.YEAR, COVERAGE.AGE_FROM, COVERAGE.AGE_TO)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/CoverageControllerTests.kt
@@ -63,6 +63,56 @@ class CoverageControllerTests : MontaguTests()
     }
 
     @Test
+    fun `getCoverageDataForGroup returns data for all countries if all-countries=true`()
+    {
+        val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
+        val context = mock<ActionContext> {
+            on { it.params(":group-id") } doReturn "gId"
+            on { it.params(":touchstone-version-id") } doReturn "tId"
+            on { it.params(":scenario-id") } doReturn "sId"
+            on { it.queryParams("all-countries") } doReturn "true"
+            on { hasPermission(any()) } doReturn true
+        }
+
+        CoverageController(context, logic)
+                .getCoverageDataForGroup().data
+        verify(logic).getCoverageDataForGroup("gId", "tId", "sId", true, null)
+    }
+
+    @Test
+    fun `getCoverageDataForGroup does not return data for all countries if all-countries=false`()
+    {
+        val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
+        val context = mock<ActionContext> {
+            on { it.params(":group-id") } doReturn "gId"
+            on { it.params(":touchstone-version-id") } doReturn "tId"
+            on { it.params(":scenario-id") } doReturn "sId"
+            on { it.queryParams("all-countries") } doReturn "false"
+            on { hasPermission(any()) } doReturn true
+        }
+
+        CoverageController(context, logic)
+                .getCoverageDataForGroup().data
+        verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
+    }
+
+    @Test
+    fun `getCoverageDataForGroup does not return data for all countries by default`()
+    {
+        val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
+        val context = mock<ActionContext> {
+            on { it.params(":group-id") } doReturn "gId"
+            on { it.params(":touchstone-version-id") } doReturn "tId"
+            on { it.params(":scenario-id") } doReturn "sId"
+            on { hasPermission(any()) } doReturn true
+        }
+
+        CoverageController(context, logic)
+                .getCoverageDataForGroup().data
+        verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
+    }
+
+    @Test
     fun `getCoverageDataForGroup returns long format as default`()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/CoverageControllerTests.kt
@@ -5,9 +5,7 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.CoverageController
-import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.logic.CoverageLogic
-import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.db.nextDecimal
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTable
@@ -44,7 +42,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
         CoverageController(context, logic).getCoverageDataForGroup()
-        verify(logic).getCoverageDataForGroup(eq("gId"), eq("tId"), eq("sId"), isNull())
+        verify(logic).getCoverageDataForGroup(eq("gId"), eq("tId"), eq("sId"), eq(false), isNull())
     }
 
     @Test
@@ -87,7 +85,7 @@ class CoverageControllerTests : MontaguTests()
         val coverageSets = mockCoverageSetsData(TouchstoneStatus.IN_PREPARATION)
         val splitData = SplitData(coverageSets, DataTable.new(listOf<LongCoverageRow>().asSequence()))
         val logic = mock<CoverageLogic> {
-            on { getCoverageDataForGroup(any(), any(), any(), anyOrNull()) } doReturn splitData
+            on { getCoverageDataForGroup(any(), any(), any(), any(), anyOrNull()) } doReturn splitData
         }
 
         val context = mock<ActionContext> {
@@ -128,15 +126,15 @@ class CoverageControllerTests : MontaguTests()
     }
 
     private fun makeLogicMockingGetCoverageData(status: TouchstoneStatus,
-                                               testYear: Int = 1970,
-                                               target: BigDecimal = BigDecimal(123.123),
-                                               coverage: BigDecimal = BigDecimal(456.456)): CoverageLogic
+                                                testYear: Int = 1970,
+                                                target: BigDecimal = BigDecimal(123.123),
+                                                coverage: BigDecimal = BigDecimal(456.456)): CoverageLogic
     {
         val coverageSets = mockCoverageSetsData(status)
         val fakeRows = generateCoverageRows(testYear, target, coverage)
         val data = SplitData(coverageSets, DataTable.new(fakeRows.asSequence()))
         return mock {
-            on { getCoverageDataForGroup(any(), any(), any(), anyOrNull()) } doReturn data
+            on { getCoverageDataForGroup(any(), any(), any(), any(), anyOrNull()) } doReturn data
             on { getCoverageSetsForGroup(any(), any(), any()) } doReturn mockCoverageSetsData(status)
         }
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
@@ -57,7 +57,7 @@ class CoverageLogicTests : MontaguTests()
             on { getScenarioAndCoverageData(any(), any()) } doReturn data
             on { touchstoneVersions } doReturn InMemoryDataSet(listOf(fakeTouchstoneVersion))
             on { getScenarioAndCoverageSets(any(), any()) } doReturn mockCoverageSetsData()
-            on { getScenarioAndCoverageDataForResponsibility(any(), any(), any())} doReturn data
+            on { getCoverageDataForResponsibility(any(), any(), any())} doReturn fakeRows.asSequence()
         }
     }
 
@@ -65,17 +65,17 @@ class CoverageLogicTests : MontaguTests()
     fun `getCoverageDataForGroup gets coverage for responsibility if allCountries is false`()
     {
         val touchstoneRepo = touchstoneRepo()
-        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo, mock())
 
         sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = false)
-        verify(touchstoneRepo).getScenarioAndCoverageDataForResponsibility(1, "tId", "s1")
+        verify(touchstoneRepo).getCoverageDataForResponsibility("tId", 1, any())
     }
 
     @Test
     fun `getCoverageDataForGroup gets general coverage data if allCountries is true`()
     {
         val touchstoneRepo = touchstoneRepo()
-        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo, mock())
 
         sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(touchstoneRepo).getScenarioAndCoverageData("tId", "s1")
@@ -84,7 +84,7 @@ class CoverageLogicTests : MontaguTests()
     @Test
     fun `getCoverageDataForGroup throws error if supplied format param is invalid`()
     {
-        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo(), mock())
 
         Assertions.assertThatThrownBy {
             sut.getCoverageDataForGroup("gId", "tId", "s1", format = "bad-format", allCountries = true)
@@ -95,7 +95,7 @@ class CoverageLogicTests : MontaguTests()
     fun `getCoverageDataForGroup checks groups exists`()
     {
         val groupRepo = mock<ModellingGroupRepository>()
-        val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo(), mock())
 
         sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(groupRepo).getModellingGroup("gId")
@@ -105,7 +105,7 @@ class CoverageLogicTests : MontaguTests()
     fun `getCoverageDataForGroup gets responsibility for group`()
     {
         val repo = responsibilityRepo()
-        val sut = RepositoriesCoverageLogic(mock(), repo, touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(mock(), repo, touchstoneRepo(), mock())
 
         sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(repo).getResponsibility("gId", "tId", "s1")
@@ -114,7 +114,7 @@ class CoverageLogicTests : MontaguTests()
     @Test
     fun `can getCoverageData`()
     {
-        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo(), mock())
         sut.getCoverageData("touchstone-1", "s1", null)
     }
 
@@ -125,7 +125,7 @@ class CoverageLogicTests : MontaguTests()
         val testTarget = BigDecimal(123.123)
         val testCoverage = BigDecimal(456.456)
 
-        val data = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+        val data = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo(), mock())
                 .getCoverageDataForGroup("gId", "tId", "s1", format = "wide", allCountries = true).data
 
         Assertions.assertThat(data.first() is WideCoverageRow).isTrue()
@@ -150,7 +150,7 @@ class CoverageLogicTests : MontaguTests()
     fun `getCoverageSetsForGroup checks responsibility for group exists`()
     {
         val responsibilitiesRepository = responsibilityRepo()
-        val sut = RepositoriesCoverageLogic(mock(), responsibilitiesRepository, touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(mock(), responsibilitiesRepository, touchstoneRepo(), mock())
 
         sut.getCoverageSetsForGroup("gId", "tId", "s1")
         verify(responsibilitiesRepository).getResponsibility("gId", "tId", "s1")
@@ -160,7 +160,7 @@ class CoverageLogicTests : MontaguTests()
     fun `getCoverageSetsForGroup checks group exists`()
     {
         val groupRepo = mock<ModellingGroupRepository>()
-        val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo(), mock())
 
         sut.getCoverageSetsForGroup("gId", "tId", "s1")
         verify(groupRepo).getModellingGroup("gId")
@@ -169,7 +169,7 @@ class CoverageLogicTests : MontaguTests()
     @Test
     fun `can get coverage sets for group`()
     {
-        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo(), mock())
 
         val result = sut.getCoverageSetsForGroup("gId", "tId", "s1")
         checkMetadataIsAsExpected(result)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
@@ -57,7 +57,28 @@ class CoverageLogicTests : MontaguTests()
             on { getScenarioAndCoverageData(any(), any()) } doReturn data
             on { touchstoneVersions } doReturn InMemoryDataSet(listOf(fakeTouchstoneVersion))
             on { getScenarioAndCoverageSets(any(), any()) } doReturn mockCoverageSetsData()
+            on { getScenarioAndCoverageDataForResponsibility(any(), any(), any())} doReturn data
         }
+    }
+
+    @Test
+    fun `getCoverageDataForGroup gets coverage for responsibility if filterToExpectations is true`()
+    {
+        val touchstoneRepo = touchstoneRepo()
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
+
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = true)
+        verify(touchstoneRepo).getScenarioAndCoverageDataForResponsibility(1, "tId", "s1")
+    }
+
+    @Test
+    fun `getCoverageDataForGroup gets general coverage data if filterToExpectations is false`()
+    {
+        val touchstoneRepo = touchstoneRepo()
+        val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
+
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
+        verify(touchstoneRepo).getScenarioAndCoverageData("tId", "s1")
     }
 
     @Test
@@ -66,7 +87,7 @@ class CoverageLogicTests : MontaguTests()
         val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
 
         Assertions.assertThatThrownBy {
-            sut.getCoverageDataForGroup("gId", "tId", "s1", "bad-format")
+            sut.getCoverageDataForGroup("gId", "tId", "s1", format = "bad-format", filterToExpectations = false)
         }.isInstanceOf(BadRequest::class.java)
     }
 
@@ -76,7 +97,7 @@ class CoverageLogicTests : MontaguTests()
         val groupRepo = mock<ModellingGroupRepository>()
         val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo())
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", null)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
         verify(groupRepo).getModellingGroup("gId")
     }
 
@@ -86,7 +107,7 @@ class CoverageLogicTests : MontaguTests()
         val repo = responsibilityRepo()
         val sut = RepositoriesCoverageLogic(mock(), repo, touchstoneRepo())
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", null)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
         verify(repo).getResponsibility("gId", "tId", "s1")
     }
 
@@ -105,7 +126,7 @@ class CoverageLogicTests : MontaguTests()
         val testCoverage = BigDecimal(456.456)
 
         val data = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
-                .getCoverageDataForGroup("gId", "tId", "s1", "wide").data
+                .getCoverageDataForGroup("gId", "tId", "s1", format = "wide", filterToExpectations = false).data
 
         Assertions.assertThat(data.first() is WideCoverageRow).isTrue()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogicTests.kt
@@ -62,22 +62,22 @@ class CoverageLogicTests : MontaguTests()
     }
 
     @Test
-    fun `getCoverageDataForGroup gets coverage for responsibility if filterToExpectations is true`()
+    fun `getCoverageDataForGroup gets coverage for responsibility if allCountries is false`()
     {
         val touchstoneRepo = touchstoneRepo()
         val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = true)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = false)
         verify(touchstoneRepo).getScenarioAndCoverageDataForResponsibility(1, "tId", "s1")
     }
 
     @Test
-    fun `getCoverageDataForGroup gets general coverage data if filterToExpectations is false`()
+    fun `getCoverageDataForGroup gets general coverage data if allCountries is true`()
     {
         val touchstoneRepo = touchstoneRepo()
         val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo)
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(touchstoneRepo).getScenarioAndCoverageData("tId", "s1")
     }
 
@@ -87,7 +87,7 @@ class CoverageLogicTests : MontaguTests()
         val sut = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
 
         Assertions.assertThatThrownBy {
-            sut.getCoverageDataForGroup("gId", "tId", "s1", format = "bad-format", filterToExpectations = false)
+            sut.getCoverageDataForGroup("gId", "tId", "s1", format = "bad-format", allCountries = true)
         }.isInstanceOf(BadRequest::class.java)
     }
 
@@ -97,7 +97,7 @@ class CoverageLogicTests : MontaguTests()
         val groupRepo = mock<ModellingGroupRepository>()
         val sut = RepositoriesCoverageLogic(groupRepo, responsibilityRepo(), touchstoneRepo())
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(groupRepo).getModellingGroup("gId")
     }
 
@@ -107,7 +107,7 @@ class CoverageLogicTests : MontaguTests()
         val repo = responsibilityRepo()
         val sut = RepositoriesCoverageLogic(mock(), repo, touchstoneRepo())
 
-        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, filterToExpectations = false)
+        sut.getCoverageDataForGroup("gId", "tId", "s1", format = null, allCountries = true)
         verify(repo).getResponsibility("gId", "tId", "s1")
     }
 
@@ -126,7 +126,7 @@ class CoverageLogicTests : MontaguTests()
         val testCoverage = BigDecimal(456.456)
 
         val data = RepositoriesCoverageLogic(mock(), responsibilityRepo(), touchstoneRepo())
-                .getCoverageDataForGroup("gId", "tId", "s1", format = "wide", filterToExpectations = false).data
+                .getCoverageDataForGroup("gId", "tId", "s1", format = "wide", allCountries = true).data
 
         Assertions.assertThat(data.first() is WideCoverageRow).isTrue()
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/CoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/CoverageTests.kt
@@ -38,7 +38,10 @@ abstract class CoverageTests : DatabaseTest()
         db.addScenarioDescription(scenarioId, "description 1", "disease-1", addDisease = true)
         db.addTouchstoneVersion("touchstone", 1, "description", touchstoneStatus, addTouchstone = true)
         val setId = db.addResponsibilitySet(groupId, touchstoneVersionId, "submitted")
-        db.addResponsibility(setId, touchstoneVersionId, scenarioId)
+        val responsibilityId = db.addResponsibility(setId, touchstoneVersionId, scenarioId)
+
+        db.addExpectationsForAllCountries(responsibilityId)
+
         db.addCoverageSet(touchstoneVersionId, "coverage set name", "vaccine-1", "without", "routine", coverageSetId,
                 addVaccine = true)
         db.addCoverageSetToScenario(scenarioId, touchstoneVersionId, coverageSetId, 0)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -131,7 +131,6 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         }
     }
 
-
     @Test
     fun `can get ordered coverage sets`()
     {
@@ -197,6 +196,28 @@ class GetScenarioTests : TouchstoneRepositoryTests()
             assertThat(result.tableData.data.toList()).isEmpty()
         }
     }
+
+    @Test
+    fun `can get scenario for responsibility with empty coverage data`()
+    {
+        var responsibilityId = 0
+        given {
+            val countries = listOf("AAA", "BBB", "CCC")
+            it.addGroup(groupId)
+            createTouchstoneAndScenarioDescriptions(it)
+            it.addScenarioToTouchstone(touchstoneVersionId, scenarioId)
+            responsibilityId = it.addResponsibilityInNewSet(groupId, touchstoneVersionId, scenarioId)
+            it.addCountries(countries)
+            giveScenarioCoverageSets(it, scenarioId, includeCoverageData = false)
+            it.addExpectations(responsibilityId, countries = countries)
+        } check {
+            val result = it.getScenarioAndCoverageDataForResponsibility(responsibilityId, touchstoneVersionId, scenarioId)
+
+            checkScenarioIsAsExpected(result.structuredMetadata)
+            assertThat(result.tableData.data.toList()).isEmpty()
+        }
+    }
+
 
     private fun checkScenarioIsAsExpected(result: ScenarioAndCoverageSets, extraTouchstones: List<String> = emptyList())
     {

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -98,8 +98,8 @@ class GetScenarioTests : TouchstoneRepositoryTests()
             createTouchstoneAndScenarioDescriptions(it)
             it.addScenarioToTouchstone(touchstoneVersionId, scenarioId)
             responsibilityId = it.addResponsibilityInNewSet(groupId, touchstoneVersionId, scenarioId)
-            it.addExpectations(responsibilityId, countries = countries)
             giveUnorderedCoverageSetsAndDataToScenario(it, countries = countries)
+            it.addExpectations(responsibilityId, countries = countries)
         } check {
             val result = it.getScenarioAndCoverageDataForResponsibility(responsibilityId, touchstoneVersionId, scenarioId)
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -93,18 +93,41 @@ class GetScenarioTests : TouchstoneRepositoryTests()
     {
         var responsibilityId = 0
         given {
-            val countries = listOf("AAA", "BBB", "CCC")
+            val countries = listOf("AAA", "BBB")
             it.addGroup(groupId)
             createTouchstoneAndScenarioDescriptions(it)
             it.addScenarioToTouchstone(touchstoneVersionId, scenarioId)
             responsibilityId = it.addResponsibilityInNewSet(groupId, touchstoneVersionId, scenarioId)
-            giveUnorderedCoverageSetsAndDataToScenario(it, countries = countries)
+            it.addCountries(countries)
+            giveUnorderedCoverageSetsAndDataToScenario(it, addCountries = false)
             it.addExpectations(responsibilityId, countries = countries)
         } check {
             val result = it.getScenarioAndCoverageDataForResponsibility(responsibilityId, touchstoneVersionId, scenarioId)
 
             assertThat(result.structuredMetadata.coverageSets!!.count()).isEqualTo(3)
             assertThat(result.tableData.data.toList().count()).isEqualTo(7)
+        }
+    }
+
+
+    @Test
+    fun `get coverage data for responsibility only returns expectations countries`()
+    {
+        var responsibilityId = 0
+        given {
+            val countries = listOf("AAA", "BBB", "CCC", "DDD")
+            it.addGroup(groupId)
+            createTouchstoneAndScenarioDescriptions(it)
+            it.addScenarioToTouchstone(touchstoneVersionId, scenarioId)
+            responsibilityId = it.addResponsibilityInNewSet(groupId, touchstoneVersionId, scenarioId)
+            it.addCountries(countries)
+            giveUnorderedCoverageSetsAndDataToScenario(it, addCountries = false)
+            it.addExpectations(responsibilityId, countries = countries.subList(1, 3))
+        } check {
+            val result = it.getScenarioAndCoverageDataForResponsibility(responsibilityId, touchstoneVersionId, scenarioId)
+
+            assertThat(result.structuredMetadata.coverageSets!!.count()).isEqualTo(1)
+            assertThat(result.tableData.data.toList().count()).isEqualTo(4)
         }
     }
 
@@ -202,8 +225,7 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         }
     }
 
-    private fun giveUnorderedCoverageSetsAndDataToScenario(db: JooqContext,
-                                                           countries: List<String> = listOf("AAA", "BBB", "CCC"))
+    private fun giveUnorderedCoverageSetsAndDataToScenario(db: JooqContext, addCountries: Boolean = true)
     {
         db.addCoverageSet(touchstoneVersionId, "First", "AF", "without", "routine", id = setA)
         db.addCoverageSet(touchstoneVersionId, "Second", "BF", "without", "campaign", id = setB)
@@ -212,7 +234,10 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         db.addCoverageSetToScenario(scenarioId, touchstoneVersionId, setB, 1)
         db.addCoverageSetToScenario(scenarioId, touchstoneVersionId, setC, 2)
 
-        db.addCountries(countries)
+        if (addCountries)
+        {
+            db.addCountries(listOf("AAA", "BBB"))
+        }
 
         // adding these in jumbled up order
         db.addCoverageRow(setC, "BBB", 2001, 2.toDecimal(), 4.toDecimal(), null, null, null)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -88,6 +88,26 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         }
     }
 
+    @Test
+    fun `can get coverage data for responsibility`()
+    {
+        var responsibilityId = 0
+        given {
+            val countries = listOf("AAA", "BBB", "CCC")
+            it.addGroup(groupId)
+            createTouchstoneAndScenarioDescriptions(it)
+            it.addScenarioToTouchstone(touchstoneVersionId, scenarioId)
+            responsibilityId = it.addResponsibilityInNewSet(groupId, touchstoneVersionId, scenarioId)
+            it.addExpectations(responsibilityId, countries = countries)
+            giveUnorderedCoverageSetsAndDataToScenario(it, countries = countries)
+        } check {
+            val result = it.getScenarioAndCoverageDataForResponsibility(responsibilityId, touchstoneVersionId, scenarioId)
+
+            assertThat(result.structuredMetadata.coverageSets!!.count()).isEqualTo(3)
+            assertThat(result.tableData.data.toList().count()).isEqualTo(7)
+        }
+    }
+
 
     @Test
     fun `can get ordered coverage sets`()
@@ -182,7 +202,8 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         }
     }
 
-    private fun giveUnorderedCoverageSetsAndDataToScenario(db: JooqContext)
+    private fun giveUnorderedCoverageSetsAndDataToScenario(db: JooqContext,
+                                                           countries: List<String> = listOf("AAA", "BBB", "CCC"))
     {
         db.addCoverageSet(touchstoneVersionId, "First", "AF", "without", "routine", id = setA)
         db.addCoverageSet(touchstoneVersionId, "Second", "BF", "without", "campaign", id = setB)
@@ -191,7 +212,7 @@ class GetScenarioTests : TouchstoneRepositoryTests()
         db.addCoverageSetToScenario(scenarioId, touchstoneVersionId, setB, 1)
         db.addCoverageSetToScenario(scenarioId, touchstoneVersionId, setC, 2)
 
-        db.addCountries(listOf("AAA", "BBB", "CCC"))
+        db.addCountries(countries)
 
         // adding these in jumbled up order
         db.addCoverageRow(setC, "BBB", 2001, 2.toDecimal(), 4.toDecimal(), null, null, null)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetScenarioTests.kt
@@ -225,7 +225,6 @@ class GetScenarioTests : TouchstoneRepositoryTests()
                     CoverageSet(setA, touchstoneVersionId, "YF without", "YF", GAVISupportLevel.WITHOUT, ActivityType.CAMPAIGN),
                     CoverageSet(setB, touchstoneVersionId, "YF with", "YF", GAVISupportLevel.WITH, ActivityType.CAMPAIGN)
             ))
-            assertThat(result.toList()).isEmpty()
         }
     }
 

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
@@ -789,6 +789,28 @@ fun JooqContext.addExpectations(
     return id
 }
 
+fun JooqContext.addExpectationsForAllCountries(
+        responsibilityId: Int,
+        description: String = "description",
+        version: String = "version",
+        yearMinInclusive: Short = 2000,
+        yearMaxInclusive: Short = 2100,
+        ageMinInclusive: Short = 0,
+        ageMaxInclusive: Short = 99,
+        cohortMinInclusive: Short? = null,
+        cohortMaxInclusive: Short? = null,
+        outcomes: List<String> = emptyList()
+): Int
+{
+
+    val countries =  dsl.select(COUNTRY.ID)
+            .from(COUNTRY)
+            .fetchInto(String::class.java)
+
+    return this.addExpectations(responsibilityId, description, version, yearMinInclusive, yearMaxInclusive,
+            ageMinInclusive, ageMaxInclusive, cohortMinInclusive, cohortMaxInclusive, countries, outcomes)
+}
+
 fun JooqContext.addExistingExpectationsToResponsibility(
         responsibilityId: Int, expectationsId: Int
 )


### PR DESCRIPTION
Changes the default behaviour to only return coverage data for countries that we expect burden estimates for, with an option to override and return data for all countries via a query parameter.