### PR TITLE
Vimc 2957 Do not round demographic data for future touchstones

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/TouchstoneController.kt
@@ -92,7 +92,7 @@ class TouchstoneController(
         val serializer = getSerializer(touchstoneVersion)
 
         val splitData =
-                touchstoneRepo.getDemographicData(type, source, touchstoneVersion.id, gender ?: "both")
+                touchstoneRepo.getDemographicData(type, source, touchstoneVersion.id, gender ?: "both", serializer)
 
         val tableData = when (format)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -5,6 +5,7 @@ import org.vaccineimpact.api.app.repositories.*
 import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTable
+import org.vaccineimpact.api.serialization.DecimalRoundingSerializer
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import org.vaccineimpact.api.serialization.SplitData
 
@@ -27,6 +28,8 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                                 private val touchstoneRepository: TouchstoneRepository,
                                 private val scenarioRepository: ScenarioRepository) : CoverageLogic
 {
+    private val serializer = DecimalRoundingSerializer.instance
+
     override fun getCoverageSetsForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String):
             ScenarioTouchstoneAndCoverageSets
     {
@@ -73,7 +76,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                 responsibilityAndTouchstone.touchstoneVersion,
                 scenario,
                 coverageSets
-        ), DataTable.new(data))
+        ), DataTable.new(data), serializer)
 
         return getDatatable(splitData, format)
     }
@@ -87,7 +90,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                 touchstoneVersion,
                 scenarioAndData.structuredMetadata.scenario,
                 scenarioAndData.structuredMetadata.coverageSets
-        ), scenarioAndData.tableData)
+        ), scenarioAndData.tableData, serializer)
         return getDatatable(splitData, format)
     }
 
@@ -135,7 +138,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
             listOf()
         }
 
-        return FlexibleDataTable.new(rows.asSequence(), years.sorted())
+        return FlexibleDataTable.new(rows.asSequence(), years.sorted(), serializer = serializer)
 
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -76,7 +76,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                 responsibilityAndTouchstone.touchstoneVersion,
                 scenario,
                 coverageSets
-        ), DataTable.new(data), serializer)
+        ), DataTable.new(data, serializer = serializer))
 
         return getDatatable(splitData, format)
     }
@@ -107,7 +107,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                     "and 'wide'.")
         }
 
-        return SplitData(splitData.structuredMetadata, tableData)
+        return SplitData(splitData.structuredMetadata, tableData, serializer)
     }
 
     private fun getWideDatatable(data: Sequence<LongCoverageRow>):
@@ -138,7 +138,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
             listOf()
         }
 
-        return FlexibleDataTable.new(rows.asSequence(), years.sorted(), serializer = serializer)
+        return FlexibleDataTable.new(rows.asSequence(), years.sorted(), serializer)
 
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -4,6 +4,7 @@ import org.jooq.Record
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
 import org.vaccineimpact.api.db.tables.Coverage
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.serialization.SplitData
 
 interface TouchstoneRepository : Repository
@@ -32,7 +33,10 @@ interface TouchstoneRepository : Repository
             : List<CoverageSet>
 
     fun getDemographicDatasets(touchstoneVersionId: String): List<DemographicDataset>
-    fun getDemographicData(statisticTypeCode: String, source: String, touchstoneVersionId: String, gender: String = "both"): SplitData<DemographicDataForTouchstone, LongDemographicRow>
+    fun getDemographicData(statisticTypeCode: String, source: String,
+                           touchstoneVersionId: String,
+                           gender: String = "both",
+                           serializer: Serializer): SplitData<DemographicDataForTouchstone, LongDemographicRow>
 
     fun mapTouchstone(records: List<Record>): Touchstone
     fun mapTouchstoneVersion(record: Record): TouchstoneVersion

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -19,6 +19,7 @@ import org.vaccineimpact.api.db.tables.records.DemographicStatisticTypeRecord
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTable
 import org.vaccineimpact.api.serialization.DecimalRoundingSerializer
+import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.serialization.SplitData
 import java.math.BigDecimal
 import kotlin.sequences.Sequence
