### PR TITLE
Upload a file in chunks and store metadata in cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ demo/build/*
 demo/out
 lib/
 spec/.idea/*
+src/app/upload_dir/*
 src/*/build/*
 src/*/out/
 src/.gradle

--- a/docs/spec/BurdenEstimates.md
+++ b/docs/spec/BurdenEstimates.md
@@ -138,17 +138,14 @@ single chunk of a file it will be associated with that file and invalid for use 
 Schema: [`Token.schema.json`](../schemas/Token.schema.json)
 
 ### Example
-`eyJhbGciOiUzI1NiJ9.eyJhY2NlciIsInN1YiI6ImFsZXguaGlsbCIsImlzcyI6InIk1PREVMX1JFVklFVyIsIIjoidHJ1ZSJ9.e8pqOx1-EqLitPWom_wtb7ZYjsZhM9EXBymuGZX_FA_Ag2N2b2qvIBv25-7fVP4ui5icFYvKUY1CeoP6f-BU3-EfXSdMxR0wwY-N9-fJJelwAaYUrpB_lB0L5gCOAV-PajVRlHxP-iVAGa9jP-w8evxkOBkO5S1-KJZgdXyLRQzMeB99BH461Ey6w5D7DzAz5JbjWSQszJIZbk_qfzexC3-9XZvqurG3uD832`
+    "eyJhbGciOiUzI1NiJ9.eyJhY2NlciIsInN1YiI6ImFsZXguaGlsbCIsImlzcyI6InIk1PREVMX1JFVklFVyIsIIjoidHJ1ZSJ9.e8pqOx1-EqLitPWom_wtb7ZYjsZhM9EXBymuGZX_FA_Ag2N2b2qvIBv25-7fVP4ui5icFYvKUY1CeoP6f-BU3-EfXSdMxR0wwY-N9-fJJelwAaYUrpB_lB0L5gCOAV-PajVRlHxP-iVAGa9jP-w8evxkOBkO5S1-KJZgdXyLRQzMeB99BH461Ey6w5D7DzAz5JbjWSQszJIZbk_qfzexC3-9XZvqurG3uD832"
     
 Required permissions: Scoped to modelling group: `estimates.write`, `responsibilities.read`.
 
 ## POST /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{set-id}/actions/upload/{token}/
 Upload a chunked CSV containing burden estimates, which can then be used to populate the given estimate
