### PR TITLE
VIMC-3062 persist original filename used to upload estimates

### DIFF
--- a/docs/schemas/BurdenEstimateSet.schema.json
+++ b/docs/schemas/BurdenEstimateSet.schema.json
@@ -7,8 +7,9 @@
         "uploaded_on": { "$ref": "Timestamp.schema.json" },
         "type": { "$ref": "BurdenEstimateSetType.schema.json" },
         "status": { "$ref": "BurdenEstimateSetStatus.schema.json" },
-        "problems": { "type": "array","items": { "type": "string" } }
-    },
+        "problems": { "type": "array","items": { "type": "string" } },
+        "original_filename": { "type": "string" }
+        },
     "additionalProperties": false,
     "required": [ "id", "uploaded_by", "uploaded_on", "type", "problems", "status" ]
 }

--- a/docs/spec/BurdenEstimates.md
+++ b/docs/spec/BurdenEstimates.md
@@ -26,7 +26,8 @@ Schema: [`BurdenEstimates.schema.json`](../schemas/BurdenEstimates.schema.json)
                 "details": "Mean over all stochastic runs"
             },
             "problems": [],
-            "status": "complete"
+            "status": "complete",
+            "original_filename": "file.csv"
         }
     ]   
 
@@ -45,7 +46,8 @@ Schema: [`BurdenEstimateSet.schema.json`](../schemas/BurdenEstimateSet.schema.js
             "details": "Mean over all stochastic runs"
         },
         "problems": [],
-        "status": "empty"
+        "status": "empty",
+        "original_filename": "file.csv"
     }
     
 ## GET /modelling-groups/{modelling-group-id}/responsibilities/{touchstone-id}/{scenario-id}/estimate-sets/{estimate-id}/estimates/

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -119,8 +119,8 @@ class BurdenEstimateUploadController(context: ActionContext,
                     path.groupId,
                     path.touchstoneVersionId,
                     path.scenarioId,
-                    data
-            )
+                    data,
+                    file.originalFileName)
 
             chunkedFileCache.remove(file.uniqueIdentifier)
 
@@ -150,9 +150,11 @@ class BurdenEstimateUploadController(context: ActionContext,
         val data = getBurdenEstimateDataFromCSV(metadata, source)
         estimatesLogic.populateBurdenEstimateSet(
                 setId,
-                path.groupId, path.touchstoneVersionId, path.scenarioId,
-                data
-        )
+                path.groupId,
+                path.touchstoneVersionId,
+                path.scenarioId,
+                data,
+                filename = null)
 
         // Then, maybe close the burden estimate set
         val keepOpen = context.queryParams("keepOpen")?.toBoolean() ?: false

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -23,7 +23,7 @@ interface BurdenEstimateLogic
                                 uploader: String, timestamp: Instant): Int
 
     fun populateBurdenEstimateSet(setId: Int, groupId: String, touchstoneVersionId: String, scenarioId: String,
-                                  estimates: Sequence<BurdenEstimateWithRunId>)
+                                  estimates: Sequence<BurdenEstimateWithRunId>, filename: String?)
 
     @Throws(MissingRowsError::class)
     fun closeBurdenEstimateSet(setId: Int, groupId: String, touchstoneVersionId: String, scenarioId: String)
@@ -256,7 +256,7 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
     }
 
     override fun populateBurdenEstimateSet(setId: Int, groupId: String, touchstoneVersionId: String, scenarioId: String,
-                                           estimates: Sequence<BurdenEstimateWithRunId>)
+                                           estimates: Sequence<BurdenEstimateWithRunId>, filename: String?)
     {
         val group = modellingGroupRepository.getModellingGroup(groupId)
         val responsibilityInfo = burdenEstimateRepository.getResponsibilityInfo(group.id, touchstoneVersionId, scenarioId)
@@ -279,6 +279,11 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
 
         burdenEstimateRepository.changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.PARTIAL)
         burdenEstimateRepository.updateCurrentBurdenEstimateSet(responsibilityInfo.id, setId, set.type)
