### PR TITLE
add new method and refactor token verification methods

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
@@ -36,6 +36,10 @@ object BurdenEstimatesRouteConfig : RouteConfig
                     .secure(readPermissions),
 
             // Populate sets
+            Endpoint("$baseUrl/:set-id/actions/request-upload/:file-name/", uploadController, "getUploadToken", method = HttpMethod.get)
+                    .json()
+                    .secure(writePermissions),
+
             Endpoint("$baseUrl/:set-id/", uploadController, "populateBurdenEstimateSet", method = HttpMethod.post)
                     .json()
                     .secure(writePermissions),

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
@@ -36,7 +36,7 @@ object BurdenEstimatesRouteConfig : RouteConfig
                     .secure(readPermissions),
 
             // Populate sets
-            Endpoint("$baseUrl/:set-id/actions/request-upload/:file-name/", uploadController, "getUploadToken", method = HttpMethod.get)
+            Endpoint("$baseUrl/:set-id/actions/request-upload/", uploadController, "getUploadToken", method = HttpMethod.get)
                     .json()
                     .secure(writePermissions),
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -4,7 +4,7 @@ import org.vaccineimpact.api.app.ResultRedirector
 import org.vaccineimpact.api.app.asResult
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.RequestDataSource
-import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -42,7 +42,7 @@ class BurdenEstimateUploadController(context: ActionContext,
 
         if (metadata.isStochastic())
         {
-            throw BadRequest("Stochastic estimate upload not supported")
+            throw InvalidOperationError("Stochastic estimate upload not supported")
         }
 
         return tokenHelper.generateUploadEstimatesToken(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -4,6 +4,7 @@ import org.vaccineimpact.api.app.ResultRedirector
 import org.vaccineimpact.api.app.asResult
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.RequestDataSource
+import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -27,6 +28,31 @@ class BurdenEstimateUploadController(context: ActionContext,
             repos,
             RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations),
             repos.burdenEstimates)
+
+    fun getUploadToken(): String
+    {
+        val path = getValidResponsibilityPath(context, estimateRepository)
+        val setId = context.params(":set-id").toInt()
+
+        // Check that this is a central estimate set
+        val metadata = estimateRepository.getBurdenEstimateSet(path.groupId,
+                path.touchstoneVersionId,
+                path.scenarioId,
+                setId)
+
+        if (metadata.isStochastic())
+        {
+            throw BadRequest("Stochastic estimate upload not supported")
+        }
+
+        return tokenHelper.generateUploadEstimatesToken(
+                context.username!!,
+                path.groupId,
+                path.touchstoneVersionId,
+                path.scenarioId,
+                setId,
+                context.params(":file-name"))
+    }
 
     fun populateBurdenEstimateSet() = populateBurdenEstimateSet(RequestDataSource.fromContentType(context))
     fun populateBurdenEstimateSet(source: RequestDataSource): Result

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -50,8 +50,7 @@ class BurdenEstimateUploadController(context: ActionContext,
                 path.groupId,
                 path.touchstoneVersionId,
                 path.scenarioId,
-                setId,
-                context.params(":file-name"))
+                setId)
     }
 
     fun populateBurdenEstimateSet() = populateBurdenEstimateSet(RequestDataSource.fromContentType(context))

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -27,10 +27,12 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { generateUploadEstimatesToken("username", "group-1", "touchstone-1", "scenario-1", 1, "file.csv") } doReturn "TOKEN"
         }
 
+        val repo = mockEstimatesRepository(mockTouchstones())
         val sut = BurdenEstimateUploadController(mockActionContext(), mock(), mockLogic(),
-                mockEstimatesRepository(mockTouchstones()), mock(),
+                repo, mock(),
                 mockTokenHelper)
         val result = sut.getUploadToken()
