### PR TITLE
use correct transaction scope for populating burden estimates

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -135,9 +135,12 @@ class BurdenEstimateUploadController(context: ActionContext,
                     path.scenarioId,
                     setId)
 
+            val logic = RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario,
+                    repos.touchstone)
+
             // Then add the burden estimates
             val data = getBurdenEstimateDataFromCSV(metadata, source)
-            estimatesLogic.populateBurdenEstimateSet(
+            logic.populateBurdenEstimateSet(
                     setId,
                     path.groupId, path.touchstoneVersionId, path.scenarioId,
                     data

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/CloseBurdenEstimateSetTests.kt
@@ -107,7 +107,6 @@ class CloseBurdenEstimateSetTests : BurdenEstimateTests()
         assertSetHasStatus("invalid", setId)
     }
 
-    @Ignore
     @Test
     fun `can populate and close burden estimate with onetime token and redirect`()
     {
@@ -125,8 +124,7 @@ class CloseBurdenEstimateSetTests : BurdenEstimateTests()
         JSONValidator().validateSuccess(resultAsString)
         assertSetHasStatus("complete", setId)
     }
-
-    @Ignore
+    
     @Test
     fun `missing rows error comes through with redirect`()
     {


### PR DESCRIPTION
Not ready for merge, controller tests need updating.