### PR TITLE
Revert "VIMC-2985 Error if attempt to create burden estimate set of type central single run"

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.api.app.controllers.BurdenEstimates
 
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.postData
-import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -41,11 +40,6 @@ open class BurdenEstimatesController(
         // First check if we're allowed to see this touchstoneVersion
         val path = getValidResponsibilityPath()
         val properties = context.postData<CreateBurdenEstimateSet>()
-
-        if (properties.type.type == BurdenEstimateSetTypeCode.CENTRAL_SINGLE_RUN)
-        {
-            throw BadRequest("Single model run estimate sets are no longer accepted.")
-        }
 
         //Also check if any specified model run parameter set belongs to this group and touchstone
         if (properties.modelRunParameterSet != null)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -2,13 +2,11 @@ package org.vaccineimpact.api.tests.controllers.BurdenEstimates
 
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.mockito.Mockito
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimatesController
-import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
@@ -110,32 +108,6 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 eq("username"),
                 timestamp = check { it > before && it < after })
         verifyValidResponsibilityPathChecks(logic, mockContext)
-    }
-
-    @Test
-    fun `cannot create estimate set with central single run type`()
-    {
-        val touchstoneSet = mockTouchstones()
-        val repo = mockEstimatesRepository(touchstoneSet)
-
-        val properties = CreateBurdenEstimateSet(
-                BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_SINGLE_RUN, "single"),
-                1
-        )
-        val mockContext = mock<ActionContext> {
-            on { username } doReturn "username"
-            on { params(":group-id") } doReturn groupId
-            on { params(":touchstone-version-id") } doReturn touchstoneVersionId
-            on { params(":scenario-id") } doReturn scenarioId
-            on { postData<CreateBurdenEstimateSet>() } doReturn properties
-        }
-
-        val logic = mockLogic()
-
-        assertThatThrownBy { BurdenEstimatesController(mockContext, logic, repo).createBurdenEstimateSet() }
-                .isInstanceOf(BadRequest::class.java)
-                .hasMessageContaining("Single model run estimate sets are no longer accepted")
-
     }
 
     @Test


### PR DESCRIPTION
Reverts vimc/montagu-api#393