+
+        if (filename != null)
+        {
+            burdenEstimateRepository.updateBurdenEstimateSetFilename(setId, filename)
+        }
     }
 
     private fun populateCentralBurdenEstimateSet(set: BurdenEstimateSet, responsibilityInfo: ResponsibilityInfo,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
@@ -56,4 +56,6 @@ interface BurdenEstimateRepository : Repository
             : Sequence<BurdenEstimateOutcome>
 
     fun getExpectedOutcomesForBurdenEstimateSet(burdenEstimateSetId: Int): List<String>
+
+    fun updateBurdenEstimateSetFilename(setId: Int, filename: String?)
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -159,6 +159,7 @@ class JooqBurdenEstimateRepository(
                 table.SET_TYPE_DETAILS,
                 table.STATUS,
                 table.RESPONSIBILITY,
+                table.ORIGINAL_FILENAME,
                 BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM
         )
                 .from(table)
@@ -181,6 +182,7 @@ class JooqBurdenEstimateRepository(
                 table.SET_TYPE,
                 table.SET_TYPE_DETAILS,
                 table.STATUS,
+                table.ORIGINAL_FILENAME,
                 BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM
         )
                 .from(table)
@@ -211,6 +213,7 @@ class JooqBurdenEstimateRepository(
                 table.SET_TYPE,
                 table.SET_TYPE_DETAILS,
                 table.STATUS,
+                table.ORIGINAL_FILENAME,
                 BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM
         )
                 .from(table)
@@ -504,6 +507,14 @@ class JooqBurdenEstimateRepository(
                 .fetchOne()
                 ?.into(ResponsibilityInfo::class.java)
                 ?: findMissingObjects(touchstoneVersionId, scenarioId)
+    }
+
+    override fun updateBurdenEstimateSetFilename(setId: Int, filename: String?)
+    {
+        dsl.update(BURDEN_ESTIMATE_SET)
+                .set(BURDEN_ESTIMATE_SET.ORIGINAL_FILENAME, filename)
+                .where(BURDEN_ESTIMATE_SET.ID.eq(setId))
+                .execute()
     }
 
     private fun getResponsibilitySetId(groupId: String, touchstoneVersionId: String): Int

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
@@ -88,7 +88,7 @@ class JooqResponsibilitiesRepository(
                 status = mapper.mapEnum(first[Tables.BURDEN_ESTIMATE_SET.STATUS]),
                 problems = input.filter { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] != null }
                         .map { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] },
-                originalFileName = first[Tables.BURDEN_ESTIMATE_SET.ORIGINAL_FILENAME]
+                originalFilename = first[Tables.BURDEN_ESTIMATE_SET.ORIGINAL_FILENAME]
         )
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqResponsibilitiesRepository.kt
@@ -58,7 +58,8 @@ class JooqResponsibilitiesRepository(
                         table.SET_TYPE,
                         table.SET_TYPE_DETAILS,
                         table.STATUS,
-                        table.ID
+                        table.ID,
+                        table.ORIGINAL_FILENAME
                 )
                 .fromJoinPath(table, Tables.BURDEN_ESTIMATE_SET_PROBLEM, joinType = JoinType.LEFT_OUTER_JOIN)
                 .join(Tables.RESPONSIBILITY)
@@ -86,7 +87,8 @@ class JooqResponsibilitiesRepository(
                 type = mapper.mapBurdenEstimateSetType(first),
                 status = mapper.mapEnum(first[Tables.BURDEN_ESTIMATE_SET.STATUS]),
                 problems = input.filter { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] != null }
-                        .map { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] }
+                        .map { it[Tables.BURDEN_ESTIMATE_SET_PROBLEM.PROBLEM] },
+                originalFileName = first[Tables.BURDEN_ESTIMATE_SET.ORIGINAL_FILENAME]
         )
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/mapping/BurdenMappingHelper.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/mapping/BurdenMappingHelper.kt
@@ -36,7 +36,8 @@ class BurdenMappingHelper : MappingHelper()
                 common[table.UPLOADED_BY],
                 mapBurdenEstimateSetType(common),
                 mapEnum(common[table.STATUS]),