+        verify(repo).getBurdenEstimateSet("group-1", "touchstone-1", "scenario-1", 1)
         assertThat(result).isEqualTo("TOKEN")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -24,7 +24,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
     fun `can get upload token`()
     {
         val mockTokenHelper = mock<WebTokenHelper> {
-            on { generateUploadEstimatesToken("username", "group-1", "touchstone-1", "scenario-1", 1, "file.csv") } doReturn "TOKEN"
+            on { generateUploadEstimatesToken("username", "group-1", "touchstone-1", "scenario-1", 1) } doReturn "TOKEN"
         }
 
         val repo = mockEstimatesRepository(mockTouchstones())
@@ -41,7 +41,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
     fun `can not get upload token for stochastic set`()
     {
         val mockTokenHelper = mock<WebTokenHelper> {
-            on { generateUploadEstimatesToken("username", "group-1", "touchstone-1", "scenario-1", 1, "file.csv") } doReturn "TOKEN"
+            on { generateUploadEstimatesToken("username", "group-1", "touchstone-1", "scenario-1", 1) } doReturn "TOKEN"
         }
 
         val repo = mockEstimatesRepository(mockTouchstones(), existingBurdenEstimateSet = defaultEstimateSet.copy(

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.mockito.Mockito
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
-import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -49,7 +49,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 repo, mock(),
                 mockTokenHelper)
         assertThatThrownBy { sut.getUploadToken() }
-                .isInstanceOf(BadRequest::class.java)
+                .isInstanceOf(InvalidOperationError::class.java)
                 .hasMessageContaining("Stochastic estimate upload not supported")
 
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -246,7 +246,7 @@ class WebTokenHelperTests : MontaguTests()
     {
         val sut = WebTokenHelper(KeyHelper.generateKeyPair())
         val now = Instant.now()
-        val result = sut.generateUploadEstimatesToken("user.name", "g1", "t1", "s1", 3, "file.csv")
+        val result = sut.generateUploadEstimatesToken("user.name", "g1", "t1", "s1", 3)
         val claims = sut.verify(result, TokenType.UPLOAD)
 
         assertThat(claims["sub"]).isEqualTo("user.name")
@@ -256,6 +256,10 @@ class WebTokenHelperTests : MontaguTests()
         assertThat(claims["scenario-id"]).isEqualTo("s1")
         assertThat(claims["set-id"].toString()).isEqualTo("3")
         assertThat(claims["token_type"]).isEqualTo("UPLOAD")
+
+        val expiry = (claims["exp"] as Date)
+        assertThat(expiry).isAfter(Date.from(now))
+        assertThat(expiry).isBefore(Date.from(Instant.now().plus(Duration.ofDays(1))))
 
         val uid = claims["uid"].toString()
         val timestamp = Instant.parse(uid.split("-").takeLast(3).joinToString("-"))

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
+import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.Result
 import org.vaccineimpact.api.models.ResultStatus
@@ -17,6 +18,7 @@ import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Duration
 import java.time.Instant
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 class WebTokenHelperTests : MontaguTests()
 {
@@ -52,7 +54,7 @@ class WebTokenHelperTests : MontaguTests()
     fun `can generate bearer token`()
     {
         val token = sut.generateToken(InternalUser(properties, roles, permissions))
-        val claims = sut.verify(token.deflated(), TokenType.BEARER, mock())
+        val claims = sut.verify(token.deflated(), TokenType.BEARER)
 
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
         assertThat(claims["token_type"]).isEqualTo("BEARER")
@@ -66,7 +68,7 @@ class WebTokenHelperTests : MontaguTests()
     fun `can generate long-lived bearer token`()
     {
         val token = sut.generateToken(InternalUser(properties, roles, permissions), lifeSpan = Duration.ofDays(365))
-        val claims = sut.verify(token.deflated(), TokenType.BEARER, mock())
+        val claims = sut.verify(token.deflated(), TokenType.BEARER)
 
         assertThat(claims["exp"] as Date).isAfter(Date.from(Instant.now() + Duration.ofDays(364)))
     }
@@ -77,7 +79,7 @@ class WebTokenHelperTests : MontaguTests()
         val roles = listOf(ReifiedRole("member", Scope.Specific("modelling-group", "test-group")))
         val token = sut.generateModelReviewToken(InternalUser(properties.copy(username = "some.user"),
                 roles, permissions), listOf("d1"))
-        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
+        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW)
 
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
         assertThat(claims["token_type"]).isEqualTo("MODEL_REVIEW")
@@ -94,7 +96,7 @@ class WebTokenHelperTests : MontaguTests()
     {
         val token = sut.generateModelReviewToken(InternalUser(properties,
                 roles + ReifiedRole("admin", Scope.Global()), permissions), listOf("d1"))
-        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
+        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW)
 
         assertThat(claims["access_level"]).isEqualTo("admin")
     }
@@ -104,7 +106,7 @@ class WebTokenHelperTests : MontaguTests()
     {
         val token = sut.generateModelReviewToken(InternalUser(properties,
                 roles + ReifiedRole("developer", Scope.Global()), permissions), listOf("d1"))
-        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW, mock())
+        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW)
 
         assertThat(claims["access_level"]).isEqualTo("admin")
     }
@@ -116,7 +118,8 @@ class WebTokenHelperTests : MontaguTests()
         val badToken = sut.generator.generate(claims.plus("iss" to "unexpected.issuer"))
         val verifier = MontaguTokenAuthenticator(sut, TokenType.BEARER)
         assertThat(verifier.validateToken(badToken)).isNull()
-        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER, mock()) }
+        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER) }
+                .isInstanceOf(TokenValidationException::class.java)
     }
 
     @Test
