### PR TITLE
I2770 - persist incomplete estimate sets to db

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -82,7 +82,7 @@ class BurdenEstimateUploadController(context: ActionContext,
         return okayResponse()
     }
 
-    fun populateBurdenEstimateSetFromLocalFile(): String
+    fun populateBurdenEstimateSetFromLocalFile(): Result
     {
         val uploadToken = context.params(":token")
         val path = UploadPath(tokenHelper.verify(uploadToken, TokenType.UPLOAD))
@@ -109,9 +109,9 @@ class BurdenEstimateUploadController(context: ActionContext,
             )
 
             chunkedFileCache.remove(file.uniqueIdentifier)
-            estimatesLogic.closeBurdenEstimateSet(path.setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
 
-            okayResponse()
+            return closeEstimateSetAndReturnMissingRowError(path.setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
+
         }
         else
         {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploa
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.MissingRowsError
+import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
 import org.vaccineimpact.api.models.ErrorInfo
@@ -174,8 +175,8 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
                 fakeCache)
 
         assertThatThrownBy { sut.populateBurdenEstimateSetFromLocalFile() }
-                .isInstanceOf(TokenValidationException::class.java)
-                .hasMessageContaining("Could not verify token")
+                .isInstanceOf(UnknownObjectError::class.java)
+                .hasMessageContaining("upload-token")
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -10,9 +10,15 @@ import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.InvalidOperationError
+import org.vaccineimpact.api.app.errors.MissingRowsError
+import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
+import org.vaccineimpact.api.models.BurdenEstimateWithRunId
+import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.api.models.ResultStatus
 import org.vaccineimpact.api.security.KeyHelper
 import org.vaccineimpact.api.security.TokenValidationException
 import org.vaccineimpact.api.security.WebTokenHelper
+import java.lang.NullPointerException
 
 class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 {
@@ -35,9 +41,70 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
-        assertThat(result).isEqualTo("OK")
+        assertThat(result.status).isEqualTo(ResultStatus.SUCCESS)
+        assertThat(result.data).isEqualTo("OK")
         verify(logic).populateBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"), any())
         verify(logic).closeBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"))
+    }
+
+    @Test
+    fun `MissingRowsErrors are caught and returned as a Result`()
+    {
+        val touchstoneSet = mockTouchstones()
+        val logic = mock<BurdenEstimateLogic> {
+            on { populateBurdenEstimateSet(any(), any(), any(), any(), any()) } doAnswer { args ->
+                // Force evaluation of sequence
+                args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
+                Unit
+            }
+            on { closeBurdenEstimateSet(any(), any(), any(), any()) } doThrow MissingRowsError("TEST")
+        }
+
+        val uid = "uid"
+
+        createTempCSVFile(uid)
+
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val repo = mockEstimatesRepository(touchstoneSet)
+        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
+        val mockTokenHelper = getMockTokenHelper("user.name", uid)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+
+        val result = sut.populateBurdenEstimateSetFromLocalFile()
+
+        assertThat(result.status).isEqualTo(ResultStatus.FAILURE)
+        assertThat(result.errors[0]).isEqualTo(ErrorInfo("missing-rows", "TEST"))
+    }
+
+    @Test
+    fun `arbitrary errors are not caught but thrown as usual`()
+    {
+        val touchstoneSet = mockTouchstones()
+        val logic = mock<BurdenEstimateLogic> {
+            on { populateBurdenEstimateSet(any(), any(), any(), any(), any()) } doAnswer { args ->
+                // Force evaluation of sequence
+                args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
+                Unit
+            }
+            on { closeBurdenEstimateSet(any(), any(), any(), any()) } doThrow NullPointerException("TEST")
+        }
+
+        val uid = "uid"
+
+        createTempCSVFile(uid)
+
+        val mockContext = mockPopulateFromLocalFileActionContext("user.name")
+        val repo = mockEstimatesRepository(touchstoneSet)
+        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
+        val mockTokenHelper = getMockTokenHelper("user.name", uid)
+
+        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+
+        assertThatThrownBy {
+            sut.populateBurdenEstimateSetFromLocalFile()
+        }.isInstanceOf(NullPointerException::class.java)
+
     }
 
     @Test
@@ -59,7 +126,8 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
-        assertThat(result).isEqualTo("OK")
+        assertThat(result.status).isEqualTo(ResultStatus.SUCCESS)
+        assertThat(result.data).isEqualTo("OK")
         assertThat(cache[uid]).isNull()
         assertThat(tempFile.exists()).isFalse()
         assertThat(file.exists()).isFalse()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -91,7 +91,7 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
         )
 
         val mockContext = mockActionContext()
-        verifyLogicIsInvokedToPopulateSet(mockContext, mockEstimatesRepository(touchstoneSet), logic, touchstoneSet,
+        verifyLogicIsInvokedToPopulateSet(mockContext, mockEstimatesRepository(touchstoneSet), logic,
                 normalCSVData.asSequence(), expectedData)
     }
 
@@ -125,7 +125,7 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
         val mockContext = mockActionContext()
         val repo = mockEstimatesRepository(touchstoneSet, existingBurdenEstimateSet = defaultEstimateSet.copy(
                 type = BurdenEstimateSetType(BurdenEstimateSetTypeCode.STOCHASTIC)))
-        verifyLogicIsInvokedToPopulateSet(mockContext, repo, logic, touchstoneSet,
+        verifyLogicIsInvokedToPopulateSet(mockContext, repo, logic,
                 csvData.asSequence(), expectedData)
     }
 
@@ -405,7 +405,6 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
             actionContext: ActionContext,
             repo: BurdenEstimateRepository,
             logic: BurdenEstimateLogic,
-            touchstoneVersionSet: SimpleDataSet<TouchstoneVersion, String>,
             actualData: Sequence<T>,
             expectedData: List<BurdenEstimateWithRunId>
     )
@@ -451,12 +450,6 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
         on { burdenEstimates } doReturn repo
         on { modellingGroup } doReturn groupRepo
         on { scenario } doReturn scenarioRepository
-    }
-
-    private val mockStream = mock<InputStream> {
-        on { it.read() } doReturn 1
-        on { it.read(any()) } doReturn 1
-        on { it.read(any(), any(), any()) } doReturn 1
     }
 
 }


### PR DESCRIPTION
This brings the new endpoint up to date with the existing behaviour.

Also catches `TokenValidationException` so that an informative error can be returned to the client (otherwise a 500 will be thrown.)