@@ -45,14 +46,15 @@ class JooqTouchstoneRepository(
     override fun getDemographicData(statisticTypeCode: String,
                                     source: String,
                                     touchstoneVersionId: String,
-                                    gender: String): SplitData<DemographicDataForTouchstone, LongDemographicRow>
+                                    gender: String,
+                                    serializer: Serializer): SplitData<DemographicDataForTouchstone, LongDemographicRow>
     {
         val metadata = getDemographicMetadata(statisticTypeCode, source, touchstoneVersionId, gender)
         val data = getDemographicStatistics(touchstoneVersionId, statisticTypeCode, source, gender)
                 .orderBy(DEMOGRAPHIC_STATISTIC.COUNTRY, DEMOGRAPHIC_STATISTIC.YEAR, DEMOGRAPHIC_STATISTIC.AGE_FROM)
                 .fetchSequence()
                 .map { mapDemographicRow(it) }
-        return SplitData(metadata, DataTable.new(data))
+        return SplitData(metadata, DataTable.new(data, serializer))
     }
 
     private fun getDemographicMetadata(

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -18,6 +18,7 @@ import org.vaccineimpact.api.db.joinPath
 import org.vaccineimpact.api.db.tables.records.DemographicStatisticTypeRecord
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTable
+import org.vaccineimpact.api.serialization.DecimalRoundingSerializer
 import org.vaccineimpact.api.serialization.SplitData
 import java.math.BigDecimal
 import kotlin.sequences.Sequence
@@ -143,7 +144,7 @@ class JooqTouchstoneRepository(
         val coverageData = getCoverageDataForScenario(touchstoneVersionId, scenarioDescId)
         val metadata = ScenarioAndCoverageSets(scenario, coverageSets)
 
-        return SplitData(metadata, DataTable.new(coverageData.asSequence()))
+        return SplitData(metadata, DataTable.new(coverageData.asSequence(), serializer = DecimalRoundingSerializer.instance))
     }
 
     override fun getCoverageDataForScenario(

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/TouchstoneControllerTests.kt
@@ -16,6 +16,7 @@ import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.api.serialization.DataTable
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.serialization.SplitData
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import org.vaccineimpact.api.test_helpers.exampleResponsibilitySetWithExpectations
@@ -191,7 +192,7 @@ class TouchstoneControllerTests : MontaguTests()
                 DemographicMetadata("id", "name", null, listOf(), "people", "age", source))
 
         val repo = mock<TouchstoneRepository> {
-            on { getDemographicData(type, source, openTouchstoneVersion.id) } doReturn
+            on { getDemographicData(type, source, openTouchstoneVersion.id, serializer = MontaguSerializer.instance) } doReturn
                     SplitData(demographicMetadata, DataTable.new(emptySequence()))
             on { touchstoneVersions } doReturn InMemoryDataSet(listOf(openTouchstoneVersion))
         }
@@ -290,7 +291,7 @@ class TouchstoneControllerTests : MontaguTests()
         )
 
         return mock<TouchstoneRepository> {
-            on { getDemographicData(type, source, openTouchstoneVersion.id) } doReturn
+            on { getDemographicData(type, source, openTouchstoneVersion.id, serializer = MontaguSerializer.instance) } doReturn
                     SplitData(demographicMetadata, DataTable.new(fakeRows))
             on { touchstoneVersions } doReturn InMemoryDataSet(listOf(openTouchstoneVersion))
         }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/DemographicTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/DemographicTests.kt
@@ -267,7 +267,7 @@ class DemographicTests : DatabaseTest()
                 requiredPermissions)
 
         val body = schema.validate(response.text)
-        assertLongDemographicValuesHaveDecimalPlaces(body, 2)
+        assertLongDemographicValuesHaveDecimalPlaces(body, 2, exact=false)
     }
 
     @Test
@@ -290,7 +290,7 @@ class DemographicTests : DatabaseTest()
                 requiredPermissions)
 
         val body = schema.validate(response.text)
-        assertWideDemographicValuesHaveDecimalPlaces(body, 2)
+        assertWideDemographicValuesHaveDecimalPlaces(body, 2, exact=false)
     }
 
     @Test
@@ -339,24 +339,37 @@ class DemographicTests : DatabaseTest()
         assertWideDemographicValuesHaveDecimalPlaces(body, 4)
     }
 
-    private fun assertLongDemographicValuesHaveDecimalPlaces(csvData: Iterable<Array<String>>, decimalPlaces: Int)
+    private fun assertLongDemographicValuesHaveDecimalPlaces(csvData: Iterable<Array<String>>, decimalPlaces: Int,
+                                                             exact: Boolean = true)
     {
         csvData.forEach {
-            val demographicValue = it[7]
-            val numParts = demographicValue.split(".")
-            assertThat(numParts[1].count()).isEqualTo(decimalPlaces)
+            assertNumericStringHasDecimalPlaces(it[7], decimalPlaces, exact)
         }
     }
 
