### PR TITLE
Vimc 2810 Test that scoped or global responsibility.read perm required for responsibilities endpoint

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
@@ -10,7 +10,6 @@ object CoverageRouteConfig : RouteConfig
 
     private val permissions = setOf(
             "*/scenarios.read",
-            "*/responsibilities.read",
             "*/coverage.read"
     )
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/TouchstoneCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/TouchstoneCoverageTests.kt
@@ -15,7 +15,7 @@ import java.io.StringReader
 
 class TouchstoneCoverageTests : CoverageTests()
 {
-    val minimumPermissions = PermissionSet("*/can-login", "*/scenarios.read", "*/responsibilities.read", "*/coverage.read")
+    val minimumPermissions = PermissionSet("*/can-login", "*/scenarios.read", "*/coverage.read")
     val url = "/touchstones/$touchstoneVersionId/$scenarioId/coverage/"
 
     @Test


### PR DESCRIPTION
Also remove requirement for */responsibilities.read from touchstone coverage endpoint. This change did not require an update to the spec as it was not mentioned anyway. 