### PR TITLE
Add scenarios to TouchstoneModelExpectations

### DIFF
--- a/docs/schemas/TouchstoneModelExpectation.schema.json
+++ b/docs/schemas/TouchstoneModelExpectation.schema.json
@@ -16,8 +16,12 @@
     },
     "expectations": {
       "$ref": "OutcomeExpectation.schema.json"
+    },
+    "scenarios": {
+      "type": "array",
+      "items": { "type": "string" }
     }
   },
   "additionalProperties": false,
-  "required": [ "touchstone_version", "modelling_group", "disease", "expectations"]
+  "required": [ "touchstone_version", "modelling_group", "disease", "expectations", "scenarios"]
 }

--- a/docs/schemas/TouchstoneModelExpectation.schema.json
+++ b/docs/schemas/TouchstoneModelExpectation.schema.json
@@ -14,14 +14,14 @@
       "type": "string",
       "minLength": 1
     },
-    "expectations": {
+    "expectation": {
       "$ref": "OutcomeExpectation.schema.json"
     },
-    "scenarios": {
+    "applicable_scenarios": {
       "type": "array",
       "items": { "type": "string" }
     }
   },
   "additionalProperties": false,
-  "required": [ "touchstone_version", "modelling_group", "disease", "expectations", "scenarios"]
+  "required": [ "touchstone_version", "modelling_group", "disease", "expectation", "applicable_scenarios"]
 }

--- a/docs/spec/Expectations.md
+++ b/docs/spec/Expectations.md
@@ -30,7 +30,8 @@ Schema: [`TouchstoneModelExpectations.schema.json`](../schemas/TouchstoneModelEx
                     "maximum_birth_year": 2050
                 },
                 "outcomes": ["cases","deaths"]
-            }
+            },
+            "scenarios": ["yf-routine", "yf-campaign"]
         },
         {
             "touchstone_version": "2018-op-1",
@@ -52,6 +53,7 @@ Schema: [`TouchstoneModelExpectations.schema.json`](../schemas/TouchstoneModelEx
                     "maximum_birth_year": 2060
                 },
                 "outcomes": ["cases"]
-            }
+            },
+            "scenarios": ["yf-routine"]
         }
     ]

--- a/docs/spec/Expectations.md
+++ b/docs/spec/Expectations.md
@@ -14,7 +14,7 @@ Schema: [`TouchstoneModelExpectations.schema.json`](../schemas/TouchstoneModelEx
             "touchstone_version": "2017-op-1",
             "modelling_group": "IC-Garkse",
             "disease": "YF",
-            "expectations": {
+            "expectation": {
                 "id": 12,
                 "description": "Expectations for pilot run",
                 "years": {
@@ -31,13 +31,13 @@ Schema: [`TouchstoneModelExpectations.schema.json`](../schemas/TouchstoneModelEx
                 },
                 "outcomes": ["cases","deaths"]
             },
-            "scenarios": ["yf-routine", "yf-campaign"]
+            "applicable_scenarios": ["yf-routine", "yf-campaign"]
         },
         {
             "touchstone_version": "2018-op-1",
             "modelling_group": "IC-Garkse",
             "disease": "YF",
-            "expectations": {
+            "expectation": {
                 "id": 13,
                 "description": "Expectations for pilot run",
                 "years": {
@@ -54,6 +54,6 @@ Schema: [`TouchstoneModelExpectations.schema.json`](../schemas/TouchstoneModelEx
                 },
                 "outcomes": ["cases"]
             },
-            "scenarios": ["yf-routine"]
+            "applicable_scenarios": ["yf-routine"]
         }
     ]

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -137,7 +137,7 @@ class JooqExpectationsRepository(dsl: DSLContext)
         val scenarios = records.map { it[SCENARIO_DESCRIPTION.ID] }.distinct().sorted()
         val diseases = records.map { it[SCENARIO_DESCRIPTION.DISEASE] }.distinct()
         val disease = diseases.singleOrNull()
-                ?: throw DatabaseContentsError("Expectations $expectationsId is used by responsibilities that do not all share the same disease: ${diseases.joinToString()}")
+                ?: throw DatabaseContentsError("CountryOutcomeExpectations $expectationsId is used by responsibilities that do not all share the same disease: ${diseases.joinToString()}")
         return ApplicableScenariosAndDisease(scenarios, disease)
     }
 
@@ -154,12 +154,12 @@ class JooqExpectationsRepository(dsl: DSLContext)
         )
     }
 