-    private fun assertWideDemographicValuesHaveDecimalPlaces(csvData: Iterable<Array<String>>, decimalPlaces: Int)
+    private fun assertWideDemographicValuesHaveDecimalPlaces(csvData: Iterable<Array<String>>, decimalPlaces: Int,
+                                                             exact: Boolean = true)
     {
         csvData.forEach{
             for (i in 6..it.count()-1 )
             {
-                val demographicValue = it[i]
-                val numParts = demographicValue.split(".")
-                assertThat(numParts[1].count()).isEqualTo(decimalPlaces)
+                assertNumericStringHasDecimalPlaces(it[i], decimalPlaces, exact)
             }
+        }
+    }
+
+    private fun assertNumericStringHasDecimalPlaces(value: String, decimalPlaces: Int, exact: Boolean)
+    {
+        val numParts = value.split(".")
+        if (exact)
+        {
+            assertThat(numParts[1].count()).isEqualTo(decimalPlaces)
+        }
+        else
+        {
+            //can be less, including none
+            if (numParts.count() != 1)
+                assertThat(numParts[1].count()).isLessThanOrEqualTo(decimalPlaces)
         }
     }
 

--- a/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/GeneralExtensions.kt
+++ b/src/databaseInterface/src/main/kotlin/org/vaccineimpact/api/db/GeneralExtensions.kt
@@ -15,7 +15,7 @@ fun Random.nextDecimal(min: Int = 0, max: Int = 1, numberOfDecimalPlaces: Int = 
     val range = max - min
     val factor = Math.pow(10.0, numberOfDecimalPlaces.toDouble()).toInt()
     val int = this.nextInt(range * factor)
-    return BigDecimal(int) / BigDecimal(factor)
+    return BigDecimal(int).divide(BigDecimal(factor), numberOfDecimalPlaces, BigDecimal.ROUND_HALF_UP)
 }
 
 fun Int.toDecimal(): BigDecimal = this.toLong().toDecimal()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetDemographicsTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/GetDemographicsTests.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.TouchstoneStatus
+import org.vaccineimpact.api.serialization.MontaguSerializer
 import org.vaccineimpact.api.test_helpers.DemographicDummyData
 
 class GetDemographicsTests : TouchstoneRepositoryTests()
@@ -79,7 +80,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
                     .withFertility()
 
         } check {
-            val version = it.getDemographicData("tot-pop", source, touchstoneVersionId).structuredMetadata.touchstoneVersion
+            val version = it.getDemographicData("tot-pop",
+                    source, touchstoneVersionId, serializer = MontaguSerializer.instance).structuredMetadata.touchstoneVersion
             Assertions.assertThat(version.name).isEqualTo(touchstoneName)
             Assertions.assertThat(version.description).isEqualTo("Description")
             Assertions.assertThat(version.status).isEqualTo(TouchstoneStatus.OPEN)
@@ -101,7 +103,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
                     .countries
 
         } check {
-            var metadata = it.getDemographicData("tot-pop", source, touchstoneVersionId)
+            var metadata = it.getDemographicData("tot-pop", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
                     .structuredMetadata.demographicData
 
             Assertions.assertThat(metadata.id).isEqualTo("tot-pop")
@@ -112,7 +115,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
             Assertions.assertThat(metadata.unit).isEqualTo("Number of people")
             Assertions.assertThat(metadata.countries).hasSameElementsAs(countries)
 
-            metadata = it.getDemographicData("as-fert", source, touchstoneVersionId)
+            metadata = it.getDemographicData("as-fert", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
                     .structuredMetadata.demographicData
 
             Assertions.assertThat(metadata.id).isEqualTo("as-fert")
@@ -137,7 +141,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val all = it.getDemographicData("tot-pop", source, touchstoneVersionId)
+            val all = it.getDemographicData("tot-pop", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
             val data = all
                     .tableData.data
 
@@ -151,7 +156,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
             Assertions.assertThat(data.count()).isEqualTo(numAges * numYears * numCountries * numVariants)
 
-            val fertilityData = it.getDemographicData("as-fert", source, touchstoneVersionId)
+            val fertilityData = it.getDemographicData("as-fert", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
                     .tableData.data
 
             numYears = 3
@@ -175,7 +181,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val data = it.getDemographicData("as-fert", source, touchstoneVersionId)
+            val data = it.getDemographicData("as-fert", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
             Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("both")
             Assertions.assertThat(data.tableData.data.any { it.gender == "both" }).isTrue()
 
@@ -195,7 +202,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val data = it.getDemographicData("tot-pop", source, touchstoneVersionId, "female")
+            val data = it.getDemographicData("tot-pop",
+                    source, touchstoneVersionId, "female", serializer = MontaguSerializer.instance)
             Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("both")
             Assertions.assertThat(data.tableData.data.any { it.gender == "both" }).isTrue()
         }
@@ -214,7 +222,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val data = it.getDemographicData("as-fert", source, touchstoneVersionId, "female")
+            val data = it.getDemographicData("as-fert", source,
+                    touchstoneVersionId, "female", serializer = MontaguSerializer.instance)
             Assertions.assertThat(data.structuredMetadata.demographicData.gender).isEqualTo("female")
             Assertions.assertThat(data.tableData.data.any { it.gender == "female" }).isTrue()
         }
@@ -230,7 +239,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
 
             Assertions.assertThatThrownBy {
-                it.getDemographicData("tot-pop", source, touchstoneVersionId)
+                it.getDemographicData("tot-pop", source, touchstoneVersionId,
+                        serializer = MontaguSerializer.instance)
             }.isInstanceOf(UnknownObjectError::class.java)
         }
     }
@@ -249,7 +259,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val result = it.getDemographicData("tot-pop", source, touchstoneVersionId)
+            val result = it.getDemographicData("tot-pop",
+                    source, touchstoneVersionId, serializer = MontaguSerializer.instance)
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
         }
     }
