### PR TITLE
VIMC-3062 preliminary refactor

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -48,7 +48,7 @@ open class BurdenEstimatesController(
                     path.touchstoneVersionId)
         }
 
-        val id = estimateRepository.createBurdenEstimateSet(path.groupId, path.touchstoneVersionId, path.scenarioId,
+        val id = estimatesLogic.createBurdenEstimateSet(path.groupId, path.touchstoneVersionId, path.scenarioId,
                 properties = properties,
                 uploader = context.username!!,
                 timestamp = Instant.now())

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupModelRunParametersController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupModelRunParametersController.kt
@@ -2,6 +2,8 @@ package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.context.ActionContext
+import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
@@ -17,13 +19,14 @@ import java.time.Instant
 
 class GroupModelRunParametersController(
         context: ActionContext,
+        private val estimateLogic: BurdenEstimateLogic,
         private val estimateRepository: BurdenEstimateRepository,
         private val touchstoneRepository: TouchstoneRepository,
         private val postDataHelper: PostDataHelper = PostDataHelper()
 ) : Controller(context)
 {
     constructor(context: ActionContext, repositories: Repositories)
-            : this(context, repositories.burdenEstimates, repositories.touchstone)
+            : this(context, RepositoriesBurdenEstimateLogic(repositories),repositories.burdenEstimates, repositories.touchstone)
 
     fun getModelRunParameterSets(): List<ModelRunParameterSet>
     {
@@ -43,7 +46,7 @@ class GroupModelRunParametersController(
         val disease = parts["disease"].contents
         val modelRuns = postDataHelper.csvData<ModelRun>(parts["file"])
 
-        val id = estimateRepository.addModelRunParameterSet(groupId, touchstoneVersionId, disease,
+        val id = estimateLogic.addModelRunParameterSet(groupId, touchstoneVersionId, disease,
                 modelRuns.toList(), context.username!!, Instant.now())
 
         return objectCreation(context, "/modelling-groups/$groupId/model-run-parameters/$id/")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
@@ -13,9 +13,11 @@ interface BurdenEstimateRepository : Repository
     val touchstoneRepository: TouchstoneRepository
 
     /** Returns the database ID of the newly created burden estimate set **/
-    fun createBurdenEstimateSet(groupId: String, touchstoneVersionId: String, scenarioId: String,
+    fun createBurdenEstimateSet(responsibilityId: Int,
+                                modelVersionId: Int,
                                 properties: CreateBurdenEstimateSet,
-                                uploader: String, timestamp: Instant): Int
+                                uploader: String,
+                                timestamp: Instant): Int
 
     fun getBurdenEstimateSet(groupId: String, touchstoneVersionId: String, scenarioId: String,
                              burdenEstimateSetId: Int): BurdenEstimateSet
@@ -24,7 +26,7 @@ interface BurdenEstimateRepository : Repository
 
     fun clearBurdenEstimateSet(setId: Int, groupId: String, touchstoneVersionId: String, scenarioId: String)
 
-    fun addModelRunParameterSet(groupId: String, touchstoneVersionId: String, disease: String,
+    fun addModelRunParameterSet(groupId: String, touchstoneVersionId: String, modelVersionId: Int,
                                 modelRuns: List<ModelRun>,
                                 uploader: String, timestamp: Instant): Int
 
@@ -39,9 +41,11 @@ interface BurdenEstimateRepository : Repository
 
     @Throws(UnknownObjectError::class)
     fun getResponsibilityInfo(groupId: String, touchstoneVersionId: String, scenarioId: String): ResponsibilityInfo
+
     fun validateEstimates(set: BurdenEstimateSet,
                           expectedRowMap: RowLookup)
             : RowLookup
+
     fun getBurdenOutcomeIds(matching: String): List<Short>
 
     fun getEstimates(setId: Int, responsibilityId: Int, outcomeIds: List<Short>,
@@ -51,5 +55,5 @@ interface BurdenEstimateRepository : Repository
     fun getBurdenEstimateOutcomesSequence(groupId: String, touchstoneVersionId: String, scenarioId: String, burdenEstimateSetId: Int)
             : Sequence<BurdenEstimateOutcome>
 
-    fun getExpectedOutcomesForBurdenEstimateSet(burdenEstimateSetId: Int) : List<String>
+    fun getExpectedOutcomesForBurdenEstimateSet(burdenEstimateSetId: Int): List<String>
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ModellingGroupRepository.kt
@@ -1,8 +1,10 @@
 package org.vaccineimpact.api.app.repositories
 
 import org.vaccineimpact.api.app.errors.UnknownObjectError
-import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.serialization.SplitData
+import org.vaccineimpact.api.models.ModellingGroup
+import org.vaccineimpact.api.models.ModellingGroupCreation
+import org.vaccineimpact.api.models.ModellingGroupDetails
+import org.vaccineimpact.api.models.Touchstone
 
 interface ModellingGroupRepository : Repository
 {
@@ -19,4 +21,6 @@ interface ModellingGroupRepository : Repository
     fun createModellingGroup(newGroup: ModellingGroupCreation)
 
     fun getDiseasesForModellingGroup(groupId: String): List<String>
+
+    fun getLatestModelVersionForGroup(groupId: String, disease: String): Int
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -477,7 +477,7 @@ class JooqBurdenEstimateRepository(
                                          timestamp: Instant): Int
     {
         val setRecord = dsl.newRecord(BURDEN_ESTIMATE_SET).apply {
-            this.modelVersion = modelVersion
+            this.modelVersion = modelVersionId
             this.responsibility = responsibilityId
             this.uploadedBy = uploader
             this.uploadedOn = Timestamp.from(timestamp)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
@@ -33,7 +33,6 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
         return mock {
             on { touchstoneRepository } doReturn touchstoneRepo
             on { getBurdenEstimateSet(any(), any(), any(), any()) } doReturn existingBurdenEstimateSet
-            on { createBurdenEstimateSet(any(), any(), any(), any(), any(), any()) } doReturn 1
         }
     }
 
@@ -45,6 +44,7 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
                 args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
                 Unit
             }
+            on { createBurdenEstimateSet(any(), any(), any(), any(), any(), any()) } doReturn 1
         }
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -102,7 +102,7 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         assertThat(url).endsWith("/modelling-groups/$groupId/responsibilities/$touchstoneVersionId/$scenarioId/estimate-sets/1/")
         verify(repo).checkModelRunParameterSetExists(1, groupId, touchstoneVersionId)
 
-        verify(repo).createBurdenEstimateSet(
+        verify(logic).createBurdenEstimateSet(
                 eq(groupId), eq(touchstoneVersionId), eq(scenarioId),
                 eq(properties),
                 eq("username"),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.tests.logic
+package org.vaccineimpact.api.tests.logic.BurdenEstimateLogic
 
 import com.nhaarman.mockito_kotlin.*
 import com.opencsv.CSVReader
@@ -719,7 +719,6 @@ AGO, age 12, year 2005""")
         assertThatThrownBy {
             sut.validateResponsibilityPath(path, statusList)
         }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining("Unknown touchstone-version with id 'touchstone-1'")
-
 
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
@@ -1,0 +1,158 @@
+package org.vaccineimpact.api.tests.logic.BurdenEstimateLogic
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Java6Assertions.assertThatThrownBy
+import org.junit.Test
+import org.mockito.internal.verification.Times
+import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.InvalidOperationError
+import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
+import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetStatus
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.time.Instant
+
+class CreateBurdenEstimateLogicTests : MontaguTests()
+{
+    private val defaultProperties = CreateBurdenEstimateSet(
+            BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_UNKNOWN),
+            modelRunParameterSet = null
+    )
+
+    private val groupId = "g1"
+    private val realGroupId = "real-g1"
+    private val touchstoneVersionId = "t1"
+    private val scenarioId = "s1"
+    private val responsibilityId = 1000
+    private val modelVersionId = 2
+    private val disease = "disease1"
+
+    private val mockGroupRepo = mock<ModellingGroupRepository>() {
+        on { getModellingGroup(groupId) } doReturn ModellingGroup(realGroupId, "desc")
+        on { getLatestModelVersionForGroup(realGroupId, disease) } doReturn modelVersionId
+    }
+
+    private fun getBurdenRepo(responsibilitySetStatus: ResponsibilitySetStatus): BurdenEstimateRepository
+    {
+        return mock {
+            on {
+                getResponsibilityInfo(realGroupId, touchstoneVersionId, scenarioId)
+            } doReturn
+                    ResponsibilityInfo(responsibilityId, disease, responsibilitySetStatus.toString().toLowerCase(), 100)
+            on {
+                createBurdenEstimateSet(eq(responsibilityId), eq(modelVersionId), any(), eq("uploader"), any())
+            } doReturn 123
+            on {
+                addModelRunParameterSet(eq(realGroupId), eq(touchstoneVersionId), eq(modelVersionId), any(), any(), any())
+            } doReturn 456
+        }
+    }
+
+    @Test
+    fun `creates burden estimate set for incomplete responsibility set`()
+    {
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+        val result =
+                sut.createBurdenEstimateSet(groupId,
+                        touchstoneVersionId,
+                        scenarioId,
+                        defaultProperties,
+                        "uploader",
+                        Instant.now())
+        assertThat(result).isEqualTo(123)
+    }
+
+    @Test
+    fun `cannot create burden estimate set if responsibility set status is submitted`()
+    {
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.SUBMITTED), mock(), mock(), mock())
+        assertThatThrownBy {
+            sut.createBurdenEstimateSet(groupId,
+                    touchstoneVersionId,
+                    scenarioId,
+                    defaultProperties,
+                    "uploader",
+                    Instant.now())
+        }.isInstanceOf(InvalidOperationError::class.java)
+                .hasMessage("the following problems occurred:\nThe burden estimates uploaded for this touchstone have been submitted for review." +
+                        " You cannot upload any new estimates.")
+
+    }
+
+    @Test
+    fun `cannot create burden estimate set if responsibility set status is approved`()
+    {
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.APPROVED), mock(), mock(), mock())
+        assertThatThrownBy {
+            sut.createBurdenEstimateSet(groupId,
+                    touchstoneVersionId,
+                    scenarioId,
+                    defaultProperties,
+                    "uploader",
+                    Instant.now())
+        }.isInstanceOf(InvalidOperationError::class.java)
+                .hasMessage("the following problems occurred:\nThe burden estimates uploaded for this touchstone have been reviewed and approved." +
+                        " You cannot upload any new estimates.")
+
+    }
+
+
+    @Test
+    fun `checks model run parameter set exists if provided`()
+    {
+        val properties = defaultProperties.copy(modelRunParameterSet = 111)
+        val mockRepo = getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock())
+        sut.createBurdenEstimateSet(groupId,
+                touchstoneVersionId,
+                scenarioId,
+                properties,
+                "uploader",
+                Instant.now())
+
+        verify(mockRepo).checkModelRunParameterSetExists(111, realGroupId, touchstoneVersionId)
+    }
+
+    @Test
+    fun `does not check model run parameter set exists if not provided`()
+    {
+        val mockRepo = getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock())
+        sut.createBurdenEstimateSet(groupId,
+                touchstoneVersionId,
+                scenarioId,
+                defaultProperties,
+                "uploader",
+                Instant.now())
+        verify(mockRepo, Times(0)).checkModelRunParameterSetExists(any(), any(), any())
+    }
+
+    @Test
+    fun `creates model run parameter set`()
+    {
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+
+        val result = sut.addModelRunParameterSet(groupId, touchstoneVersionId, disease,
+                listOf(ModelRun("run1", mapOf())), "uploader", Instant.now())
+        assertThat(result).isEqualTo(456)
+    }
+
+    @Test
+    fun `cannot create model run parameter set if no model runs provided`()
+    {
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.addModelRunParameterSet(groupId, touchstoneVersionId, disease,
+                    listOf(), "uploader", Instant.now())
+        }.isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining("No model runs provided")
+
+    }
+
+}

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
@@ -68,9 +68,10 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `cannot create model run parameter set if touchstone doesn't exist`()
     {
-        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
+        val returnedIds = withDatabase { setupDatabase(it) }
+        assertUnknownObjectError(setup = { },
                 work = { repo ->
-                    repo.addModelRunParameterSet(groupId, "wrong-id", returnedIds!!.modelVersion!!,
+                    repo.addModelRunParameterSet(groupId, "wrong-id", returnedIds.modelVersion!!,
                             modelRuns, "test.user", timestamp)
                 })
     }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/ModelParameterTests.kt
@@ -28,8 +28,8 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
         given { db ->
             returnedIds = setupDatabase(db)
         } makeTheseChanges { repo ->
-            repo.addModelRunParameterSet(groupId, touchstoneVersionId, diseaseId,
-                     modelRuns, username, timestamp)
+            repo.addModelRunParameterSet(groupId, touchstoneVersionId, returnedIds!!.modelVersion!!,
+                    modelRuns, username, timestamp)
         } andCheckDatabase { db ->
 
             val record = db.dsl.select()
@@ -66,53 +66,13 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     }
 
     @Test
-    fun `cannot create model run parameter set if group has no model`()
-    {
-        JooqContext().use { db ->
-            returnedIds = setupDatabase(db, addModel = false)
-            val repo = makeRepository(db)
-
-            Assertions.assertThatThrownBy {
-                repo.addModelRunParameterSet(groupId, touchstoneVersionId, diseaseId,
-                        modelRuns, username, timestamp)
-            }.isInstanceOf(DatabaseContentsError::class.java)
-                    .hasMessageContaining("Modelling group $groupId does not have any models/model versions in the database")
-        }
-    }
-
-    @Test
-    fun `cannot create model run parameter set if no model runs provided`()
-    {
-        JooqContext().use { db ->
-            returnedIds = setupDatabase(db)
-            val repo = makeRepository(db)
-
-            Assertions.assertThatThrownBy {
-                repo.addModelRunParameterSet(groupId, touchstoneVersionId, diseaseId,
-                        listOf(), username, timestamp)
-            }.isInstanceOf(BadRequest::class.java)
-                    .hasMessageContaining("No model runs provided")
-        }
-    }
-
-    @Test
     fun `cannot create model run parameter set if touchstone doesn't exist`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
                 work = { repo ->
-                    repo.addModelRunParameterSet(groupId, "wrong-id", diseaseId,
-                             modelRuns, "test.user", timestamp)
-        })
-    }
-
-    @Test
-    fun `cannot create model run parameter set if group doesn't exist`()
-    {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
-                work = { repo ->
-                    repo.addModelRunParameterSet("wrong-id", touchstoneVersionId, diseaseId,
-                        modelRuns, "test.user", timestamp)
-        })
+                    repo.addModelRunParameterSet(groupId, "wrong-id", returnedIds!!.modelVersion!!,
+                            modelRuns, "test.user", timestamp)
+                })
     }
 
     private fun assertUnknownObjectError(setup: (db: JooqContext) -> Any,
@@ -145,8 +105,8 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
         given { db ->
             returnedIds = setupDatabase(db)
         } makeTheseChanges { repo ->
-            repo.addModelRunParameterSet(groupId, touchstoneVersionId, diseaseId,
-                   modelRuns, username, timestamp)
+            repo.addModelRunParameterSet(groupId, touchstoneVersionId, returnedIds!!.modelVersion!!,
+                    modelRuns, username, timestamp)
 
         } andCheck { repo ->
             val sets = repo.getModelRunParameterSets(groupId, touchstoneVersionId)
@@ -188,7 +148,7 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `Unknown Object error if model run parameter set id does not exist`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
                 work = { repo ->
                     repo.getModelRunParameterSet(groupId, touchstoneVersionId, 1)
                 })
@@ -197,7 +157,7 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `Unknown Object error if model run parameter set does not belong to the group`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabaseWithModelRunParameterSetValues(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabaseWithModelRunParameterSetValues(db) },
                 work = { repo ->
                     repo.getModelRunParameterSet("group-2", touchstoneVersionId, 1)
                 })
@@ -207,16 +167,16 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `Unknown Object error if model run parameter set does not belong to the touchstone version`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabaseWithModelRunParameterSetValues(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabaseWithModelRunParameterSetValues(db) },
                 work = { repo ->
                     repo.getModelRunParameterSet(groupId, "touchstone-2", 1)
-        })
+                })
     }
 
     @Test
     fun `cannot get model run parameter sets if touchstone doesn't exist`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
                 work = { repo ->
                     repo.getModelRunParameterSets(groupId, "wrong-id")
                 })
@@ -225,7 +185,7 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `cannot get model run parameter sets if group doesn't exist`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
                 work = { repo ->
                     repo.getModelRunParameterSets("wrong-id", touchstoneVersionId)
                 })
@@ -245,7 +205,7 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
     @Test
     fun `check model run parameter set exists throws error when set does not exist`()
     {
-        assertUnknownObjectError(setup = {db -> setupDatabase(db)},
+        assertUnknownObjectError(setup = { db -> setupDatabase(db) },
                 work = { repo ->
                     repo.checkModelRunParameterSetExists(99, groupId, touchstoneVersionId)
                 })
@@ -257,7 +217,7 @@ class ModelParameterTests : BurdenEstimateRepositoryTests()
         var returnedIds: ReturnedIds? = null
         withDatabase { db ->
             returnedIds = setupDatabaseWithModelRunParameterSet(db)
-            db.addGroup("some other group", "another group" )
+            db.addGroup("some other group", "another group")
         }
         withRepo { repo ->
             val modelRunParameterSetId = returnedIds!!.modelRunParameterSetId!!

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.api.databaseTests.tests.modellingGroupRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import org.vaccineimpact.api.app.errors.DatabaseContentsError
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.ModellingGroup
 import org.vaccineimpact.api.models.ModellingGroupDetails
@@ -247,6 +248,40 @@ class GetModellingGroupTests : ModellingGroupRepositoryTests()
     {
         givenABlankDatabase() check { repo ->
             assertThatThrownBy { repo.getModellingGroupDetails("a") }.isInstanceOf(org.vaccineimpact.api.app.errors.UnknownObjectError::class.java)
+        }
+    }
+
+    @Test
+    fun `can get latest model version for modelling group`()
+    {
+        val groupId = "g1"
+        val diseaseId = "d1"
+        withDatabase {
+            it.addGroup(groupId, "description")
+            it.addDisease(diseaseId)
+            it.addModel("m1", groupId, diseaseId)
+        }
+
+        withRepo {
+            assertThat(it.getLatestModelVersionForGroup(groupId, diseaseId)).isEqualTo(diseaseId)
+        }
+    }
+
+    @Test
+    fun `throws UnknownObjectError if group has no models`() {
+
+        val groupId = "g1"
+        val diseaseId = "d1"
+        withDatabase {
+            it.addGroup(groupId, "description")
+            it.addDisease(diseaseId)
+        }
+
+        withRepo {
+            assertThatThrownBy {
+                it.getLatestModelVersionForGroup(groupId, diseaseId)
+            }.isInstanceOf(DatabaseContentsError::class.java)
+                    .hasMessageContaining("Modelling group $groupId does not have any models/model versions in the database")
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/modellingGroupRepository/GetModellingGroupTests.kt
@@ -256,14 +256,15 @@ class GetModellingGroupTests : ModellingGroupRepositoryTests()
     {
         val groupId = "g1"
         val diseaseId = "d1"
-        withDatabase {
+        val versionId = withDatabase {
             it.addGroup(groupId, "description")
             it.addDisease(diseaseId)
             it.addModel("m1", groupId, diseaseId)
+            it.addModelVersion("m1", "v1", setCurrent = true)
         }
 
         withRepo {
-            assertThat(it.getLatestModelVersionForGroup(groupId, diseaseId)).isEqualTo(diseaseId)
+            assertThat(it.getLatestModelVersionForGroup(groupId, diseaseId)).isEqualTo(versionId)
         }
     }
 


### PR DESCRIPTION
I figured while I'm touching the burden estimate set creation logic I should move it into the logic layer as per our incremental refactor. So this PR keeps functionality the same but moves logic into the logic layer.

Contains commits from https://github.com/vimc/montagu-api/pull/401 so merge that one first and merge master in here for clean diff.