-set by making a further POST request to 
-`/modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{set-id}/actions/populate/` 
-(see below.) The token parameter must be an upload token obtained from a GET request to 
-`/modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{set-id}/actions/request-upload/` 
-(see above.) Once a token has been used to start uploading a file, it becomes associated with that file and 
+set by making a further POST request to `/actions/populate/` 
+(see below.) The token parameter must be an upload token obtained from a GET request to `/actions/request-upload` (see above.) Once a token has been used to start uploading a file, it becomes associated with that file and 
 cannot be re-used.
 
 ### Query parameters

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
@@ -1,0 +1,51 @@
+package org.vaccineimpact.api.app
+
+import org.vaccineimpact.api.app.models.ChunkedFile
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+interface Cache<T> {
+    operator fun get(uniqueIdentifier: String): T?
+    fun put(item: T)
+    fun remove(uniqueIdentifier: String)
+}
+
+class ChunkedFileCache(val flushInterval: Long = TimeUnit.HOURS.toMillis(1)): Cache<ChunkedFile>
+{
+    private val memoryCache = ConcurrentHashMap<String, ChunkedFile>()
+    private val lastAccessedMap = ConcurrentHashMap<String, Long>()
+
+    override operator fun get(uniqueIdentifier: String): ChunkedFile?
+    {
+        lastAccessedMap[uniqueIdentifier] = System.currentTimeMillis()
+        recycle()
+        return memoryCache[uniqueIdentifier]
+    }
+
+    override fun put(item: ChunkedFile)
+    {
+        lastAccessedMap[item.uniqueIdentifier] = System.currentTimeMillis()
+        recycle()
+        memoryCache[item.uniqueIdentifier] = item
+    }
+
+    override fun remove(uniqueIdentifier: String)
+    {
+        memoryCache[uniqueIdentifier]?.cleanUp()
+        lastAccessedMap.remove(uniqueIdentifier)
+        memoryCache.remove(uniqueIdentifier)
+    }
+
+    private fun recycle() {
+        lastAccessedMap.filter {
+            it.value < System.currentTimeMillis() - flushInterval
+        }.map {
+            remove(it.key)
+        }
+    }
+
+    companion object
+    {
+        val instance = ChunkedFileCache()
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
@@ -8,7 +8,7 @@ import java.io.RandomAccessFile
 open class ChunkedFileManager
 {
     // Note: currentChunk is 1-indexed
-    fun writeChunk(inputStream: InputStream, contentLength: Int, metadata: ChunkedFile, currentChunk: Int)
+    open fun writeChunk(inputStream: InputStream, contentLength: Int, metadata: ChunkedFile, currentChunk: Int)
     {
         File(UPLOAD_DIR).mkdir()
         val uploadPath = "$UPLOAD_DIR/${metadata.uniqueIdentifier}.temp"

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
@@ -1,0 +1,51 @@
+package org.vaccineimpact.api.app
+
+import org.vaccineimpact.api.app.models.ChunkedFile
+import java.io.File
+import java.io.InputStream
+import java.io.RandomAccessFile
+
+open class ChunkedFileManager
+{
+    // Note: currentChunk is 1-indexed
+    fun writeChunk(inputStream: InputStream, contentLength: Int, metadata: ChunkedFile, currentChunk: Int)
+    {
+        File(UPLOAD_DIR).mkdir()
+        val uploadPath = "$UPLOAD_DIR/${metadata.uniqueIdentifier}.temp"
+        val raf = RandomAccessFile(uploadPath, "rw")
+
+        // Seek to position
+        raf.seek((currentChunk - 1) * metadata.chunkSize)
+
+        // Write to file
+        var readBytes: Long = 0
+        val bytes = ByteArray(1024 * 100)
+        while (readBytes < contentLength)
+        {
+            val r = inputStream.read(bytes)
+            if (r < 0)
+            {
+                break
+            }
+            raf.write(bytes, 0, r)
+            readBytes += r.toLong()
+        }
+        raf.close()
+    }
+
+    fun markFileAsComplete(chunkedFile: ChunkedFile)
+    {
+        if (chunkedFile.uploadFinished())
+        {
+            val uploadPath = "$UPLOAD_DIR/${chunkedFile.uniqueIdentifier}.temp"
+            val tempFile = File(uploadPath)
+            val newPath = uploadPath.substring(0, uploadPath.length - ".temp".length)
+            tempFile.renameTo(File(newPath))
+        }
+    }
+
+    companion object
+    {
+        const val UPLOAD_DIR = "upload_dir"
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
@@ -47,6 +47,10 @@ object BurdenEstimatesRouteConfig : RouteConfig
                     .json()
                     .secure(writePermissions),
 
+            Endpoint("$baseUrl/:set-id/actions/upload/:token/", uploadController, "uploadBurdenEstimateFile", method = HttpMethod.post)
+                    .json()
+                    .secure(writePermissions),
+
             Endpoint("$baseUrl/:set-id/", uploadController, "populateBurdenEstimateSet", method = HttpMethod.post)
                     .json()
                     .secure(writePermissions),

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
@@ -10,6 +10,7 @@ import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.api.security.CookieName
 import spark.Request
+import java.io.InputStream
 import java.io.OutputStream
 import java.io.Reader
 
@@ -32,10 +33,11 @@ interface ActionContext
     fun queryString(): String?
     fun params(): Map<String, String>
     fun params(key: String): String
-    fun getPart(name: String, multipartData: MultipartData = ServletFileUploadWrapper()): Reader
+    fun getPart(name: String, multipartData: MultipartData = ServletFileUploadWrapper()): InputStream
     fun getParts(multipartData: MultipartData = ServletFileUploadWrapper()): MultipartDataMap
 
     fun requestReader(): Reader
+    fun getInputStream(): InputStream
     fun <T : Any> postData(klass: Class<T>): T
 
     fun addResponseHeader(key: String, value: String): Unit

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
@@ -28,7 +28,7 @@ interface ActionContext
     val redirectUrl: String?
 
     fun contentType(): String
-    val contentLength: Int
+    fun contentLength(): Int
 
     fun queryParams(key: String): String?
     fun queryString(): String?

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/ActionContext.kt
@@ -28,6 +28,7 @@ interface ActionContext
     val redirectUrl: String?
 
     fun contentType(): String
+    val contentLength: Int
 
     fun queryParams(key: String): String?
     fun queryString(): String?

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -34,7 +34,7 @@ class DirectActionContext(private val context: SparkWebContext) : ActionContext
             : this(SparkWebContext(request, response))
 
     override fun contentType(): String = request.contentType()
-    override val contentLength = request.raw().contentLength
+    override fun contentLength() = request.raw().contentLength
     override fun queryParams(key: String): String? = request.queryParams(key)
     override fun queryString(): String? = request.queryString()
     override fun params(): Map<String, String> = request.params()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -34,6 +34,7 @@ class DirectActionContext(private val context: SparkWebContext) : ActionContext
             : this(SparkWebContext(request, response))
 
     override fun contentType(): String = request.contentType()
+    override val contentLength = request.raw().contentLength
     override fun queryParams(key: String): String? = request.queryParams(key)
     override fun queryString(): String? = request.queryString()
     override fun params(): Map<String, String> = request.params()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/DirectActionContext.kt
@@ -19,10 +19,7 @@ import org.vaccineimpact.api.security.CookieName
 import org.vaccineimpact.api.serialization.ModelBinder
 import spark.Request
 import spark.Response
-import java.io.BufferedOutputStream
-import java.io.BufferedReader
-import java.io.OutputStream
-import java.io.Reader
+import java.io.*
 import java.util.zip.GZIPOutputStream
 
 
@@ -44,13 +41,13 @@ class DirectActionContext(private val context: SparkWebContext) : ActionContext
     override fun <T : Any> postData(klass: Class<T>): T = ModelBinder().deserialize(request.body(), klass)
 
     // Return one part as a stream
-    override fun getPart(name: String, multipartData: MultipartData): Reader
+    override fun getPart(name: String, multipartData: MultipartData): InputStream
     {
         val parts = getPartsAsSequence(multipartData)
         val matchingPart = parts.firstOrNull { it.fieldName == name }
                 ?: throw MissingRequiredMultipartParameterError(name)
 
-        return matchingPart.openStream().bufferedReader()
+        return matchingPart.openStream()
     }
 
     // Pull all parts into memory and return them as a map
@@ -75,6 +72,7 @@ class DirectActionContext(private val context: SparkWebContext) : ActionContext
     }
 
     override fun requestReader(): BufferedReader = request.raw().inputStream.bufferedReader()
+    override fun getInputStream(): InputStream = request.raw().inputStream
 
     override fun setResponseStatus(status: Int)
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
@@ -1,11 +1,12 @@
 package org.vaccineimpact.api.app.context
 
+import java.io.InputStream
 import java.io.Reader
 import java.io.StringReader
 
 interface RequestDataSource
 {
-    fun getContent(): Reader
+    fun getContent(): InputStream
 
     companion object
     {
@@ -32,7 +33,7 @@ interface RequestDataSource
 
 class RequestBodySource(private val context: ActionContext) : RequestDataSource
 {
-    override fun getContent() = context.requestReader()
+    override fun getContent() = context.getInputStream()
 }
 
 class MultipartStreamSource(val partName: String, private val context: ActionContext) : RequestDataSource
@@ -42,5 +43,5 @@ class MultipartStreamSource(val partName: String, private val context: ActionCon
 
 data class InMemoryRequestData(val contents: String) : RequestDataSource
 {
-    override fun getContent() = StringReader(contents)
+    override fun getContent() = contents.byteInputStream()
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
@@ -5,15 +5,15 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
 data class ChunkedFile(val totalChunks: Int,
+                       val totalSize: Long,
                        val chunkSize: Long,
                        val uniqueIdentifier: String,
-                       var filePath: String
+                       val originalFileName: String
 )
 {
-    constructor(totalChunks: Int, chunkSize: Long, uniqueIdentifier: String, file: File):
-            this(totalChunks, chunkSize, uniqueIdentifier, "${file.absolutePath}.temp")
 
     val uploadedChunks = ConcurrentHashMap<Int, Boolean>()
+    var filePath = "$UPLOAD_DIR/$uniqueIdentifier.temp"
 
     fun uploadFinished(): Boolean
     {
@@ -38,5 +38,10 @@ data class ChunkedFile(val totalChunks: Int,
 
     fun cleanUp() {
         File(filePath).delete()
+    }
+
+    companion object
+    {
+        const val UPLOAD_DIR = "upload_dir"
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
@@ -1,0 +1,42 @@
+package org.vaccineimpact.api.app.models
+
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+
+data class ChunkedFile(val totalChunks: Int,
+                       val chunkSize: Long,
+                       val uniqueIdentifier: String,
+                       var filePath: String
+)
+{
+    constructor(totalChunks: Int, chunkSize: Long, uniqueIdentifier: String, file: File):
+            this(totalChunks, chunkSize, uniqueIdentifier, "${file.absolutePath}.temp")
+
+    val uploadedChunks = ConcurrentHashMap<Int, Boolean>()
+
+    fun uploadFinished(): Boolean
+    {
+        for (i in 1..totalChunks)
+        {
+            if (!uploadedChunks.containsKey(i))
+            {
+                return false
+            }
+        }
+
+        //Upload finished, change filename
+        val file = File(filePath)
+        val newPath = filePath.substring(0, filePath.length - ".temp".length)
+
+        if (!file.renameTo(File(newPath))){
+            throw IOException("Unable to rename file")
+        }
+        filePath = newPath
+        return true
+    }
+
+    fun cleanUp() {
+        File(filePath).delete()
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/models/ChunkedFile.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.api.app.models
 
+import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
 import java.io.File
-import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
 data class ChunkedFile(val totalChunks: Int,
@@ -11,9 +11,7 @@ data class ChunkedFile(val totalChunks: Int,
                        val originalFileName: String
 )
 {
-
     val uploadedChunks = ConcurrentHashMap<Int, Boolean>()
-    var filePath = "$UPLOAD_DIR/$uniqueIdentifier.temp"
 
     fun uploadFinished(): Boolean
     {
@@ -25,23 +23,12 @@ data class ChunkedFile(val totalChunks: Int,
             }
         }
 
-        //Upload finished, change filename
-        val file = File(filePath)
-        val newPath = filePath.substring(0, filePath.length - ".temp".length)
-
-        if (!file.renameTo(File(newPath))){
-            throw IOException("Unable to rename file")
-        }
-        filePath = newPath
         return true
     }
 
     fun cleanUp() {
-        File(filePath).delete()
+        File("$UPLOAD_DIR/$uniqueIdentifier").delete()
+        File("$UPLOAD_DIR/$uniqueIdentifier.temp").delete()
     }
 
-    companion object
-    {
-        const val UPLOAD_DIR = "upload_dir"
-    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
@@ -1,0 +1,131 @@
+package org.vaccineimpact.api.tests
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.vaccineimpact.api.app.ChunkedFileCache
+import org.vaccineimpact.api.app.models.ChunkedFile
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class ChunkedFileCacheTests : MontaguTests()
+{
+    @Test
+    fun `can put and read object from cache multiple times`()
+    {
+        val sut = ChunkedFileCache()
+        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        sut.put(testInfo)
+
+        var result = sut["uid"]
+        assertThat(result).isSameAs(testInfo)
+
+        result = sut["uid"]
+        assertThat(result).isSameAs(testInfo)
+    }
+
+    @Test
+    fun `can remove object from cache`()
+    {
+        val sut = ChunkedFileCache()
+        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        sut.put(testInfo)
+
+        var result = sut["uid"]
+        assertThat(result).isSameAs(testInfo)
+
+        sut.remove("uid")
+
+        result = sut["uid"]
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `removes old objects from cache on put operations`()
+    {
+        val flushInterval = TimeUnit.MILLISECONDS.toMillis(5)
+        val sut = ChunkedFileCache(flushInterval)
+
+        val oldUID = "old"
+        val freshUID = "fresh"
+
+        val oldInfo = ChunkedFile(10, 100, oldUID, "file.csv")
+        sut.put(oldInfo)
+
+        // first confirm that the object can be retrieved
+        var result = sut[oldUID]
+        assertThat(result).isNotNull()
+
+        // now wait longer than the flush interval
+        Thread.sleep(10)
+
+        // make a fresh put request
+        val newInfo = ChunkedFile(10, 100, freshUID, "somefile.csv")
+        sut.put(newInfo)
+
+        // the old object should have been flushed
+        result = sut[oldUID]
+        assertThat(result).isNull()
+
+        // the new object should not have been flushed
+        val newResult = sut[freshUID]
+        assertThat(newResult).isNotNull()
+    }
+
+
+    @Test
+    fun `removes old objects from cache on get operations`()
+    {
+        val oldUID = "old"
+        val freshUID = "fresh"
+
+        val flushInterval = TimeUnit.MILLISECONDS.toMillis(5)
+        val sut = ChunkedFileCache(flushInterval)
+
+        val oldInfo = ChunkedFile(10, 100, oldUID, "file.csv")
+        sut.put(oldInfo)
+
+        // first confirm that the object can be retrieved
+        var result = sut[oldUID]
+        assertThat(result).isNotNull()
+
+        // now wait longer than the flush interval
+        Thread.sleep(10)
+
+        // make a fresh request for a different object
+        val dummyGetRequest = sut[freshUID]
+        result = sut[oldUID]
+        assertThat(result).isNull()
+
+    }
+
+    @Test
+    fun `can update and read from ChunkedFile items in concurrent threads`()
+    {
+        val sut = ChunkedFileCache()
+        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        sut.put(testInfo)
+
+        var result = false
+        val threads = mutableListOf<Thread>()
+        File(testInfo.filePath).createNewFile()
+        for (i in 1..10)
+        {
+            threads.add(
+                    thread(start = true) {
+                        sut["uid"]!!.uploadedChunks[i] = true
+                        result = sut["uid"]!!.uploadFinished()
+                    })
+        }
+
+        while (threads.any { it.isAlive })
+        {
+            // just wait for threads to finish
+        }
+
+        File(testInfo.filePath).delete()
+        assertThat(result).isTrue()
+    }
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
@@ -15,7 +15,7 @@ class ChunkedFileCacheTests : MontaguTests()
     fun `can put and read object from cache multiple times`()
     {
         val sut = ChunkedFileCache()
-        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        val testInfo = ChunkedFile(10, 100, 1000, "uid", "file.csv")
         sut.put(testInfo)
 
         var result = sut["uid"]
@@ -29,7 +29,7 @@ class ChunkedFileCacheTests : MontaguTests()
     fun `can remove object from cache`()
     {
         val sut = ChunkedFileCache()
-        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        val testInfo = ChunkedFile(10, 100, 1000, "uid", "file.csv")
         sut.put(testInfo)
 
         var result = sut["uid"]
@@ -50,7 +50,7 @@ class ChunkedFileCacheTests : MontaguTests()
         val oldUID = "old"
         val freshUID = "fresh"
 
-        val oldInfo = ChunkedFile(10, 100, oldUID, "file.csv")
+        val oldInfo = ChunkedFile(10, 100, 1000, oldUID, "file.csv")
         sut.put(oldInfo)
 
         // first confirm that the object can be retrieved
@@ -61,7 +61,7 @@ class ChunkedFileCacheTests : MontaguTests()
         Thread.sleep(10)
 
         // make a fresh put request
-        val newInfo = ChunkedFile(10, 100, freshUID, "somefile.csv")
+        val newInfo = ChunkedFile(10, 100, 1000, freshUID, "somefile.csv")
         sut.put(newInfo)
 
         // the old object should have been flushed
@@ -83,7 +83,7 @@ class ChunkedFileCacheTests : MontaguTests()
         val flushInterval = TimeUnit.MILLISECONDS.toMillis(5)
         val sut = ChunkedFileCache(flushInterval)
 
-        val oldInfo = ChunkedFile(10, 100, oldUID, "file.csv")
+        val oldInfo = ChunkedFile(10, 100, 1000, oldUID, "file.csv")
         sut.put(oldInfo)
 
         // first confirm that the object can be retrieved
@@ -104,7 +104,7 @@ class ChunkedFileCacheTests : MontaguTests()
     fun `can update and read from ChunkedFile items in concurrent threads`()
     {
         val sut = ChunkedFileCache()
-        val testInfo = ChunkedFile(10, 100, "uid", "file.csv")
+        val testInfo = ChunkedFile(10, 100, 1000, "uid", "file.csv")
         sut.put(testInfo)
 
         var result = false

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileCacheTests.kt
@@ -5,7 +5,6 @@ import org.junit.Test
 import org.vaccineimpact.api.app.ChunkedFileCache
 import org.vaccineimpact.api.app.models.ChunkedFile
 import org.vaccineimpact.api.test_helpers.MontaguTests
-import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
@@ -109,7 +108,6 @@ class ChunkedFileCacheTests : MontaguTests()
 
         var result = false
         val threads = mutableListOf<Thread>()
-        File(testInfo.filePath).createNewFile()
         for (i in 1..10)
         {
             threads.add(
@@ -124,7 +122,6 @@ class ChunkedFileCacheTests : MontaguTests()
             // just wait for threads to finish
         }
 
-        File(testInfo.filePath).delete()
         assertThat(result).isTrue()
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileUploadManagerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/ChunkedFileUploadManagerTests.kt
@@ -1,0 +1,74 @@
+package org.vaccineimpact.api.tests
+
+import org.assertj.core.api.Assertions.*
+import org.junit.After
+import org.junit.Test
+import org.vaccineimpact.api.app.ChunkedFileManager
+import org.vaccineimpact.api.app.models.ChunkedFile
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.io.File
+
+class ChunkedFileUploadManagerTests : MontaguTests()
+{
+    val uid = "uid"
+    val tempFileName = "${ChunkedFileManager.UPLOAD_DIR}/$uid.temp"
+    val finalFileName = "${ChunkedFileManager.UPLOAD_DIR}/$uid"
+
+    @After
+    fun `clean up files`()
+    {
+        File(tempFileName).delete()
+        File(finalFileName).delete()
+    }
+
+    @Test
+    fun `renames file if upload is complete`()
+    {
+        val sut = ChunkedFileManager()
+        val tempFile = File(tempFileName)
+        val finalFile = File(finalFileName)
+        tempFile.createNewFile()
+
+        val testFile = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100, uniqueIdentifier = uid,
+                originalFileName = "file.csv")
+
+        assertThat(tempFile.exists()).isTrue()
+        assertThat(finalFile.exists()).isFalse()
+
+        for (i in 1..10)
+        {
+            testFile.uploadedChunks[i] = true
+        }
+
+        sut.markFileAsComplete(testFile)
+        assertThat(tempFile.exists()).isFalse()
+        assertThat(finalFile.exists()).isTrue()
+    }
+
+    @Test
+    fun `can write chunks to file`()
+    {
+        val sut = ChunkedFileManager()
+
+        val content = "TEST"
+        val chunked = "TEST".chunked(1)
+
+        val fakeFile = ChunkedFile(totalChunks = chunked.count(),
+                totalSize = content.toByteArray().count().toLong(),
+                chunkSize = 1,
+                uniqueIdentifier = uid,
+                originalFileName = "file.csv")
+
+        for (i in 0 until chunked.count())
+        {
+            val stream = chunked[i].byteInputStream()
+            val length = chunked[i].length
+            sut.writeChunk(stream, length, fakeFile, i + 1)
+        }
+
+        assertThat(File(tempFileName).exists()).isTrue()
+        val result = File(tempFileName).readText()
+        assertThat(result).isEqualTo(content)
+
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/context/RequestDataSourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/context/RequestDataSourceTests.kt
@@ -17,23 +17,23 @@ class RequestDataSourceTests : MontaguTests()
     @Test
     fun `can get content type from body source`()
     {
-        val reader = StringReader("Text")
+        val text = "Text".byteInputStream()
         val context = mock<ActionContext> {
-            on { requestReader() } doReturn reader
+            on { getInputStream() } doReturn text
             on { contentType() } doReturn "content/type"
         }
         val source = RequestBodySource(context)
-        assertThat(source.getContent()).isEqualTo(reader)
+        assertThat(source.getContent().reader().readText()).isEqualTo("Text")
     }
 
     @Test
     fun `can get content type from multipart stream source`()
     {
-        val file = StringReader("Text")
+        val file = "Text".byteInputStream()
         val context = mock<ActionContext> {
             on { getPart(eq("part1"), anyOrNull()) } doReturn file
         }
         val source = MultipartStreamSource("part1", context)
-        assertThat(source.getContent()).isEqualTo(file)
+        assertThat(source.getContent().reader().readText()).isEqualTo("Text")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -1,12 +1,14 @@
 package org.vaccineimpact.api.tests.controllers.BurdenEstimates
 
 import com.nhaarman.mockito_kotlin.*
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.util.diff.Chunk
 import org.junit.Test
 import org.mockito.Mockito
 import org.vaccineimpact.api.app.Cache
 import org.vaccineimpact.api.app.ChunkedFileCache
+import org.vaccineimpact.api.app.ChunkedFileManager
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
 import org.vaccineimpact.api.app.errors.BadRequest
@@ -23,6 +25,7 @@ import org.vaccineimpact.api.security.TokenType
 import org.vaccineimpact.api.security.TokenValidationException
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.tests.mocks.mockCSVPostData
+import java.io.InputStream
 
 class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
 {
@@ -286,10 +289,26 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         val mockContext = mockResumableUploadActionContext("uid")
         val mockTokenHelper = getMockTokenHelper("user.name", "uid")
         val fakeCache = makeFakeCacheWithChunkedFile("uid", uploadFinished = false)
+
+        var chunkWritten = false
+
+        class MockFileManager: ChunkedFileManager() {
+            override fun writeChunk(inputStream: InputStream,
+                                    contentLength: Int,
+                                    metadata: ChunkedFile,
+                                    currentChunk: Int) {
+                if (metadata == fakeCache["uid"])
+                {
+                    chunkWritten = true
+                }
+            }
+        }
+
         val sut = BurdenEstimateUploadController(mockContext, mock(), mock(), mock(), mock(),
-                mockTokenHelper, fakeCache, mock())
+                mockTokenHelper, fakeCache, MockFileManager())
 
         sut.uploadBurdenEstimateFile()
+        assertThat(chunkWritten).isTrue()
     }
 
     private fun getMockTokenHelper(username: String, uid: String): WebTokenHelper
@@ -409,6 +428,12 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
 
     private fun mockRepositories(repo: BurdenEstimateRepository) = mock<Repositories> {
         on { burdenEstimates } doReturn repo
+    }
+
+    private val mockStream = mock<InputStream> {
+        on { it.read() } doReturn 1
+        on { it.read(any()) } doReturn 1
+        on { it.read(any(), any(), any()) } doReturn 1
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/DirectActionContextTests.kt
@@ -134,7 +134,7 @@ class DirectActionContextTests : MontaguTests()
         }
         val context = DirectActionContext(mockWebContext())
         val actual = context.getPart("partB", mockData)
-        assertThat(actual.readText()).isEqualTo("Message B")
+        assertThat(actual.reader().readText()).isEqualTo("Message B")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupModelRunParameterControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/GroupModelRunParameterControllerTests.kt
@@ -117,7 +117,7 @@ class GroupModelRunParameterControllerTests : MontaguTests()
     @Test
     fun `throws UnknownObjectError if touchstone is in preparation when adding model run params`()
     {
-        val uploaded = StringReader("disease-1")
+        val uploaded = "disease-1".byteInputStream()
         val mockContext = mock<ActionContext> {
             on { params(":group-id") } doReturn "group-1"
             on { params(":touchstone-version-id") } doReturn "touchstone-bad"

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
@@ -35,14 +35,17 @@ class ChunkedFileTests : MontaguTests()
     @Test
     fun `deletes file on cleanup`() {
         val tempFile = File("${ChunkedFileManager.UPLOAD_DIR}/uid.temp")
+        val finalFile = File("${ChunkedFileManager.UPLOAD_DIR}/uid")
         File(ChunkedFileManager.UPLOAD_DIR).mkdir()
         tempFile.createNewFile()
+        finalFile.createNewFile()
 
         val sut = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100, uniqueIdentifier = "uid",
                 originalFileName = "file.csv")
 
         sut.cleanUp()
         assertThat(tempFile.exists()).isFalse()
+        assertThat(finalFile.exists()).isFalse()
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
@@ -35,6 +35,7 @@ class ChunkedFileTests : MontaguTests()
     @Test
     fun `deletes file on cleanup`() {
         val tempFile = File("${ChunkedFileManager.UPLOAD_DIR}/uid.temp")
+        File(ChunkedFileManager.UPLOAD_DIR).mkdir()
         tempFile.createNewFile()
 
         val sut = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100, uniqueIdentifier = "uid",

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
@@ -1,0 +1,62 @@
+package org.vaccineimpact.api.tests.models
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.vaccineimpact.api.app.models.ChunkedFile
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.io.File
+
+class ChunkedFileTests : MontaguTests()
+{
+
+    @Test
+    fun `detects upload has finished when all chunks are present`()
+    {
+        val sut = ChunkedFile(totalChunks = 10, chunkSize = 100, uniqueIdentifier = "uid", filePath = "file.csv")
+        File(sut.filePath).createNewFile()
+        for (i in 1..10)
+        {
+            sut.uploadedChunks[i] = true
+            assertThat(sut.uploadFinished()).isEqualTo(i == 10)
+        }
+        File(sut.filePath).delete()
+    }
+
+    @Test
+    fun `renames file if upload has finished`()
+    {
+        val tempFile = File("file.csv.temp")
+        val finalFile = File("file.csv")
+        tempFile.createNewFile()
+
+        val sut = ChunkedFile(totalChunks = 10, chunkSize = 100, uniqueIdentifier = "uid", file = finalFile)
+        assertThat(sut.filePath).endsWith("file.csv.temp")
+
+        for (i in 1..10)
+        {
+            sut.uploadedChunks[i] = true
+        }
+
+        val result = sut.uploadFinished()
+        assertThat(result).isTrue()
+        assertThat(sut.filePath).endsWith("file.csv")
+        assertThat(tempFile.exists()).isFalse()
+        assertThat(finalFile.exists()).isTrue()
+
+        finalFile.delete()
+    }
+
+    @Test
+    fun `deletes file on cleanup`() {
+        val tempFile = File("file.csv.temp")
+        val finalFile = File("file.csv")
+        tempFile.createNewFile()
+
+        val sut = ChunkedFile(totalChunks = 10, chunkSize = 100, uniqueIdentifier = "uid", file = finalFile)
+        sut.cleanUp()
+
+        assertThat(tempFile.exists()).isFalse()
+        assertThat(finalFile.exists()).isFalse()
+    }
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/ChunkedFileTests.kt
@@ -3,16 +3,16 @@ package org.vaccineimpact.api.tests.models
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
+import org.vaccineimpact.api.app.ChunkedFileManager
 import org.vaccineimpact.api.app.models.ChunkedFile
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.io.File
 
 class ChunkedFileTests : MontaguTests()
 {
-
     val uid = "uid"
-    val tempFileName = "${ChunkedFile.UPLOAD_DIR}/$uid.temp"
-    val finalFileName = "${ChunkedFile.UPLOAD_DIR}/$uid"
+    val tempFileName = "${ChunkedFileManager.UPLOAD_DIR}/$uid.temp"
+    val finalFileName = "${ChunkedFileManager.UPLOAD_DIR}/$uid"
 
     @After
     fun `clean up files`(){
@@ -25,7 +25,6 @@ class ChunkedFileTests : MontaguTests()
     {
         val sut = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100,
                 uniqueIdentifier = "uid", originalFileName = "file.csv")
-        File(sut.filePath).createNewFile()
         for (i in 1..10)
         {
             sut.uploadedChunks[i] = true
@@ -34,31 +33,8 @@ class ChunkedFileTests : MontaguTests()
     }
 
     @Test
-    fun `renames file if upload has finished`()
-    {
-        val tempFile = File("${ChunkedFile.UPLOAD_DIR}/uid.temp")
-        val finalFile = File("${ChunkedFile.UPLOAD_DIR}/uid")
-        tempFile.createNewFile()
-
-        val sut = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100, uniqueIdentifier = "uid",
-                originalFileName = "file.csv")
-        assertThat(sut.filePath).endsWith("uid.temp")
-
-        for (i in 1..10)
-        {
-            sut.uploadedChunks[i] = true
-        }
-
-        val result = sut.uploadFinished()
-        assertThat(result).isTrue()
-        assertThat(sut.filePath).endsWith("uid")
-        assertThat(tempFile.exists()).isFalse()
-        assertThat(finalFile.exists()).isTrue()
-    }
-
-    @Test
     fun `deletes file on cleanup`() {
-        val tempFile = File("${ChunkedFile.UPLOAD_DIR}/uid.temp")
+        val tempFile = File("${ChunkedFileManager.UPLOAD_DIR}/uid.temp")
         tempFile.createNewFile()
 
         val sut = ChunkedFile(totalChunks = 10, totalSize = 1000, chunkSize = 100, uniqueIdentifier = "uid",

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/BurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/BurdenEstimateTests.kt
@@ -38,14 +38,22 @@ abstract class BurdenEstimateTests : DatabaseTest()
         return ReturnedIds(responsibilityId, modelVersionId, setId)
     }
 
-    protected fun setUpWithBurdenEstimateSet(db: JooqContext, setId: Int? = null, status: String = "empty",
-                                             expectedOutcomes: List<String> = listOf(), setType: String = "central-single-run"): Int
+    protected fun setUpWithBurdenEstimateSet(db: JooqContext,
+                                             setId: Int? = null,
+                                             status: String = "empty",
+                                             expectedOutcomes: List<String> = listOf(),
+                                             setType: String = "central-single-run",
+                                             yearMinInclusive: Short = 1996,
+                                             yearMaxInclusive: Short = 1997): Int
     {
         val returnedIds = setUp(db)
         TestUserHelper.setupTestUser()
 
-        db.addExpectations(returnedIds.responsibilityId, yearMinInclusive = 1996, yearMaxInclusive = 1997,
-                ageMaxInclusive = 50, ageMinInclusive = 50, countries = listOf("AFG", "AGO"), outcomes = expectedOutcomes)
+        db.addExpectations(returnedIds.responsibilityId,
+                ageMaxInclusive = 50, ageMinInclusive = 50,
+                yearMinInclusive = yearMinInclusive,
+                yearMaxInclusive = yearMaxInclusive,
+                countries = listOf("AFG", "AGO"), outcomes = expectedOutcomes)
         return db.addBurdenEstimateSet(
                 returnedIds.responsibilityId,
                 returnedIds.modelVersionId,
@@ -121,6 +129,19 @@ abstract class BurdenEstimateTests : DatabaseTest()
    "Hib3",   1996,    50,     "AGO",       "Angola",          5000,     1000,      NA,    5670
    "Hib3",   1997,    50,     "AGO",       "Angola",          6000,     1200,      NA,    5870
 """
+
+    val longCsvData = """
+"disease", "year", "age", "country", "country_name", "cohort_size", "deaths", "cases", "dalys"
+   "Hib3",   1996,    50,     "AFG",  "Afghanistan",         10000,     1000,    2000,      NA
+   "Hib3",   1997,    50,     "AFG",  "Afghanistan",         10500,      900,    2000,      NA
+   "Hib3",   1996,    50,     "AGO",       "Angola",          5000,     1000,      NA,    5670
+   "Hib3",   1997,    50,     "AGO",       "Angola",          6000,     1200,      NA,    5870
+   "Hib3",   1998,    50,     "AFG",  "Afghanistan",         10000,     1000,    2000,      NA
+   "Hib3",   1999,    50,     "AFG",  "Afghanistan",         10500,      900,    2000,      NA
+   "Hib3",   1998,    50,     "AGO",       "Angola",          5000,     1000,      NA,    5670
+   "Hib3",   1999,    50,     "AGO",       "Angola",          6000,     1200,      NA,    5870
+"""
+
     val duplicateCsvData = """
 "disease", "year", "age", "country", "country_name", "cohort_size", "deaths", "cases", "dalys"
    "Hib3",   1996,    50,     "AFG",  "Afghanistan",         10000,     1000,    2000,      NA

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -268,12 +268,11 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
         val uploadToken = getUploadToken("$setUrl$setId", token)
 
-        val queryParams = mapOf("resumableChunkNumber" to 1,
-                "resumableTotalSize" to size,
-                "resumableChunkSize" to size,
-                "resumableIdentifier" to uploadToken,
-                "resumableFilename" to  fileName,
-                "resumableTotalChunks" to 1)
+        val queryParams = mapOf("chunkNumber" to 1,
+                "totalSize" to size,
+                "chunkSize" to size,
+                "fileName" to  fileName,
+                "totalChunks" to 1)
                 .map { "${it.key}=${it.value}" }
                 .joinToString("&")
 
@@ -316,12 +315,11 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         var response = sendChunk(setId, 1, csvData, 1, uploadToken, token)
         JSONValidator().validateSuccess(response.text)
 
-        val newMetadata = mapOf("resumableChunkNumber" to 1,
-                "resumableTotalSize" to size,
-                "resumableChunkSize" to 1,
-                "resumableIdentifier" to uploadToken,
-                "resumableFilename" to  fileName,
-                "resumableTotalChunks" to 1)
+        val newMetadata = mapOf("chunkNumber" to 1,
+                "totalSize" to size,
+                "chunkSize" to 1,
+                "fileName" to  fileName,
+                "totalChunks" to 1)
                 .map { "${it.key}=${it.value}" }
                 .joinToString("&")
 
@@ -343,16 +341,15 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
                           uploadToken: String,
                           token: TokenLiteral): Response
     {
-        val queryParams = mapOf("resumableChunkNumber" to number,
-                "resumableChunkSize" to 100,
-                "resumableTotalSize" to 1000,
-                "resumableIdentifier" to uploadToken,
-                "resumableFilename" to "test.csv",
-                "resumableTotalChunks" to total)
+        val queryParams = mapOf("chunkNumber" to number,
+                "chunkSize" to 100,
+                "totalSize" to 1000,
+                "fileName" to "test.csv",
+                "totalChunks" to total)
                 .map { "${it.key}=${it.value}" }
                 .joinToString("&")
 
-        val response = RequestHelper().postFile("$setUrl$setId/actions/upload/$token/?$queryParams", chunk, token = token)
+        val response = RequestHelper().postFile("$setUrl$setId/actions/upload/$uploadToken/?$queryParams", chunk, token = token)
         JSONValidator().validateSuccess(response.text)
         return response
     }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTableDeserializer.kt
@@ -5,6 +5,7 @@ import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.helpers.AllColumnsRequired
 import org.vaccineimpact.api.models.helpers.FlexibleColumns
 import org.vaccineimpact.api.serialization.validation.ValidationException
+import java.io.InputStream
 import java.io.Reader
 import java.io.StringReader
 import kotlin.reflect.KClass
@@ -178,6 +179,15 @@ open class DataTableDeserializer<out T>(
         ): Sequence<T>
         {
             return getDeserializer(type, serializer).deserialize(body)
+        }
+
+        fun <T : Any> deserialize(
+                body: InputStream,
+                type: KClass<T>,
+                serializer: Serializer = MontaguSerializer.instance
+        ): Sequence<T>
+        {
+            return getDeserializer(type, serializer).deserialize(body.reader())
         }
 
         fun <T : Any> deserialize(


### PR DESCRIPTION
Adds a new endpoint which accepts chunked data of the kind sent by `resumablejs` or any similar framework.
Sorry about the size of this one, but I struggled to split it up any further in a way that would be meaningful - you kind of need the whole picture to review the parts. Let me know if anything is unclear.