@@ -126,7 +129,8 @@ class WebTokenHelperTests : MontaguTests()
         val badToken = sut.generator.generate(claims.plus("token_type" to "unexpected.type"))
         val verifier = MontaguTokenAuthenticator(sut, TokenType.BEARER)
         assertThat(verifier.validateToken(badToken)).isNull()
-        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER, mock()) }
+        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER) }
+                .isInstanceOf(TokenValidationException::class.java)
     }
 
     @Test
@@ -136,7 +140,8 @@ class WebTokenHelperTests : MontaguTests()
         val badToken = sut.generator.generate(claims.plus("exp" to Date.from(Instant.now())))
         val verifier = MontaguTokenAuthenticator(sut, TokenType.BEARER)
         assertThat(verifier.validateToken(badToken)).isNull()
-        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER, mock()) }
+        assertThatThrownBy { sut.verify(badToken.deflated(), TokenType.BEARER) }
+                .isInstanceOf(TokenValidationException::class.java)
     }
 
     @Test
@@ -146,7 +151,8 @@ class WebTokenHelperTests : MontaguTests()
         val evilToken = sauron.generateToken(InternalUser(properties, roles, permissions))
         val verifier = MontaguTokenAuthenticator(sut, TokenType.BEARER)
         assertThat(verifier.validateToken(evilToken)).isNull()
-        assertThatThrownBy { sut.verify(evilToken.deflated(), TokenType.BEARER, mock()) }
+        assertThatThrownBy { sut.verify(evilToken.deflated(), TokenType.BEARER) }
+                .isInstanceOf(TokenValidationException::class.java)
     }
 
     @Test
@@ -159,7 +165,7 @@ class WebTokenHelperTests : MontaguTests()
         }
 
         val token = sut.generateOnetimeActionToken("/some/url/", "username", permissions, roles)
-        val claims = sut.verify(token.deflated(), TokenType.ONETIME, mockTokenChecker)
+        val claims = sut.verifyOneTimeToken(token.deflated(), mockTokenChecker)
         assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
         assertThat(claims["token_type"]).isEqualTo("ONETIME")
         assertThat(claims["sub"]).isEqualTo("username")
@@ -177,7 +183,7 @@ class WebTokenHelperTests : MontaguTests()
             on { checkToken(any()) } doReturn false
         }
         val token = sut.generateOnetimeActionToken("/some/url/", "username", "", "")
-        assertThatThrownBy { sut.verify(token.deflated(), TokenType.ONETIME, mockTokenChecker) }
+        assertThatThrownBy { sut.verifyOneTimeToken(token.deflated(), mockTokenChecker) }
     }
 
     @Test
@@ -187,7 +193,15 @@ class WebTokenHelperTests : MontaguTests()
             on { checkToken(any()) } doReturn true
         }
         val token = sut.generateOnetimeActionToken("", "username", "", "")
