### PR TITLE
Ignore intermittently failing CloseBurdenEstimateSetTests tests

### DIFF
--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
 import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
@@ -16,6 +17,7 @@ import org.vaccineimpact.api.db.fieldsAsList
 import org.vaccineimpact.api.validateSchema.JSONValidator
 import spark.route.HttpMethod
 
+@Ignore
 class CloseBurdenEstimateSetTests : BurdenEstimateTests()
 {
     private val setId = 1

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
@@ -17,7 +17,6 @@ import org.vaccineimpact.api.db.fieldsAsList
 import org.vaccineimpact.api.validateSchema.JSONValidator
 import spark.route.HttpMethod
 
-@Ignore
 class CloseBurdenEstimateSetTests : BurdenEstimateTests()
 {
     private val setId = 1
@@ -106,6 +105,7 @@ class CloseBurdenEstimateSetTests : BurdenEstimateTests()
         assertSetHasStatus("invalid", setId)
     }
 
+    @Ignore
     @Test
     fun `can populate and close burden estimate with onetime token and redirect`()
     {
@@ -124,6 +124,7 @@ class CloseBurdenEstimateSetTests : BurdenEstimateTests()
         assertSetHasStatus("complete", setId)
     }
 
+    @Ignore
     @Test
     fun `missing rows error comes through with redirect`()
     {


### PR DESCRIPTION
Blackbox tests all passing on API build config for this branch, skipping the 7 affected tests. 