### PR TITLE
order estimates

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -61,6 +61,7 @@ class JooqBurdenEstimateRepository(
                 .where(BURDEN_ESTIMATE.BURDEN_ESTIMATE_SET.eq(setId))
                 .and(BURDEN_ESTIMATE.BURDEN_OUTCOME.`in`(outcomeIds))
                 .groupBy(BURDEN_ESTIMATE.YEAR, BURDEN_ESTIMATE.AGE)
+                .orderBy(BURDEN_ESTIMATE.YEAR, BURDEN_ESTIMATE.AGE)
                 .fetchInto(BurdenEstimateDataPoint::class.java)
                 .groupBy { if (burdenEstimateGrouping == BurdenEstimateGrouping.AGE) it.age else it.year }
 


### PR DESCRIPTION
The un-ordered data was breaking react-vis in strange ways: https://github.com/uber/react-vis/issues/1068