### PR TITLE
i2628 - Throw an error for erroneous scenario id on estimate-set endpoint

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/BurdenEstimatesRouteConfig.kt
@@ -23,7 +23,7 @@ object BurdenEstimatesRouteConfig : RouteConfig
 
     override val endpoints = listOf(
             // Get and create sets
-            Endpoint("$baseUrl/", controller, "getBurdenEstimates")
+            Endpoint("$baseUrl/", controller, "getBurdenEstimateSets")
                     .json()
                     .secure(readPermissions),
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
@@ -18,7 +18,7 @@ abstract class BaseBurdenEstimateController(context: ActionContext,
 
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations))
+            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario))
 
     protected fun closeEstimateSetAndReturnMissingRowError(setId: Int, groupId: String, touchstoneVersionId: String,
                                                            scenarioId: String): Result

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -36,7 +36,7 @@ class BurdenEstimateUploadController(context: ActionContext,
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
             repos,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations),
+            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario),
             repos.burdenEstimates)
 
     fun getUploadToken(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -18,13 +18,13 @@ open class BurdenEstimatesController(
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations),
+            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario),
             repos.burdenEstimates)
 
     fun getBurdenEstimates(): List<BurdenEstimateSet>
     {
         val path = getValidResponsibilityPath(context, estimateRepository)
-        return estimateRepository.getBurdenEstimateSets(path.groupId, path.touchstoneVersionId, path.scenarioId)
+        return estimatesLogic.getBurdenEstimateSets(path.groupId, path.touchstoneVersionId, path.scenarioId)
     }
 
     fun getBurdenEstimateSet(): BurdenEstimateSet

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -21,7 +21,7 @@ open class BurdenEstimatesController(
             RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario),
             repos.burdenEstimates)
 
-    fun getBurdenEstimates(): List<BurdenEstimateSet>
+    fun getBurdenEstimateSets(): List<BurdenEstimateSet>
     {
         val path = getValidResponsibilityPath(context, estimateRepository)
         return estimatesLogic.getBurdenEstimateSets(path.groupId, path.touchstoneVersionId, path.scenarioId)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.api.app.models.BurdenEstimateOutcome
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.ExpectationsRepository
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.app.validate
 import org.vaccineimpact.api.app.validateStochastic
@@ -28,14 +29,23 @@ interface BurdenEstimateLogic
                      burdenEstimateGrouping: BurdenEstimateGrouping = BurdenEstimateGrouping.AGE):
             BurdenEstimateDataSeries
 
+    fun getBurdenEstimateSets(groupId: String, touchstoneVersionId: String, scenarioId: String): List<BurdenEstimateSet>
+
     fun getBurdenEstimateData(setId: Int, groupId: String, touchstoneVersionId: String,
                               scenarioId: String) : FlexibleDataTable<BurdenEstimate>
 }
 
 class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: ModellingGroupRepository,
                                       private val burdenEstimateRepository: BurdenEstimateRepository,
-                                      private val expectationsRepository: ExpectationsRepository) : BurdenEstimateLogic
+                                      private val expectationsRepository: ExpectationsRepository,
+                                      private val scenarioRepository: ScenarioRepository) : BurdenEstimateLogic
 {
+    override fun getBurdenEstimateSets(groupId: String, touchstoneVersionId: String, scenarioId: String): List<BurdenEstimateSet>
+    {
+        scenarioRepository.checkScenarioDescriptionExists(scenarioId)
+        return burdenEstimateRepository.getBurdenEstimateSets(groupId, touchstoneVersionId, scenarioId)
+    }
+
     override fun getEstimates(setId: Int, groupId: String, touchstoneVersionId: String,
                               scenarioId: String,
                               outcome: String,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ScenarioRepository.kt
@@ -1,11 +1,12 @@
 package org.vaccineimpact.api.app.repositories
 
+import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.models.Scenario
 
 interface ScenarioRepository : Repository
 {
-    /** Throws an UnknownObjectError if it doesn't exist **/
+    @Throws(UnknownObjectError::class)
     fun checkScenarioDescriptionExists(id: String): Unit
 
     fun getScenarios(descriptionIds: Iterable<String>): List<Scenario>

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -33,17 +33,18 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         )
         val touchstoneRepo = mockTouchstoneRepository()
         val repo = mock<BurdenEstimateRepository> {
-            on { getBurdenEstimateSets(any(), any(), any()) } doReturn data
             on { touchstoneRepository } doReturn touchstoneRepo
+        }
+        val logic = mock<BurdenEstimateLogic> {
+            on { getBurdenEstimateSets(any(), any(), any()) } doReturn data
         }
         val context = mock<ActionContext> {
             on { params(":group-id") } doReturn "group-1"
             on { params(":touchstone-version-id") } doReturn "touchstone-1"
             on { params(":scenario-id") } doReturn "scenario-1"
         }
-        assertThat(BurdenEstimatesController(context, mock(), repo).getBurdenEstimateSets())
+        assertThat(BurdenEstimatesController(context, logic, repo).getBurdenEstimateSets())
                 .hasSameElementsAs(data.toList())
-        verify(repo).getBurdenEstimateSets("group-1", "touchstone-1", "scenario-1")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -10,6 +10,7 @@ import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimatesCont
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTableDeserializer
 import java.time.Instant

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -10,7 +10,6 @@ import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimatesCont
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
-import org.vaccineimpact.api.app.repositories.ScenarioRepository
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTableDeserializer
 import java.time.Instant
@@ -42,7 +41,7 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":touchstone-version-id") } doReturn "touchstone-1"
             on { params(":scenario-id") } doReturn "scenario-1"
         }
-        assertThat(BurdenEstimatesController(context, mock(), repo).getBurdenEstimates())
+        assertThat(BurdenEstimatesController(context, mock(), repo).getBurdenEstimateSets())
                 .hasSameElementsAs(data.toList())
         verify(repo).getBurdenEstimateSets("group-1", "touchstone-1", "scenario-1")
     }


### PR DESCRIPTION
Create logic method for getting burden estimate sets and check scenario exists before looking up estimate sets.