-                problems
+                problems,
+                common[table.ORIGINAL_FILENAME]
         )
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
@@ -39,7 +39,7 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
     protected fun mockLogic(): BurdenEstimateLogic
     {
         return mock {
-            on { populateBurdenEstimateSet(any(), any(), any(), any(), any()) } doAnswer { args ->
+            on { populateBurdenEstimateSet(any(), any(), any(), any(), any(), anyOrNull()) } doAnswer { args ->
                 // Force evaluation of sequence
                 args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
                 Unit
@@ -58,6 +58,6 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
             1, Instant.now(), "test.user",
             BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "mean"),
             BurdenEstimateSetStatus.EMPTY,
-            emptyList()
-    )
+            emptyList(),
+            null)
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -23,12 +23,14 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 BurdenEstimateSet(1, Instant.MIN, "ThePast",
                         BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "Median"),
                         BurdenEstimateSetStatus.COMPLETE,
-                        emptyList()
+                        emptyList(),
+                        "file.csv"
                 ),
                 BurdenEstimateSet(2, Instant.MAX, "TheFuture",
                         BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_SINGLE_RUN, null),
                         BurdenEstimateSetStatus.EMPTY,
-                        listOf("Doesn't exist yet")
+                        listOf("Doesn't exist yet"),
+                        null
                 )
         )
         val touchstoneRepo = mockTouchstoneRepository()
@@ -55,7 +57,8 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         val data = BurdenEstimateSet(1, Instant.MIN, "ThePast",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "Median"),
                 BurdenEstimateSetStatus.COMPLETE,
-                emptyList()
+                emptyList(),
+                "file.csv"
         )
         val touchstoneRepo = mockTouchstoneRepository()
         val repo = mock<BurdenEstimateRepository> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -35,7 +35,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 
         val mockContext = mockPopulateFromLocalFileActionContext("user.name")
         val repo = mockEstimatesRepository(touchstoneSet)
-        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
+        val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true, fileName = "file.csv")
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
         val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
@@ -44,7 +44,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 
         assertThat(result.status).isEqualTo(ResultStatus.SUCCESS)
         assertThat(result.data).isEqualTo("OK")
-        verify(logic).populateBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"), any())
+        verify(logic).populateBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"), any(), eq("file.csv"))
         verify(logic).closeBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"))
     }
 
@@ -53,7 +53,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
     {
         val touchstoneSet = mockTouchstones()
         val logic = mock<BurdenEstimateLogic> {
-            on { populateBurdenEstimateSet(any(), any(), any(), any(), any()) } doAnswer { args ->
+            on { populateBurdenEstimateSet(any(), any(), any(), any(), any(), anyOrNull()) } doAnswer { args ->
                 // Force evaluation of sequence
                 args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
                 Unit
@@ -82,7 +82,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
     {
         val touchstoneSet = mockTouchstones()
         val logic = mock<BurdenEstimateLogic> {
-            on { populateBurdenEstimateSet(any(), any(), any(), any(), any()) } doAnswer { args ->
+            on { populateBurdenEstimateSet(any(), any(), any(), any(), any(), anyOrNull()) } doAnswer { args ->
                 // Force evaluation of sequence
                 args.getArgument<Sequence<BurdenEstimateWithRunId>>(4).toList()
                 Unit

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -344,10 +344,10 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
         }
     }
 
-    protected fun makeFakeCacheWithChunkedFile(uid: String, uploadFinished: Boolean): Cache<ChunkedFile>
+    protected fun makeFakeCacheWithChunkedFile(uid: String, uploadFinished: Boolean, fileName: String = "filename.csv"): Cache<ChunkedFile>
     {
         val fakeInfo = ChunkedFile(totalChunks = 1, totalSize = 1000, chunkSize = 100,
-                uniqueIdentifier = uid, originalFileName = "filename.csv")
+                uniqueIdentifier = uid, originalFileName = fileName)
 
         if (uploadFinished)
         {
@@ -428,7 +428,8 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
                 eq(groupId), eq(touchstoneVersionId), eq(scenarioId),
                 argWhere {
                     it.toSet() == expectedData.toSet()
-                }
+                },
+                anyOrNull()
         )
         verifyValidResponsibilityPathChecks(logic, actionContext)
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
@@ -29,7 +29,8 @@ class BurdenEstimateLogicTests : MontaguTests()
             1, Instant.now(), "test.user",
             BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "mean"),
             BurdenEstimateSetStatus.EMPTY,
-            emptyList()
+            emptyList(),
+            null
     )
 
     private val disease = "disease-1"
@@ -108,7 +109,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val estimatesRepo = mockEstimatesRepository(estimateWriter)
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), estimatesRepo, mockExpectationsRepository(), mock(), mock())
         Assertions.assertThatThrownBy {
-            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, data)
+            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, data, null)
         }.isInstanceOf(InconsistentDataError::class.java)
                 .hasMessageContaining("disease")
     }