-        assertThatThrownBy { sut.verify(token.deflated(), TokenType.ONETIME, mockTokenChecker) }
+        assertThatThrownBy { sut.verifyOneTimeToken(token.deflated(), mockTokenChecker) }
+    }
+
+    @Test
+    fun `verifying a onetime token with the wrong method throws an exception`()
+    {
+        val token = sut.generateOnetimeActionToken("/some/url/", "username", "", "")
+        assertThatThrownBy { sut.verify(token.deflated(), TokenType.ONETIME) }
+                .isInstanceOf(UnsupportedOperationException::class.java)
     }
 
     @Test
@@ -200,7 +214,7 @@ class WebTokenHelperTests : MontaguTests()
         createHelper(serializer)
         val result = Result(ResultStatus.SUCCESS, "OK", listOf())
         val token = sut.encodeResult(result)
-        val claims = sut.verify(token.deflated(), TokenType.API_RESPONSE, mock())
+        val claims = sut.verify(token.deflated(), TokenType.API_RESPONSE)
 
         assertThat(claims["token_type"]).isEqualTo("API_RESPONSE")
         assertThat(claims["sub"]).isEqualTo("api_response")
@@ -219,10 +233,34 @@ class WebTokenHelperTests : MontaguTests()
         val result = Result(ResultStatus.FAILURE, null,
                 listOf(ErrorInfo("some-code", "some message")))
         val token = sut.encodeResult(result)
-        val claims = sut.verify(token.deflated(), TokenType.API_RESPONSE, mock())
+        val claims = sut.verify(token.deflated(), TokenType.API_RESPONSE)
 
         assertThat(claims["token_type"]).isEqualTo("API_RESPONSE")
         assertThat(claims["sub"]).isEqualTo("api_response")
         assertThat(claims["result"]).isEqualTo("errorResult")
+    }
+
+
+    @Test
+    fun `can generate upload estimates token`()
+    {
+        val sut = WebTokenHelper(KeyHelper.generateKeyPair())
+        val now = Instant.now()
+        val result = sut.generateUploadEstimatesToken("user.name", "g1", "t1", "s1", 3, "file.csv")
+        val claims = sut.verify(result, TokenType.UPLOAD)
+
+        assertThat(claims["sub"]).isEqualTo("user.name")
+        assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
+        assertThat(claims["group-id"]).isEqualTo("g1")
+        assertThat(claims["touchstone-id"]).isEqualTo("t1")
+        assertThat(claims["scenario-id"]).isEqualTo("s1")
+        assertThat(claims["set-id"].toString()).isEqualTo("3")
+        assertThat(claims["token_type"]).isEqualTo("UPLOAD")
+
+        val uid = claims["uid"].toString()
+        val timestamp = Instant.parse(uid.split("-").takeLast(3).joinToString("-"))
+        val setId = uid.split("-")[0]
+        assertThat(setId).isEqualTo("3")
+        assertThat(timestamp.toEpochMilli() - now.toEpochMilli()).isLessThan(TimeUnit.SECONDS.toMillis(1))
     }
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -252,10 +252,8 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
         }
-        val fileName = "test.csv"
-
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
-        val response = RequestHelper().get("$setUrl$setId/actions/request-upload/$fileName/", token = token)
+        val response = RequestHelper().get("$setUrl$setId/actions/request-upload/", token = token)
         JSONValidator().validateSuccess(response.text)
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -249,13 +249,13 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     @Test
     fun `can get token for burden estimate uploads`()
     {
-        JooqContext().use {
+        val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
         }
         val fileName = "test.csv"
 
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
-        val response = RequestHelper().get("$setUrl/actions/request-upload/$fileName/", token = token)
+        val response = RequestHelper().get("$setUrl$setId/actions/request-upload/$fileName/", token = token)
         JSONValidator().validateSuccess(response.text)
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -1,11 +1,9 @@
 package org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates
 
+import com.github.fge.jsonschema.main.JsonValidator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
-import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
-import org.vaccineimpact.api.blackboxTests.helpers.getResultFromRedirect
-import org.vaccineimpact.api.blackboxTests.helpers.validate
+import org.vaccineimpact.api.blackboxTests.helpers.*
 import org.vaccineimpact.api.blackboxTests.schemas.CSVSchema
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.BURDEN_ESTIMATE
@@ -246,6 +244,19 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
                     .fetch()
             assertThat(records).isEmpty()
         }
