### PR TITLE
add modelling groups to jwt token

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -72,8 +72,10 @@ class WebTokenHelperTests : MontaguTests()
     }
 
     @Test
-    fun `can generate model review token`()
+    fun `can generate model review token with no group membership`()
     {
+        val roles = roles + listOf(ReifiedRole("member", Scope.Specific("modelling-group",
+                "membership-group")))
         val token = sut.generateModelReviewToken(InternalUser(properties, roles, permissions))
         val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
 
@@ -82,14 +84,16 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["sub"]).isEqualTo("test.user")
         assertThat(claims["exp"]).isInstanceOf(Date::class.java)
         assertThat(claims["test-group"]).isEqualTo("true")
+        assertThat(claims["membership-group"]).isEqualTo("true")
         assertThat(claims["url"]).isEqualTo("*")
         assertThat(claims["access_level"]).isEqualTo("user")
-        assertThat(claims.keys.count()).isEqualTo(7)
+        assertThat(claims.keys.count()).isEqualTo(8)
     }
 
     @Test
     fun `can generate model review token for user with no models to review`()
     {
+        val roles = listOf(ReifiedRole("member", Scope.Specific("modelling-group", "test-group")))
         val token = sut.generateModelReviewToken(InternalUser(properties.copy(username = "some.user"),
                 roles, permissions))
         val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
@@ -100,7 +104,8 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["exp"]).isInstanceOf(Date::class.java)
         assertThat(claims["url"]).isEqualTo("*")
         assertThat(claims["access_level"]).isEqualTo("user")
-        assertThat(claims.keys.count()).isEqualTo(6)
+        assertThat(claims["test-group"]).isEqualTo("true")
+        assertThat(claims.keys.count()).isEqualTo(7)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -72,7 +72,7 @@ class WebTokenHelperTests : MontaguTests()
     }
 
     @Test
-    fun `can generate model review token with no group membership`()
+    fun `can generate model review token`()
     {
         val roles = roles + listOf(ReifiedRole("member", Scope.Specific("modelling-group",
                 "membership-group")))

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/AuthenticationTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/AuthenticationTests.kt
@@ -50,6 +50,7 @@ class AuthenticationTests : DatabaseTest()
                     email = TestUserHelper.email, password = TestUserHelper.defaultPassword)
             it.ensureUserHasRole(TestUserHelper.username, ReifiedRole("reports-reviewer", Scope.Global()))
             it.ensureUserHasRole(TestUserHelper.username, ReifiedRole("user", Scope.Global()))
+            it.ensureUserHasRole(TestUserHelper.username, ReifiedRole("member", Scope.Specific("modelling-group", "group-1")))
         }
 
         val token = TokenFetcher().getToken(TestUserHelper.email, TestUserHelper.defaultPassword)
@@ -67,6 +68,7 @@ class AuthenticationTests : DatabaseTest()
         val modelReviewToken = checkCookieAndGetValue(response, "jwt_token")
         val modelReviewClaims = JWT.decode(modelReviewToken)
         assertThat(modelReviewClaims.getClaim("test-group").asString()).isEqualTo("true")
+        assertThat(modelReviewClaims.getClaim("group-1").asString()).isEqualTo("true")
     }
 
     @Test


### PR DESCRIPTION
As well as configured permissions, all users should be granted access to their own modelling groups.