@@ -265,7 +276,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            Assertions.assertThatThrownBy { it.getDemographicData("tot-pop", source, touchstoneVersionId) }
+            Assertions.assertThatThrownBy { it.getDemographicData("tot-pop", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance) }
                     .isInstanceOf(UnknownObjectError::class.java)
                     .matches { (it as UnknownObjectError).typeName == "demographic-statistic-type" }
 
@@ -282,7 +294,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
                     .withFertility()
         } check {
 
-            val result = it.getDemographicData("tot-pop", source, touchstoneVersionId)
+            val result = it.getDemographicData("tot-pop", source,
+                    touchstoneVersionId, serializer = MontaguSerializer.instance)
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
 
         }
@@ -299,7 +312,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            val result = it.getDemographicData("tot-pop", source, touchstoneVersionId)
+            val result = it.getDemographicData("tot-pop",
+                    source, touchstoneVersionId, serializer = MontaguSerializer.instance)
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
         }
     }
@@ -325,7 +339,8 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
         } check {
             val expectedCountries = countries.take(2)
 
-            val result = it.getDemographicData("tot-pop", source, anotherTouchstoneId)
+            val result = it.getDemographicData("tot-pop", source,
+                    anotherTouchstoneId, serializer = MontaguSerializer.instance)
             val metadata = result.structuredMetadata.demographicData
             
             assertThat(metadata.countries).isEqualTo(expectedCountries)
@@ -358,10 +373,12 @@ class GetDemographicsTests : TouchstoneRepositoryTests()
 
         } check {
 
-            var result = it.getDemographicData("tot-pop", source, anotherTouchstoneId)
+            var result = it.getDemographicData("tot-pop", source,
+                    anotherTouchstoneId, serializer = MontaguSerializer.instance)
             Assertions.assertThat(result.tableData.data.count()).isEqualTo(0)
 
-            result = it.getDemographicData("tot-pop", newSource, anotherTouchstoneId)
+            result = it.getDemographicData("tot-pop", newSource, anotherTouchstoneId,
+                    serializer = MontaguSerializer.instance)
             Assertions.assertThat(result.tableData.data.count()).isGreaterThan(0)
         }
     }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTable.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTable.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 
 open class DataTable<T : Any>(override val data: Sequence<T>,
-                              var serializer: Serializer = MontaguSerializer.instance,
+                              protected val serializer: Serializer = MontaguSerializer.instance,
                               val type: KClass<T>
                               ) : StreamSerializable<T>
 {

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTable.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DataTable.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 
 open class DataTable<T : Any>(override val data: Sequence<T>,
-                              protected val serializer: Serializer = MontaguSerializer.instance,
+                              var serializer: Serializer = MontaguSerializer.instance,
                               val type: KClass<T>
                               ) : StreamSerializable<T>
 {

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DecimalRoundingSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/DecimalRoundingSerializer.kt
@@ -1,0 +1,27 @@
+package org.vaccineimpact.api.serialization
+
+import java.math.BigDecimal
+import java.text.DecimalFormat
+import org.vaccineimpact.api.serialization.MontaguSerializer
+
+open class DecimalRoundingSerializer : MontaguSerializer()
+{
+    companion object
+    {
+        val instance: Serializer = DecimalRoundingSerializer()
+    }
+
+    private val decimalFormat = DecimalFormat("###.##")
+
+    private fun serializeBigDecimal(value: BigDecimal) : String
+    {
+        return decimalFormat.format(value)
+    }
+
+    override fun serializeValueForCSV(value: Any?) = when (value)
+    {
+        is BigDecimal -> serializeBigDecimal(value)
+        else -> super.serializeValueForCSV(value)
+    }
+
+}

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
@@ -2,15 +2,12 @@ package org.vaccineimpact.api.serialization
 
 import com.github.salomonbrys.kotson.jsonSerializer
 import com.github.salomonbrys.kotson.registerTypeAdapter
-import com.github.salomonbrys.kotson.registerTypeHierarchyAdapter
 import com.google.gson.*
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetStatus
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityStatus
-import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
-import java.text.DecimalFormat
 
 interface Serializer
 {
@@ -124,18 +121,10 @@ open class MontaguSerializer : Serializer
 
     override val serializeNullsTo = "<NA>"
 
-    private val decimalFormat = DecimalFormat("###.##")
-
-    private fun serializeBigDecimal(value: BigDecimal) : String
-    {
-        return decimalFormat.format(value)
-    }
-
     override fun serializeValueForCSV(value: Any?) = when (value)
     {
         null -> serializeNullsTo
         is Enum<*> -> serializeEnum(value)
-        is BigDecimal -> serializeBigDecimal(value)
         else -> value.toString()
     }
 

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DecimalRoundingSerializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DecimalRoundingSerializerTests.kt
@@ -1,0 +1,23 @@
+package org.vaccineimpact.api.tests.serialization
+
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.vaccineimpact.api.serialization.DecimalRoundingSerializer
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.math.BigDecimal
+
+class DecimalRoundingSerializerTests : MontaguTests()
+{
+    private val serializer = DecimalRoundingSerializer.instance
+
+    @Test
+    fun `serializes decimal for CSV with correct decimal places`()
+    {
+        Assertions.assertThat(serializer.serializeValueForCSV(BigDecimal(123))).isEqualTo("123")
+        Assertions.assertThat(serializer.serializeValueForCSV(BigDecimal(123.4))).isEqualTo("123.4")
+        Assertions.assertThat(serializer.serializeValueForCSV(BigDecimal(123.45))).isEqualTo("123.45")
+        Assertions.assertThat(serializer.serializeValueForCSV(BigDecimal(123.456))).isEqualTo("123.46")
+        Assertions.assertThat(serializer.serializeValueForCSV(BigDecimal(123.5000000))).isEqualTo("123.5")
+    }
+
+}

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/MontaguSerializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/MontaguSerializerTests.kt
@@ -164,20 +164,11 @@ class MontaguSerializerTests : MontaguTests()
     }
 
     @Test
-    fun `serializes decimal for CSV with correct decimal places`()
+    fun `serializes decimal for CSV unrounded`()
     {
-        assertThat(serializer.serializeValueForCSV(BigDecimal(123))).isEqualTo("123")
-        assertThat(serializer.serializeValueForCSV(BigDecimal(123.4))).isEqualTo("123.4")
-        assertThat(serializer.serializeValueForCSV(BigDecimal(123.45))).isEqualTo("123.45")
-        assertThat(serializer.serializeValueForCSV(BigDecimal(123.456))).isEqualTo("123.46")
-        assertThat(serializer.serializeValueForCSV(BigDecimal(123.5000000))).isEqualTo("123.5")
+        assertThat(serializer.serializeValueForCSV(BigDecimal(123.4567999))).startsWith("123.456799")
     }
 
-    @Test
-    fun `serializes decimal for CSV with no grouping`()
-    {
-        assertThat(serializer.serializeValueForCSV((BigDecimal(123456.78)))).isEqualTo("123456.78")
-    }
 
     fun checkSerializedForm(expected: JsonObject, actual: Any): Unit
     {

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
@@ -598,7 +598,7 @@ fun JooqContext.generateDemographicData(
                         age + ageRange.step,
                         genderId = genderId,
                         variant = variantId,
-                        value = random.nextDecimal(1000, 10000, numberOfDecimalPlaces = 2)
+                        value = random.nextDecimal(1000, 10000, numberOfDecimalPlaces = 4)
                 ))
 
             }


### PR DESCRIPTION
This is a bit of a messy hack to accommodate the fact that SplitData / DataTables are reshaped from long to wide, and each object gets its own serializer on construction. Not sure if it's worth doing a more serious refactor?