### PR TITLE
remove funder from admin access list

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -110,7 +110,7 @@ class WebTokenHelperTests : MontaguTests()
                 roles + ReifiedRole("funder", Scope.Global()), permissions))
         val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
 
-        assertThat(claims["access_level"]).isEqualTo("admin")
+        assertThat(claims["access_level"]).isEqualTo("user")
     }
 
     @Test

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -77,7 +77,7 @@ open class WebTokenHelper(
         val modelsToReview = getReviewersMap()[user.username]?.map { it to "true" }
                 ?.toMap() ?: mapOf()
 
-        val adminRoles = listOf("admin", "funder", "developer").map { ReifiedRole(it, Scope.Global()) }
+        val adminRoles = listOf("admin", "developer").map { ReifiedRole(it, Scope.Global()) }
         val access = if (user.roles.intersect(adminRoles).any())
         {
             "admin"


### PR DESCRIPTION
Checked with Kim and the inclusion of users with the `funder` role here doesn't make sense.