### PR TITLE
I2653 populate burden estimate set from file

### DIFF
--- a/docs/spec/BurdenEstimates.md
+++ b/docs/spec/BurdenEstimates.md
@@ -170,7 +170,8 @@ outcomes in the database.
 Required permissions: Scoped to modelling group: `estimates.write`, `responsibilities.read`.
 
 ## POST /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{set-id}/actions/populate/{token}/
-Populates the given burden estimate set from a file previously uploaded using the given upload token.
+Populates the given burden estimate set from a file previously uploaded using the given upload token. It then
+closes the set and marks it as either `complete` if containing all expected rows, or `invalid` if missing rows.
 
 This can only be invoked if:
 
@@ -192,7 +193,7 @@ unchanged. This can only be invoked if:
 Required permissions: Scoped to modelling group: `estimates.write`, `responsibilities.read`.
 
 ## POST /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{set-id}/actions/close/
-Marks a burden estimate set as `complete`. This can only be invoked if:
+Marks a burden estimate set as `complete` if containing all expected rows, or `invalid` if missing rows. This can only be invoked if:
 
 * The touchstone is `open`
 * The relevant responsibility set is `incomplete`

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
@@ -51,6 +51,10 @@ object BurdenEstimatesRouteConfig : RouteConfig
                     .json()
                     .secure(writePermissions),
 
+            Endpoint("$baseUrl/:set-id/actions/populate/:token/", uploadController, "populateBurdenEstimateSetFromLocalFile", method = HttpMethod.post)
+                    .json()
+                    .secure(writePermissions),
+
             Endpoint("$baseUrl/:set-id/", uploadController, "populateBurdenEstimateSet", method = HttpMethod.post)
                     .json()
                     .secure(writePermissions),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -1,0 +1,135 @@
+package org.vaccineimpact.api.tests.controllers.BurdenEstimates
+
+import org.junit.Test
+import org.vaccineimpact.api.app.context.ActionContext
+import java.io.File
+import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import com.nhaarman.mockito_kotlin.*
+import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
+import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
+import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.InvalidOperationError
+import org.vaccineimpact.api.security.KeyHelper
+import org.vaccineimpact.api.security.TokenValidationException
+import org.vaccineimpact.api.security.WebTokenHelper
+
+class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
+{
+    @Test
+    fun `can populate central estimate set from local file`()
+    {
+        val touchstoneSet = mockTouchstones()
+        val logic = mockLogic()
+
+        val uid = "uid"
+
+        createTempCSVFile(uid)
+
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val repo = mockEstimatesRepository(touchstoneSet)
+        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
+        val mockTokenHelper = getMockTokenHelper("user.name", uid)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+
+        val result = sut.populateBurdenEstimateSetFromLocalFile()
+
+        assertThat(result).isEqualTo("OK")
+        verify(logic).populateBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"), any())
+        verify(logic).closeBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"))
+    }
+
+    @Test
+    fun `populating central estimate set from local file deletes file and clears cache item on success`()
+    {
+        val touchstoneSet = mockTouchstones()
+        val logic = mockLogic()
+        val uid = "uid"
+
+        val file = File(uid)
+        val tempFile = createTempCSVFile(uid)
+
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val repo = mockEstimatesRepository(touchstoneSet)
+        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
+        val mockTokenHelper = getMockTokenHelper("user.name", uid)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+
+        val result = sut.populateBurdenEstimateSetFromLocalFile()
+
+        assertThat(result).isEqualTo("OK")
+        assertThat(cache[uid]).isNull()
+        assertThat(tempFile.exists()).isFalse()
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `populating set from local file throws error if uid not recognised`()
+    {
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val mockTokenHelper = getMockTokenHelper("user.name", "uid")
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), mock(), mock(), mock(), mockTokenHelper, mock())
+
+        assertThatThrownBy { sut.populateBurdenEstimateSetFromLocalFile() }
+                .isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining("Unrecognised file identifier - has this token already been used?")
+
+    }
+
+    @Test
+    fun `populating set from local file requires file to be fully uploaded`()
+    {
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val mockTokenHelper = getMockTokenHelper("user.name", "uid")
+        val fakeCache = makeFakeCacheWithChunkedFile("uid", uploadFinished = false)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), mock(), mock(), mock(),
+                mockTokenHelper, fakeCache)
+
+        assertThatThrownBy { sut.populateBurdenEstimateSetFromLocalFile() }
+                .isInstanceOf(InvalidOperationError::class.java)
+                .hasMessageContaining("This file has not been fully uploaded")
+
+    }
+
+    @Test
+    fun `populating set from local file requires token to be validated`()
+    {
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val fakeCache = makeFakeCacheWithChunkedFile("uid", uploadFinished = true)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), mock(), mock(), mock(),
+                WebTokenHelper(KeyHelper.keyPair),
+                fakeCache)
+
+        assertThatThrownBy { sut.populateBurdenEstimateSetFromLocalFile() }
+                .isInstanceOf(TokenValidationException::class.java)
+                .hasMessageContaining("Could not verify token")
+
+    }
+
+    private fun createTempCSVFile(fileName: String): File
+    {
+        File(UPLOAD_DIR).mkdir()
+        val tempFile = File("$UPLOAD_DIR/$fileName.temp")
+        tempFile.createNewFile()
+        tempFile.writeText(normalCSVDataString)
+        return tempFile
+    }
+
+    private fun mockPopulateFromLocalFileActionContext(user: String): ActionContext
+    {
+        return mock {
+            on { username } doReturn user
+            on { params(":set-id") } doReturn "1"
+            on { params(":group-id") } doReturn "group-1"
+            on { params(":touchstone-version-id") } doReturn "touchstone-1"
+            on { params(":scenario-id") } doReturn "scenario-1"
+            on { params(":token") } doReturn "faketoken"
+        }
+    }
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -24,7 +24,7 @@ import org.vaccineimpact.api.security.TokenValidationException
 import org.vaccineimpact.api.security.WebTokenHelper
 import org.vaccineimpact.api.tests.mocks.mockCSVPostData
 