-    private fun BurdenEstimateExpectationRecord.withCountriesAndOutcomes(): Expectations
+    private fun BurdenEstimateExpectationRecord.withCountriesAndOutcomes(): CountryOutcomeExpectations
     {
         val record = this
         val countries = getCountries(record)
         val outcomes = getOutcomes(record)
-        return Expectations(
+        return CountryOutcomeExpectations(
                 record.id,
                 record.description,
                 record.yearMinInclusive..record.yearMaxInclusive,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -113,7 +113,6 @@ class JooqExpectationsRepository(dsl: DSLContext)
                     it.value.map{ row -> row[SCENARIO.SCENARIO_DESCRIPTION]}.distinct()
                 }
 
-
         return records.groupBy{it[BURDEN_ESTIMATE_EXPECTATION.ID]}
                 .map{
                     val fields = it.value.first()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ExpectationsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ExpectationsControllerTests.kt
@@ -2,15 +2,12 @@ package org.vaccineimpact.api.tests.controllers
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import jnr.ffi.annotations.Direct
 import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.ExpectationsController
 import org.vaccineimpact.api.app.repositories.ExpectationsRepository
 import org.vaccineimpact.api.models.CohortRestriction
-import org.vaccineimpact.api.models.Country
 import org.vaccineimpact.api.models.TouchstoneModelExpectations
 import org.vaccineimpact.api.models.OutcomeExpectations
 import org.vaccineimpact.api.test_helpers.MontaguTests
@@ -25,11 +22,10 @@ class ExpectationsControllerTests : MontaguTests()
         val expectations = listOf(
                 TouchstoneModelExpectations("t1-v1", "group1", "disease1",
                        OutcomeExpectations(1, "description", 1980..2000, 0..80,
-                                CohortRestriction(1900, 2000), listOf("deaths", "DALYs"))),
+                                CohortRestriction(1900, 2000), listOf("deaths", "DALYs")), listOf("routine")),
                 TouchstoneModelExpectations("t2-v2", "group2", "disease2",
                         OutcomeExpectations(2, "description2", 1981..2001, 0..90,
-                                CohortRestriction(1890, 2000), listOf("deaths", "cases")))
-        )
+                                CohortRestriction(1890, 2000), listOf("deaths", "cases")), listOf("campaign", "routine")))
 
         val mockRepo = mock<ExpectationsRepository> {
             on { this.getAllExpectations() } doReturn expectations

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
@@ -154,7 +154,7 @@ class ResponsibilityControllerTests : MontaguTests()
         """.trimMargin())
     }
 
-    private val fakeExpectations = Expectations(1, "desc", 2000..2001, 1..1, CohortRestriction(), listOf(Country("a", "countrya")),
+    private val fakeExpectations = CountryOutcomeExpectations(1, "desc", 2000..2001, 1..1, CohortRestriction(), listOf(Country("a", "countrya")),
             listOf("dalys"))
 
     private val fakeExpectationMapping = ExpectationMapping(

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/extensions/ExpectationsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/extensions/ExpectationsTests.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.api.models.CohortRestriction
 import org.vaccineimpact.api.models.Country
-import org.vaccineimpact.api.models.Expectations
+import org.vaccineimpact.api.models.CountryOutcomeExpectations
 import org.vaccineimpact.api.test_helpers.MontaguTests
 
 class ExpectationsTests : MontaguTests()
@@ -17,7 +17,7 @@ class ExpectationsTests : MontaguTests()
         val longCountryList = (1..100).map {
             Country(it.toString(), it.toString())
         }
-        val expectations = Expectations(1,
+        val expectations = CountryOutcomeExpectations(1,
                 "desc",
                 2001..2080,
                 1..80,
@@ -42,7 +42,7 @@ class ExpectationsTests : MontaguTests()
         val countryList = (1..1).map {
             Country(it.toString(), it.toString())
         }
-        val expectations = Expectations(1,
+        val expectations = CountryOutcomeExpectations(1,
                 "desc",
                 2000..2001,
                 1..2,
@@ -90,7 +90,7 @@ class ExpectationsTests : MontaguTests()
             Country(it.toString(), it.toString())
         }
 
-        val expectations = Expectations(1,
+        val expectations = CountryOutcomeExpectations(1,
                 "desc",
                 2000..2001,
                 1..1,
@@ -126,7 +126,7 @@ class ExpectationsTests : MontaguTests()
         val longCountryList = (1..100).map {
             Country(it.toString(), it.toString())
         }
-        val expectations = Expectations(1,
+        val expectations = CountryOutcomeExpectations(1,
                 "desc",
                 2001..2080,
                 1..80,
@@ -148,7 +148,7 @@ class ExpectationsTests : MontaguTests()
     {
         val expectedOutcomes = listOf("Dalys", "Deaths")
 
-        val expectations = Expectations(
+        val expectations = CountryOutcomeExpectations(
                 1,
                 "desc",
                 2000..2007,
@@ -172,7 +172,7 @@ class ExpectationsTests : MontaguTests()
         val expectedOutcomes = listOf("Dalys", "Deaths")
         val cohortRestriction = CohortRestriction(1994, null)
 
-        val expectations = Expectations(
+        val expectations = CountryOutcomeExpectations(
                 1,
                 "desc",
                 2000..2007,
@@ -196,7 +196,7 @@ class ExpectationsTests : MontaguTests()
         val expectedOutcomes = listOf("Dalys", "Deaths")
         val cohortRestriction = CohortRestriction(null, 2001)
 
-        val expectations = Expectations(
+        val expectations = CountryOutcomeExpectations(
                 1,
                 "desc",
                 2000..2007,
@@ -220,7 +220,7 @@ class ExpectationsTests : MontaguTests()
         val expectedOutcomes = listOf("Dalys", "Deaths")
         val cohortRestriction = CohortRestriction(1996, 2002)
 
-        val expectations = Expectations(
+        val expectations = CountryOutcomeExpectations(
                 1,
                 "desc",
                 2000..2007,

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogicTests.kt
@@ -62,7 +62,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         }
     }
 
-    private val fakeExpectations = Expectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
+    private val fakeExpectations = CountryOutcomeExpectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
             listOf(Country("AFG", "")),
             listOf())
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ExpecationsLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ExpecationsLogicTests.kt
@@ -52,7 +52,7 @@ class ExpectationsLogicTests : MontaguTests()
                 "", 1, "", TouchstoneStatus.OPEN)))
     }
 
-    private val fakeExpectations = Expectations(expectationId, "desc", 1..11, 2000..2009, CohortRestriction(), listOf(), listOf())
+    private val fakeExpectations = CountryOutcomeExpectations(expectationId, "desc", 1..11, 2000..2009, CohortRestriction(), listOf(), listOf())
     private val fakeExpectationsMapping = ExpectationMapping(fakeExpectations, listOf(scenarioId), disease)
 
     private val expectationsRepo = mock<ExpectationsRepository> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
@@ -8,13 +8,13 @@ import org.vaccineimpact.api.app.validate
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
 import org.vaccineimpact.api.models.CohortRestriction
 import org.vaccineimpact.api.models.Country
-import org.vaccineimpact.api.models.Expectations
+import org.vaccineimpact.api.models.CountryOutcomeExpectations
 import org.vaccineimpact.api.test_helpers.MontaguTests
 
 class ValidateBurdenEstimateSequenceTests : MontaguTests()
 {
     private val countries = listOf(Country("AFG", ""), Country("AGO", ""))
-    private val expectations = Expectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
+    private val expectations = CountryOutcomeExpectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
             countries,
             listOf())
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ExpectationsTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ExpectationsTests.kt
@@ -55,7 +55,9 @@ class ExpectationsTests : DatabaseTest()
                                     "maximum_birth_year" to null
                                 ),
                                 "outcomes" to array("cases", "deaths")
-                        )
+
+                        ),
+                        "scenarios" to array(scenarioId)
                 )
             })
 
@@ -80,7 +82,8 @@ class ExpectationsTests : DatabaseTest()
                                         "maximum_birth_year" to null
                                 ),
                                 "outcomes" to array()
-                        )
+                        ),
+                        "scenarios" to array(otherScenarioId)
                 )
             })
         }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ExpectationsTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/ExpectationsTests.kt
@@ -39,7 +39,7 @@ class ExpectationsTests : DatabaseTest()
                         "touchstone_version" to touchstoneVersionId,
                         "modelling_group" to groupId,
                         "disease" to "YF",
-                        "expectations" to obj(
+                        "expectation" to obj(
                                 "id" to 1,
                                 "description" to "description",
                                 "years" to obj(
@@ -57,7 +57,7 @@ class ExpectationsTests : DatabaseTest()
                                 "outcomes" to array("cases", "deaths")
 
                         ),
-                        "scenarios" to array(scenarioId)
+                        "applicable_scenarios" to array(scenarioId)
                 )
             })
 
@@ -66,7 +66,7 @@ class ExpectationsTests : DatabaseTest()
                         "touchstone_version" to "touchstone2-2",
                         "modelling_group" to otherGroupId,
                         "disease" to "HepB",
-                        "expectations" to obj(
+                        "expectation" to obj(
                                 "id" to 2,
                                 "description" to "description",
                                 "years" to obj(
@@ -83,7 +83,7 @@ class ExpectationsTests : DatabaseTest()
                                 ),
                                 "outcomes" to array()
                         ),
-                        "scenarios" to array(otherScenarioId)
+                        "applicable_scenarios" to array(otherScenarioId)
                 )
             })
         }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -260,24 +260,28 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
             db.addTouchstoneVersion("touchstone2", 2, addTouchstone = true)
             db.addScenarioDescription(scenarioId, "desc", "YF", addDisease = true)
             db.addScenarioDescription(otherScenarioId, "other desc", "HepB", addDisease = true)
+            db.addScenarioDescription("scenario3", "desc3", "HepB", addDisease = false)
             db.addGroup(groupId)
             db.addGroup(otherGroupId)
             val setId1 = db.addResponsibilitySet(groupId, touchstoneVersionId)
             val setId2 = db.addResponsibilitySet(otherGroupId, "touchstone2-2")
             val r1 = db.addResponsibility(setId1, touchstoneVersionId, scenarioId)
             val r2 = db.addResponsibility(setId2, "touchstone2-2", otherScenarioId)
+            val r3 = db.addResponsibility(setId2, "touchstone2-2", "scenario3")
             val expId1 = db.addExpectations(r1, outcomes=listOf("deaths"))
             val expId2 = db.addExpectations(r2, outcomes=listOf("deaths", "cases"))
             db.addExistingExpectationsToResponsibility(r1, expId1)
             db.addExistingExpectationsToResponsibility(r2, expId2)
+            db.addExistingExpectationsToResponsibility(r3, expId2)
         }
         withRepo { repo ->
             val result = repo.getAllExpectations()
             assertThat(result).isEqualTo(listOf(
                     TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF",
-                            exampleOutcomeExpectations(outcomes=listOf("deaths"))),
+                            exampleOutcomeExpectations(outcomes=listOf("deaths")), listOf(scenarioId)),
                     TouchstoneModelExpectations("touchstone2-2", otherGroupId, "HepB",
-                            exampleOutcomeExpectations(id=2, outcomes=listOf("cases", "deaths")))
+                            exampleOutcomeExpectations(id=2, outcomes=listOf("cases", "deaths")),
+                            listOf(otherScenarioId, "scenario3"))
             ))
         }
     }
@@ -304,7 +308,8 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
         withRepo { repo ->
             val result = repo.getAllExpectations()
             assertThat(result).isEqualTo(listOf(
-                    TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF", exampleOutcomeExpectations())
+                    TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF", exampleOutcomeExpectations(),
+                            listOf(scenarioId))
             ))
         }
     }
@@ -349,7 +354,8 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
         withRepo { repo ->
             val result = repo.getAllExpectations()
             assertThat(result).isEqualTo(listOf(
-                    TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF", exampleOutcomeExpectations())
+                    TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF", exampleOutcomeExpectations(),
+                            listOf(scenarioId))
             ))
         }
     }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -103,7 +103,7 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
     {
         val years = 2000..2010
         val ages = 0..10
-        val expectations = Expectations(1, "", years, ages, CohortRestriction(null, null),
+        val expectations = CountryOutcomeExpectations(1, "", years, ages, CohortRestriction(null, null),
                 listOf(Country("ABC", "a"), Country("DEF", "d")), listOf("cases"))
 
         val setId = withDatabase { db ->

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/ExampleObjects.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/ExampleObjects.kt
@@ -17,7 +17,7 @@ fun exampleInternalUser(username: String = "username") = InternalUser(
         emptyList()
 )
 
-fun exampleExpectations(id: Int=1) = Expectations(
+fun exampleExpectations(id: Int=1) = CountryOutcomeExpectations(
         id = id,
         description = "description",
         years = 2000..2100,


### PR DESCRIPTION
Another pair of preliminary PRs, to add scenarios to the /expectations endpoint. 
Here's the other one: https://github.com/vimc/montagu-webmodels/pull/84