@@ -120,7 +121,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val repo = mockEstimatesRepository(writer)
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
 
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData)
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
 
         verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
     }
@@ -131,8 +132,18 @@ class BurdenEstimateLogicTests : MontaguTests()
         val repo = mockEstimatesRepository()
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
 
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData)
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
         verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.PARTIAL)
+    }
+
+    @Test
+    fun `original filename is updated`()
+    {
+        val repo = mockEstimatesRepository()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, "file.csv")
+        verify(repo).updateBurdenEstimateSetFilename(setId, "file.csv")
     }
 
     @Test
@@ -141,7 +152,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val repo = mockEstimatesRepository()
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
 
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData)
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
         verify(repo).getEstimateWriter(defaultEstimateSet)
     }
 
@@ -458,7 +469,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         }
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
 
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData)
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
         verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
     }
 
@@ -474,7 +485,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
 
         Assertions.assertThatThrownBy {
-            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData)
+            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
         }.isInstanceOf(InvalidOperationError::class.java)
                 .hasMessageContaining("You must create a new set if you want to upload any new estimates.")
 
@@ -653,7 +664,7 @@ AGO, age 12, year 2005""")
     {
         val fakeEstimateSets = listOf(BurdenEstimateSet(1, Instant.now(), "someone",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, ""),
-                BurdenEstimateSetStatus.COMPLETE, listOf()))
+                BurdenEstimateSetStatus.COMPLETE, listOf(), null))
 
         val repo = mock<BurdenEstimateRepository> {
             on { getBurdenEstimateSets("g1", "t1", "s1") } doReturn fakeEstimateSets

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/BurdenEstimateSetTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/models/BurdenEstimateSetTests.kt
@@ -15,10 +15,10 @@ class BurdenEstimateSetTests
     {
         val stochasticSet = BurdenEstimateSet(1, Instant.now(), "uploader",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.STOCHASTIC),
-                BurdenEstimateSetStatus.EMPTY, emptyList())
+                BurdenEstimateSetStatus.EMPTY, emptyList(), null)
         val centralSet = BurdenEstimateSet(1, Instant.now(), "uploader",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_SINGLE_RUN),
-                BurdenEstimateSetStatus.EMPTY, emptyList())
+                BurdenEstimateSetStatus.EMPTY, emptyList(), null)
         assertThat(stochasticSet.isStochastic()).isTrue()
         assertThat(centralSet.isStochastic()).isFalse()
     }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/PopulateBurdenEstimateTests.kt
@@ -3,7 +3,10 @@ package org.vaccineimpact.api.blackboxTests.tests.BurdenEstimates
 import khttp.responses.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.blackboxTests.helpers.*
+import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
+import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
+import org.vaccineimpact.api.blackboxTests.helpers.TokenLiteral
+import org.vaccineimpact.api.blackboxTests.helpers.validate
 import org.vaccineimpact.api.blackboxTests.schemas.CSVSchema
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.*
@@ -193,8 +196,8 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload file in 1 chunk and then populate set`() {
-
+    fun `can upload file in 1 chunk and then populate set`()
+    {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
         }
@@ -208,7 +211,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         val queryParams = mapOf("chunkNumber" to 1,
                 "totalSize" to size,
                 "chunkSize" to size,
-                "fileName" to  fileName,
+                "fileName" to fileName,
                 "totalChunks" to 1)
                 .map { "${it.key}=${it.value}" }
                 .joinToString("&")
@@ -224,11 +227,16 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
                     .from(BURDEN_ESTIMATE)
                     .fetch()
             assertThat(records).isNotEmpty
+
+            val metadata = db.dsl.selectFrom(BURDEN_ESTIMATE_SET)
+                    .fetchOne()
+            assertThat(metadata[BURDEN_ESTIMATE_SET.ORIGINAL_FILENAME]).isEqualTo("test.csv")
         }
     }
 
     @Test
-    fun `can upload file by multiple chunks and then populate set`() {
+    fun `can upload file by multiple chunks and then populate set`()
+    {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it, yearMinInclusive = 1996, yearMaxInclusive = 1999)
         }
@@ -257,7 +265,8 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `can upload file by multiple chunks and get validation error on set population`() {
+    fun `can upload file by multiple chunks and get validation error on set population`()
+    {
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
         }
@@ -286,7 +295,8 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
     }
 
     @Test
-    fun `cannot reuse an upload token for a different file`() {
+    fun `cannot reuse an upload token for a different file`()
+    {
 
         val setId = JooqContext().use {
             setUpWithBurdenEstimateSet(it)
@@ -304,7 +314,7 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         val newMetadata = mapOf("chunkNumber" to 1,
                 "totalSize" to size,
                 "chunkSize" to 1,
-                "fileName" to  fileName,
+                "fileName" to fileName,
                 "totalChunks" to 1)
                 .map { "${it.key}=${it.value}" }
                 .joinToString("&")
@@ -335,7 +345,8 @@ class PopulateBurdenEstimateTests : BurdenEstimateTests()
         assertThat(response.statusCode).isEqualTo(400)
     }
 
-    private fun getUploadToken(setUrl: String, token: TokenLiteral) : String {
+    private fun getUploadToken(setUrl: String, token: TokenLiteral): String
+    {
         val response = RequestHelper().get("$setUrl/actions/request-upload/", token = token)
         val json = com.beust.klaxon.Parser().parse(StringBuilder(response.text)) as com.beust.klaxon.JsonObject
         return json["data"] as String

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -32,7 +32,7 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
     }
 
     @Test
-    fun `can update set filename`()
+    fun `can update burden estimate set original filename`()
     {
         val setId = withDatabase { db ->
             setupDatabaseWithBurdenEstimateSet(db, type = "central-averaged")

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -32,6 +32,23 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
     }
 
     @Test
+    fun `can update set filename`()
+    {
+        val setId = withDatabase { db ->
+            setupDatabaseWithBurdenEstimateSet(db, type = "central-averaged")
+        }
+        withRepo {
+            it.updateBurdenEstimateSetFilename(setId, "file.csv")
+        }
+
+        withDatabase { db ->
+            val t = Tables.BURDEN_ESTIMATE_SET
+            val set = db.dsl.selectFrom(t).where(t.ID.eq(setId)).fetchOne()
+            Assertions.assertThat(set[t.ORIGINAL_FILENAME]).isEqualTo("file.csv")
+        }
+    }
+
+    @Test
     fun `can update current central estimate set`()
     {
         val (returnedIds, setId) = withDatabase { db ->
@@ -74,7 +91,8 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
                 1, Instant.now(), "test.user",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "mean"),
                 BurdenEstimateSetStatus.EMPTY,
-                emptyList()
+                emptyList(),
+                null
         )
         withRepo {
             val result = it.getEstimateWriter(centralEstimateSet)
@@ -89,7 +107,8 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
                 1, Instant.now(), "test.user",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.STOCHASTIC, "mean"),
                 BurdenEstimateSetStatus.EMPTY,
-                emptyList()
+                emptyList(),
+                null
         )
         withRepo {
             val result = it.getEstimateWriter(stochasticEstimateSet)
@@ -127,7 +146,7 @@ class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()
 
         val burdenEstimateSet = BurdenEstimateSet(setId, Instant.now(), "",
                 BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED),
-                BurdenEstimateSetStatus.EMPTY, listOf())
+                BurdenEstimateSetStatus.EMPTY, listOf(), null)
 
         val result = withRepo {
             it.validateEstimates(burdenEstimateSet,

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
@@ -232,14 +232,14 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
             Assertions.assertThat(a.uploadedOn).isAfter(before)
             Assertions.assertThat(a.uploadedOn).isBefore(after)
             Assertions.assertThat(a.problems).isEmpty()
-            Assertions.assertThat(a.originalFileName).isNull()
+            Assertions.assertThat(a.originalFilename).isNull()
 
             val b = sets.single { it.id == setB }
             Assertions.assertThat(b.uploadedBy).isEqualTo("some.other.user")
             Assertions.assertThat(b.uploadedOn).isAfter(a.uploadedOn)
             Assertions.assertThat(b.uploadedOn).isBefore(after)
             Assertions.assertThat(b.problems).hasSameElementsAs(listOf("some problem"))
-            Assertions.assertThat(b.originalFileName).isEqualTo("file.csv")
+            Assertions.assertThat(b.originalFilename).isEqualTo("file.csv")
         }
     }
 
@@ -278,7 +278,7 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
             assertThat(set.uploadedBy).isEqualTo(username)
             assertThat(set.problems).isEmpty()
             assertThat(set.isStochastic()).isTrue()
-            assertThat(set.originalFileName).isEqualTo("file.csv")
+            assertThat(set.originalFilename).isEqualTo("file.csv")
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/RetrieveBurdenEstimatesTests.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.api.databaseTests.tests.burdenEstimateRepository
 
-import com.sun.org.apache.bcel.internal.classfile.Unknown
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -15,7 +14,6 @@ import org.vaccineimpact.api.models.BurdenEstimateGrouping
 import org.vaccineimpact.api.models.BurdenEstimateSet
 import org.vaccineimpact.api.models.BurdenEstimateSetType
 import org.vaccineimpact.api.models.BurdenEstimateSetTypeCode
-import spark.route.HttpMethod
 import java.time.Instant
 
 class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
@@ -224,7 +222,7 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
             val modelVersionId = ids.modelVersion!!
             db.addUserForTesting(otherUser)
             setA = db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username)
-            setB = db.addBurdenEstimateSet(ids.responsibility, modelVersionId, "some.other.user")
+            setB = db.addBurdenEstimateSet(ids.responsibility, modelVersionId, "some.other.user", filename = "file.csv")
             db.addBurdenEstimateProblem("some problem", setB)
         } check { repo ->
             val after = Instant.now()
@@ -234,12 +232,14 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
             Assertions.assertThat(a.uploadedOn).isAfter(before)
             Assertions.assertThat(a.uploadedOn).isBefore(after)
             Assertions.assertThat(a.problems).isEmpty()
+            Assertions.assertThat(a.originalFileName).isNull()
 
             val b = sets.single { it.id == setB }
             Assertions.assertThat(b.uploadedBy).isEqualTo("some.other.user")
             Assertions.assertThat(b.uploadedOn).isAfter(a.uploadedOn)
             Assertions.assertThat(b.uploadedOn).isBefore(after)
             Assertions.assertThat(b.problems).hasSameElementsAs(listOf("some problem"))
+            Assertions.assertThat(b.originalFileName).isEqualTo("file.csv")
         }
     }
 
@@ -271,13 +271,14 @@ class RetrieveBurdenEstimatesTests : BurdenEstimateRepositoryTests()
         val setId = withDatabase { db ->
             val ids = setupDatabase(db)
             val modelVersionId = ids.modelVersion!!
-            db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username, setType = "stochastic")
+            db.addBurdenEstimateSet(ids.responsibility, modelVersionId, username, setType = "stochastic", filename = "file.csv")
         }
         withRepo { repo ->
             val set = repo.getBurdenEstimateSet(groupId, touchstoneVersionId, scenarioId,  setId)
             assertThat(set.uploadedBy).isEqualTo(username)
             assertThat(set.problems).isEmpty()
             assertThat(set.isStochastic()).isTrue()
+            assertThat(set.originalFileName).isEqualTo("file.csv")
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/GetResponsibilitiesTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/GetResponsibilitiesTests.kt
@@ -167,11 +167,12 @@ class GetResponsibilitiesTests : ResponsibilitiesRepositoryTests()
             val responsibilityId = it.addResponsibility(setId, "touchstone-1", "scenario-1")
             it.addModel("model-1", "group", "disease 1")
             val version = it.addModelVersion("model-1", "version-1")
-            burdenEstimateId = it.addBurdenEstimateSet(responsibilityId, version, "test.user")
+            burdenEstimateId = it.addBurdenEstimateSet(responsibilityId, version, "test.user", filename = "file.csv")
             it.updateCurrentEstimate(responsibilityId, burdenEstimateId)
         } check { repo ->
             val set = repo.getResponsibilitiesForGroup("group", "touchstone-1", ScenarioFilterParameters())
             assertThat(set.responsibilities.first().currentEstimateSet!!.id).isEqualTo(burdenEstimateId)
+            assertThat(set.responsibilities.first().currentEstimateSet!!.originalFilename).isEqualTo("file.csv")
             assertThat(set.responsibilities.first().status).isEqualTo(ResponsibilityStatus.VALID)
         }
     }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/GetResponsibilityTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/responsibilitiesRepository/GetResponsibilityTests.kt
@@ -91,7 +91,7 @@ class GetResponsibilityTests : ResponsibilitiesRepositoryTests()
             val responsibilityId = it.addResponsibility(setId, "touchstone-1", "scenario-1")
             it.addModel("model-1", "group", "d1")
             val version = it.addModelVersion("model-1", "version-1")
-            burdenEstimateId = it.addBurdenEstimateSet(responsibilityId, version, "test.user")
+            burdenEstimateId = it.addBurdenEstimateSet(responsibilityId, version, "test.user", filename = "file.csv")
             it.updateCurrentEstimate(responsibilityId, burdenEstimateId)
         } check { repo ->
             val responsibility = repo.getResponsibility("group", "touchstone-1", "scenario-1")
@@ -99,6 +99,7 @@ class GetResponsibilityTests : ResponsibilitiesRepositoryTests()
             assertThat(responsibility.currentEstimateSet!!.id).isEqualTo(burdenEstimateId)
             assertThat(responsibility.status).isEqualTo(ResponsibilityStatus.VALID)
             assertThat(responsibility.currentEstimateSet!!.uploadedOn).isNotNull()
+            assertThat(responsibility.currentEstimateSet!!.originalFilename).isNotNull()
         }
     }
 

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
@@ -82,6 +82,7 @@ open class MontaguSerializer : Serializer
         val baseGson = common.create()
         gson = common
                 .registerTypeAdapter<User>(ruleBasedSerializer(baseGson))
+                .registerTypeAdapter<BurdenEstimateSet>(ruleBasedSerializer(baseGson))
                 .registerTypeAdapter<ScenarioTouchstoneAndCoverageSets>(ruleBasedSerializer(baseGson))
                 .registerTypeAdapter<ScenarioAndCoverageSets>(ruleBasedSerializer(baseGson))
                 .registerTypeAdapter<BurdenEstimateDataSeries>(BurdenEstimateDataSeriesTypeAdaptor())

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
@@ -226,7 +226,8 @@ fun JooqContext.addBurdenEstimateSet(
         setType: String = "central-single-run", setTypeDetails: String? = null,
         modelRunParameterSetId: Int? = null,
         timestamp: Instant = Instant.now(),
-        setId: Int? = null
+        setId: Int? = null,
+        filename: String? = null
 ): Int
 {
     val record = this.dsl.newRecord(BURDEN_ESTIMATE_SET).apply {
@@ -241,6 +242,7 @@ fun JooqContext.addBurdenEstimateSet(
         this.complete = false
         this.status = status
         this.modelRunParameterSet = modelRunParameterSetId
+        this.originalFilename = filename
     }
     if (setId != null)
     {


### PR DESCRIPTION
Persist the filename used to populate estimates and return it on requests for metadata.