### PR TITLE
Bug fix - can't set cookies for test user on support

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqModellingGroupRepository.kt
@@ -1,23 +1,15 @@
 package org.vaccineimpact.api.app.repositories.jooq
 
-import org.jooq.*
-import org.vaccineimpact.api.app.errors.BadRequest
+import org.jooq.DSLContext
 import org.vaccineimpact.api.app.errors.UnknownObjectError
-import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
-import org.vaccineimpact.api.app.filters.whereMatchesFilter
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
-import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
-import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.app.repositories.jooq.mapping.BurdenMappingHelper
 import org.vaccineimpact.api.db.Tables.*
 import org.vaccineimpact.api.db.fetchInto
 import org.vaccineimpact.api.db.fieldsAsList
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.db.tables.records.ModellingGroupRecord
-import org.vaccineimpact.api.db.tables.records.ResponsibilitySetRecord
 import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.serialization.SplitData
 
 class JooqModellingGroupRepository(
         dsl: DSLContext,
@@ -30,7 +22,8 @@ class JooqModellingGroupRepository(
                 .fromJoinPath(MODELLING_GROUP, MODEL)
                 .where(MODELLING_GROUP.ID.eq(groupId))
                 .and(MODEL.IS_CURRENT)
-                .fetchInto(String::class.java)
+                .fetch()
+                .mapNotNull { it.into(String::class.java) }
     }
 
     override fun createModellingGroup(newGroup: ModellingGroupCreation)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/security/WebTokenHelperTests.kt
@@ -92,6 +92,23 @@ class WebTokenHelperTests : MontaguTests()
     }
 
     @Test
+    fun `can generate model review token for user with no diseases`()
+    {
+        val roles = listOf(ReifiedRole("member", Scope.Specific("modelling-group", "test-group")))
+        val token = sut.generateModelReviewToken(InternalUser(properties.copy(username = "some.user"),
+                roles, permissions), listOf())
+        val claims = sut.verify(token.deflated(), TokenType.MODEL_REVIEW)
+
+        assertThat(claims["iss"]).isEqualTo("vaccineimpact.org")
+        assertThat(claims["token_type"]).isEqualTo("MODEL_REVIEW")
+        assertThat(claims["sub"]).isEqualTo("some.user")
+        assertThat(claims["exp"]).isInstanceOf(Date::class.java)
+        assertThat(claims["url"]).isEqualTo("*")
+        assertThat(claims["access_level"]).isEqualTo("user")
+        assertThat(claims.keys.count()).isEqualTo(6)
+    }
+
+    @Test
     fun `can generate model review token for admin`()
     {
         val token = sut.generateModelReviewToken(InternalUser(properties,

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
@@ -173,6 +173,20 @@ class GetModellingGroupTests : ModellingGroupRepositoryTests()
     }
 
     @Test
+    fun `does not get null diseases for modelling group`()
+    {
+        val groupId = "g1"
+        withDatabase {
+            it.addGroup(groupId, "description")
+            it.addModel("m1", groupId, null)
+        }
+
+        withRepo {
+            assertThat(it.getDiseasesForModellingGroup(groupId).any()).isFalse()
+        }
+    }
+
+    @Test
     fun `does not get duplicate diseases`()
     {
         val groupId = "g1"

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
@@ -32,7 +32,7 @@ fun JooqContext.addGroup(id: String, description: String = id, current: String? 
 fun JooqContext.addModel(
         id: String,
         groupId: String,
-        diseaseId: String,
+        diseaseId: String?,
         description: String = id,
         citation: String = "Unknown citation",
         isCurrent: Boolean = true,


### PR DESCRIPTION
Source of the bug - test.user is a member of all groups, including the group `gavi-legacy-sdf6` which has a model marked as current with null disease id. The null disease id is the source of the null pointer exception. 