### PR TITLE
add attachment header with test

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -85,6 +85,8 @@ open class BurdenEstimatesController(
     {
         val path = getValidResponsibilityPath(context, estimateRepository)
         val setId = context.params(":set-id").toInt()
+        val filename = "burden_estimates_${path.groupId}_${path.touchstoneVersionId}_${path.scenarioId}.csv"
+        context.addAttachmentHeader(filename)
         return estimatesLogic.getBurdenEstimateData(setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/RetrieveBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/RetrieveBurdenEstimateTests.kt
@@ -109,6 +109,8 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         val response = RequestHelper().get(estimatesUrl, permissions, acceptsContentType = "text/csv")
 
         Assertions.assertThat(response.headers["Content-Type"]).isEqualTo("text/csv");
+        Assertions.assertThat(response.headers["Content-Disposition"])
+                .isEqualTo("attachment; filename=\"burden_estimates_group-1_touchstone-1_scenario-1.csv\"");
 
         val csv = StringReader(response.text)
                 .use { CSVReader(it).readAll() }


### PR DESCRIPTION
When downloading burden estimates we should provide a content attachment header with the filename.