+    }
+
+    @Test
+    fun `can get token for burden estimate uploads`()
+    {
+        JooqContext().use {
+            setUpWithBurdenEstimateSet(it)
+        }
+        val fileName = "test.csv"
+
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val response = RequestHelper().get("$setUrl/actions/request-upload/$fileName/", token = token)
+        JSONValidator().validateSuccess(response.text)
     }
 
 }

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/TokenType.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/TokenType.kt
@@ -6,5 +6,6 @@ enum class TokenType
     LEGACY_ONETIME,
     ONETIME,
     MODEL_REVIEW,
-    API_RESPONSE
+    API_RESPONSE,
+    UPLOAD
 }

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -34,19 +34,17 @@ open class WebTokenHelper(
                                           groupId: String,
                                           touchstoneVersionId: String,
                                           scenarioId: String,
-                                          setId: Int,
-                                          fileName: String): String
+                                          setId: Int): String
     {
         val claims = mapOf(
                 "iss" to issuer,
                 "token_type" to TokenType.UPLOAD,
                 "sub" to username,
-                "exp" to Date.from(Instant.now().plus(defaultLifespan)),
+                "exp" to Date.from(Instant.now().plus(Duration.ofDays(1))),
                 "group-id" to groupId,
                 "scenario-id" to scenarioId,
                 "set-id" to setId,
                 "touchstone-id" to touchstoneVersionId,
-                "file-name" to fileName,
                 "uid" to "$setId-${Instant.now()}")
 
         return generator.generate(claims)

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/WebTokenHelper.kt
@@ -30,6 +30,28 @@ open class WebTokenHelper(
         return generator.generate(claims(user, lifeSpan))
     }
 
+    open fun generateUploadEstimatesToken(username: String,
+                                          groupId: String,
+                                          touchstoneVersionId: String,
+                                          scenarioId: String,
+                                          setId: Int,
+                                          fileName: String): String
+    {
+        val claims = mapOf(
+                "iss" to issuer,
+                "token_type" to TokenType.UPLOAD,
+                "sub" to username,
+                "exp" to Date.from(Instant.now().plus(defaultLifespan)),
+                "group-id" to groupId,
+                "scenario-id" to scenarioId,
+                "set-id" to setId,
+                "touchstone-id" to touchstoneVersionId,
+                "file-name" to fileName,
+                "uid" to "$setId-${Instant.now()}")
+
+        return generator.generate(claims)
+    }
+
     open fun generateOnetimeActionToken(
             url: String,
             username: String,
@@ -96,14 +118,26 @@ open class WebTokenHelper(
         ) + diseasePermissions
     }
 
-    open fun verify(compressedToken: String, expectedType: TokenType,
-                    oneTimeTokenChecker: OneTimeTokenChecker): Map<String, Any>
+    open fun verify(compressedToken: String, expectedType: TokenType): Map<String, Any>
     {
         val authenticator = when (expectedType)
         {
-            TokenType.ONETIME -> OneTimeTokenAuthenticator(this, oneTimeTokenChecker)
+            TokenType.ONETIME -> throw UnsupportedOperationException("Please use verifyOneTimeToken")
             else -> MontaguTokenAuthenticator(this, expectedType)
         }
+        try
+        {
+            return authenticator.validateTokenAndGetClaims(compressedToken)
+        }
+        catch (e: NullPointerException)
+        {
+            throw TokenValidationException("Could not verify token")
+        }
+    }
+
+    open fun verifyOneTimeToken(compressedToken: String, oneTimeTokenChecker: OneTimeTokenChecker): Map<String, Any>
+    {
+        val authenticator = OneTimeTokenAuthenticator(this, oneTimeTokenChecker)
         return authenticator.validateTokenAndGetClaims(compressedToken)
     }
 


### PR DESCRIPTION
* new method to generate upload token for burden estimate file upload
* slight refactor so that regular token verification doesn't require a `OnetimeTokenChecker` to be passed in

* return a more accurate error from token verification failures