-class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
+open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
 {
     @Test
     fun `can get upload token`()
@@ -292,7 +292,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         sut.uploadBurdenEstimateFile()
     }
 
-    private fun getMockTokenHelper(username: String, uid: String): WebTokenHelper
+    protected fun getMockTokenHelper(username: String, uid: String): WebTokenHelper
     {
         return mock {
             on { verify(any(), eq(TokenType.UPLOAD)) } doReturn
@@ -306,7 +306,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         }
     }
 
-    private fun makeFakeCacheWithChunkedFile(uid: String, uploadFinished: Boolean): Cache<ChunkedFile>
+    protected fun makeFakeCacheWithChunkedFile(uid: String, uploadFinished: Boolean): Cache<ChunkedFile>
     {
         val fakeInfo = ChunkedFile(totalChunks = 1, totalSize = 1000, chunkSize = 100,
                 uniqueIdentifier = uid, originalFileName = "filename.csv")
@@ -320,7 +320,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         return cache
     }
 
-    private fun populateAndCheckIfSetIsClosed(keepOpen: String?, expectedClosed: Boolean)
+    protected fun populateAndCheckIfSetIsClosed(keepOpen: String?, expectedClosed: Boolean)
     {
         val timesExpected = if (expectedClosed) times(1) else never()
 
@@ -333,7 +333,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 "group-1", "touchstone-1", "scenario-1")
     }
 
-    private fun mockActionContext(user: String = "username", keepOpen: String? = null): ActionContext
+    protected fun mockActionContext(user: String = "username", keepOpen: String? = null): ActionContext
     {
         return mock {
             on { username } doReturn user
@@ -346,7 +346,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         }
     }
 
-    private fun mockResumableUploadActionContext(uploadToken: String,
+    protected fun mockResumableUploadActionContext(uploadToken: String,
                                                  fileName: String = "filename.csv",
                                                  user: String = "user.name"): ActionContext
     {
@@ -364,7 +364,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         }
     }
 
-    private fun <T : Any> verifyLogicIsInvokedToPopulateSet(
+    protected fun <T : Any> verifyLogicIsInvokedToPopulateSet(
             actionContext: ActionContext,
             repo: BurdenEstimateRepository,
             logic: BurdenEstimateLogic,
@@ -390,7 +390,7 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         )
     }
 
-    private val normalCSVData = listOf(
+    protected val normalCSVData = listOf(
             BurdenEstimate("yf", 2000, 50, "AFG", "Afghanistan", 1000F, mapOf(
                     "deaths" to 10F,
                     "cases" to 100F
@@ -401,13 +401,13 @@ class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             ))
     )
 
-    private val normalCSVDataString = """
+    protected val normalCSVDataString = """
 "disease", "year", "age", "country", "country_name", "cohort_size", "deaths", "cases"
    "yf",   2000,    50,     "AFG",  "Afghanistan",         1000,     10,    100
    "yf",   1980,    30,     "AGO",  "Angola",         2000,      20,    73.6
 """
 
-    private fun mockRepositories(repo: BurdenEstimateRepository) = mock<Repositories> {
+    protected fun mockRepositories(repo: BurdenEstimateRepository) = mock<Repositories> {
         on { burdenEstimates } doReturn repo
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -322,7 +322,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     @Test
     fun `can upload by multiple chunks and get validation error on population`() {
         val setId = JooqContext().use {
-            setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
+            setUpWithBurdenEstimateSet(it)
         }
 
         val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -256,7 +256,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload file in 1 chunk and populate`() {
+    fun `can upload file in 1 chunk and then populate set`() {
 
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
@@ -291,7 +291,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload by multiple chunks and then populate`() {
+    fun `can upload file by multiple chunks and then populate set`() {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
         }
@@ -320,7 +320,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload by multiple chunks and get validation error on population`() {
+    fun `can upload file by multiple chunks and get validation error on set population`() {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
         }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -256,7 +256,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload file in 1 chunk`() {
+    fun `can upload file in 1 chunk and populate`() {
 
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
@@ -278,10 +278,20 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
 
         val response = RequestHelper().postFile("$setUrl$setId/actions/upload/$uploadToken/?$queryParams", csvData, token = token)
         JSONValidator().validateSuccess(response.text)
+
+        val populateResponse = populateFromFile(setId, 1, uploadToken, token)
+        JSONValidator().validateSuccess(populateResponse.text)
+
+        JooqContext().use { db ->
+            val records = db.dsl.select(BURDEN_ESTIMATE.fieldsAsList())
+                    .from(BURDEN_ESTIMATE)
+                    .fetch()
+            assertThat(records).isNotEmpty
+        }
     }
 
     @Test
-    fun `can upload by multiple chunks`() {
+    fun `can upload by multiple chunks and then populate`() {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
         }
@@ -296,6 +306,45 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         {
             val response = sendChunk(setId, i + 1, data[i], numChunks, uploadToken, token)
             JSONValidator().validateSuccess(response.text)
+        }
+
+        val response = populateFromFile(setId, numChunks, uploadToken, token)
+        JSONValidator().validateSuccess(response.text)
+
+        JooqContext().use { db ->
+            val records = db.dsl.select(BURDEN_ESTIMATE.fieldsAsList())
+                    .from(BURDEN_ESTIMATE)
+                    .fetch()
+            assertThat(records).isNotEmpty
+        }
+    }
+
+    @Test
+    fun `can upload by multiple chunks and get validation error on population`() {
+        val setId = JooqContext().use {
+            setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
+        }
+
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val uploadToken = getUploadToken("$setUrl$setId", token)
+        val chunkSize = 100
+        val data = longCsvData.chunked(chunkSize)
+        val numChunks = data.count()
+
+        for (i in 0 until numChunks)
+        {
+            val response = sendChunk(setId, i + 1, data[i], numChunks, uploadToken, token)
+            JSONValidator().validateSuccess(response.text)
+        }
+
+        val response = populateFromFile(setId, numChunks, uploadToken, token)
+        assertThat(response.text).contains("We are not expecting data for age 50 and year 1998")
+
+        JooqContext().use { db ->
+            val records = db.dsl.select(BURDEN_ESTIMATE.fieldsAsList())
+                    .from(BURDEN_ESTIMATE)
+                    .fetch()
+            assertThat(records).isEmpty()
         }
     }
 
@@ -328,6 +377,27 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
                 "The given token has already been used to upload a different file. Please request a fresh upload token.")
     }
 
+    @Test
+    fun `populating set fails if file is not fully uploaded`()
+    {
+        val setId = JooqContext().use {
+            setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
+        }
+
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredWritePermissions, includeCanLogin = true)
+        val uploadToken = getUploadToken("$setUrl$setId", token)
+
+        val chunkSize = 100
+        val data = longCsvData.chunked(chunkSize)
+        val numChunks = data.count()
+
+        sendChunk(setId, 1, data[0], numChunks, uploadToken, token)
+
+        val response = populateFromFile(setId, numChunks, uploadToken, token)
+        assertThat(response.text).contains("This file has not been fully uploaded")
+        assertThat(response.statusCode).isEqualTo(400)
+    }
+
     private fun getUploadToken(setUrl: String, token: TokenLiteral) : String {
         val response = RequestHelper().get("$setUrl/actions/request-upload/", token = token)
         val json = com.beust.klaxon.Parser().parse(StringBuilder(response.text)) as com.beust.klaxon.JsonObject
@@ -352,5 +422,13 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         val response = RequestHelper().postFile("$setUrl$setId/actions/upload/$uploadToken/?$queryParams", chunk, token = token)
         JSONValidator().validateSuccess(response.text)
         return response
+    }
+
+    private fun populateFromFile(setId: Int,
+                                 total: Int,
+                                 uploadToken: String,
+                                 token: TokenLiteral): Response
+    {
+        return RequestHelper().post("$setUrl$setId/actions/populate/$uploadToken/", token = token)
     }
 }


### PR DESCRIPTION
This adds the third and final endpoint, which populates the burden estimate set from the uploaded file.