### PR TITLE
VIMC-2986 send Slack notifications

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile "org.pac4j:pac4j-http:2.2.1"
     compile "commons-fileupload:commons-fileupload:1.3.3"
     compile "com.offbytwo:docopt:0.6.0.20150202"
+    compile "khttp:khttp:0.1.0"
 
     compile project(":databaseInterface")
     compile project(":models")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
@@ -17,8 +17,7 @@ abstract class BaseBurdenEstimateController(context: ActionContext,
 
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario,
-                                                repos.touchstone))
+            RepositoriesBurdenEstimateLogic(repos))
 
     protected fun closeEstimateSetAndReturnMissingRowError(setId: Int, groupId: String, touchstoneVersionId: String,
                                                            scenarioId: String): Result

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -41,8 +41,7 @@ class BurdenEstimateUploadController(context: ActionContext,
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
             repos,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario,
-                    repos.touchstone),
+            RepositoriesBurdenEstimateLogic(repos),
             repos.burdenEstimates)
 
     fun getUploadToken(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -18,8 +18,7 @@ open class BurdenEstimatesController(
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            RepositoriesBurdenEstimateLogic(repos.modellingGroup, repos.burdenEstimates, repos.expectations, repos.scenario,
-                    repos.touchstone),
+            RepositoriesBurdenEstimateLogic(repos),
             repos.burdenEstimates)
 
     fun getBurdenEstimateSets(): List<BurdenEstimateSet>

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -54,14 +54,17 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
                                       private val burdenEstimateRepository: BurdenEstimateRepository,
                                       private val expectationsRepository: ExpectationsRepository,
                                       private val scenarioRepository: ScenarioRepository,
-                                      private val touchstoneRepository: TouchstoneRepository) : BurdenEstimateLogic
+                                      private val touchstoneRepository: TouchstoneRepository,
+                                      private val notifier: Notifier) : BurdenEstimateLogic
 {
 
-    constructor(repositories: Repositories) : this(repositories.modellingGroup,
+    constructor(repositories: Repositories, notifier: Notifier = SlackNotifier()) : this(
+            repositories.modellingGroup,
             repositories.burdenEstimates,
             repositories.expectations,
             repositories.scenario,
-            repositories.touchstone)
+            repositories.touchstone,
+            notifier)
 
     override fun createBurdenEstimateSet(groupId: String, touchstoneVersionId: String, scenarioId: String,
                                          properties: CreateBurdenEstimateSet,
@@ -284,6 +287,8 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
         {
             burdenEstimateRepository.updateBurdenEstimateSetFilename(setId, filename)
         }
+
+        notifier.notify("A burden estimate set has just been uploaded for ${group.id}")
     }
 
     private fun populateCentralBurdenEstimateSet(set: BurdenEstimateSet, responsibilityInfo: ResponsibilityInfo,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/HttpClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/HttpClient.kt
@@ -4,6 +4,7 @@ import khttp.responses.Response
 
 interface HttpClient
 {
+    @Throws(Exception::class)
     fun post(url: String, headers: Map<String, String>, json: Map<String, String> = mapOf()): Response
     fun get(url: String, headers: Map<String, String>): Response
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/HttpClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/HttpClient.kt
@@ -1,0 +1,29 @@
+package org.vaccineimpact.api.app.logic
+
+import khttp.responses.Response
+
+interface HttpClient
+{
+    fun post(url: String, headers: Map<String, String>, json: Map<String, String> = mapOf()): Response
+    fun get(url: String, headers: Map<String, String>): Response
+}
+
+class KHttpClient : HttpClient
+{
+    override fun post(url: String, headers: Map<String, String>, json: Map<String, String>): Response
+    {
+        return if (json.any())
+        {
+            khttp.post(url, headers, json = json)
+        }
+        else
+        {
+            khttp.post(url, headers)
+        }
+    }
+
+    override fun get(url: String, headers: Map<String, String>): Response
+    {
+        return khttp.get(url, headers)
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/Notifier.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/Notifier.kt
@@ -10,19 +10,20 @@ interface Notifier
     fun notify(message: String)
 }
 
-class SlackNotifier(private val client: HttpClient = KHttpClient(), private val appConfig: ConfigWrapper = Config) : Notifier
+class SlackNotifier(private val client: HttpClient = KHttpClient(),
+                    private val appConfig: ConfigWrapper = Config) : Notifier
 {
     private val logger = LoggerFactory.getLogger(SlackNotifier::class.java)
     override fun notify(message: String)
     {
         try
         {
-            val headers = mapOf("Content-Type" to ContentTypes.json)
+            val headers = mapOf("Content-type" to ContentTypes.json)
             client.post(appConfig["slack.url"], headers, mapOf("text" to message))
         }
         catch (e: Exception)
         {
-            logger.warn("There was a problem sending the slack message: ${e.message}")
+            logger.warn("There was a problem sending the Slack message: ${e.message}")
         }
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/Notifier.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/Notifier.kt
@@ -1,0 +1,28 @@
+package org.vaccineimpact.api.app.logic
+
+import org.slf4j.LoggerFactory
+import org.vaccineimpact.api.db.Config
+import org.vaccineimpact.api.db.ConfigWrapper
+import org.vaccineimpact.api.models.helpers.ContentTypes
+
+interface Notifier
+{
+    fun notify(message: String)
+}
+
+class SlackNotifier(private val client: HttpClient = KHttpClient(), private val appConfig: ConfigWrapper = Config) : Notifier
+{
+    private val logger = LoggerFactory.getLogger(SlackNotifier::class.java)
+    override fun notify(message: String)
+    {
+        try
+        {
+            val headers = mapOf("Content-Type" to ContentTypes.json)
+            client.post(appConfig["slack.url"], headers, mapOf("text" to message))
+        }
+        catch (e: Exception)
+        {
+            logger.warn("There was a problem sending the slack message: ${e.message}")
+        }
+    }
+}

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -31,3 +31,4 @@ email.username=${email_username}
 email.password=${email_password}
 
 contact.support=${contact_support}
+slack.url=${slack_url}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BaseBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BaseBurdenEstimateLogicTests.kt
@@ -1,0 +1,86 @@
+package org.vaccineimpact.api.tests.logic.BurdenEstimateLogic
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doAnswer
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.ExpectationsRepository
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.burdenestimates.BurdenEstimateWriter
+import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
+import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.time.Instant
+
+abstract class BaseBurdenEstimateLogicTests : MontaguTests()
+{
+    protected val defaultEstimateSet = BurdenEstimateSet(
+            1, Instant.now(), "test.user",
+            BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "mean"),
+            BurdenEstimateSetStatus.EMPTY,
+            emptyList(),
+            null
+    )
+
+    protected val disease = "disease-1"
+    protected val responsibilityId = 1
+    protected val setId = 1
+    protected val groupId = "group-1"
+    protected val touchstoneVersionId = "touchstone-1"
+    protected val scenarioId = "scenario-1"
+
+    protected fun mockWriter(): BurdenEstimateWriter
+    {
+        return mock {
+            on { addEstimatesToSet(any(), any(), any()) } doAnswer { args ->
+                // Force evaluation of sequence
+                args.getArgument<Sequence<BurdenEstimateWithRunId>>(1).toList()
+                Unit
+            }
+        }
+    }
+
+    protected val fakeExpectations = CountryOutcomeExpectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
+            listOf(Country("AFG", "")),
+            listOf())
+
+    protected fun mockExpectationsRepository(): ExpectationsRepository = mock {
+        on { getExpectationsForResponsibility(responsibilityId) } doReturn ExpectationMapping(fakeExpectations, listOf(), disease)
+    }
+
+    protected fun mockGroupRepository(): ModellingGroupRepository = mock {
+        on { getModellingGroup(groupId) } doReturn ModellingGroup(groupId, "description")
+    }
+
+    protected fun mockEstimatesRepository(mockEstimateWriter: BurdenEstimateWriter = mockWriter(),
+                                        existingBurdenEstimateSet: BurdenEstimateSet = defaultEstimateSet
+    ): BurdenEstimateRepository
+    {
+        return mock {
+            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn existingBurdenEstimateSet
+            on { getResponsibilityInfo(any(), any(), any()) } doReturn
+                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
+            on { getEstimateWriter(any()) } doReturn mockEstimateWriter
+        }
+    }
+
+    protected val validData = sequenceOf(
+            BurdenEstimateWithRunId("yf", null, 2000, 1, "AFG", "Afghanistan", 1000F, mapOf(
+                    "deaths" to 10F,
+                    "cases" to 100F
+            )),
+            BurdenEstimateWithRunId("yf", null, 2001, 1, "AFG", "Afghanistan", 1000F, mapOf(
+                    "deaths" to 10F,
+                    "cases" to 100F
+            )),
+            BurdenEstimateWithRunId("yf", null, 2000, 2, "AFG", "Afghanistan", 1000F, mapOf(
+                    "deaths" to 10F,
+                    "cases" to 100F
+            )),
+            BurdenEstimateWithRunId("yf", null, 2001, 2, "AFG", "Afghanistan", 1000F, mapOf(
+                    "deaths" to 10F,
+                    "cases" to 100F
+            )))
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
@@ -23,138 +23,8 @@ import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import java.time.Instant
 
-class BurdenEstimateLogicTests : MontaguTests()
+class BurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
 {
-    private val defaultEstimateSet = BurdenEstimateSet(
-            1, Instant.now(), "test.user",
-            BurdenEstimateSetType(BurdenEstimateSetTypeCode.CENTRAL_AVERAGED, "mean"),
-            BurdenEstimateSetStatus.EMPTY,
-            emptyList(),
-            null
-    )
-
-    private val disease = "disease-1"
-    private val responsibilityId = 1
-    private val setId = 1
-    private val groupId = "group-1"
-    private val touchstoneVersionId = "touchstone-1"
-    private val scenarioId = "scenario-1"
-
-    private fun mockWriter(): BurdenEstimateWriter
-    {
-        return mock {
-            on { addEstimatesToSet(any(), any(), any()) } doAnswer { args ->
-                // Force evaluation of sequence
-                args.getArgument<Sequence<BurdenEstimateWithRunId>>(1).toList()
-                Unit
-            }
-        }
-    }
-
-    private fun mockEstimatesRepository(mockEstimateWriter: BurdenEstimateWriter = mockWriter(),
-                                        existingBurdenEstimateSet: BurdenEstimateSet = defaultEstimateSet
-    ): BurdenEstimateRepository
-    {
-        return mock {
-            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn existingBurdenEstimateSet
-            on { getResponsibilityInfo(any(), any(), any()) } doReturn
-                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
-            on { getEstimateWriter(any()) } doReturn mockEstimateWriter
-        }
-    }
-
-    private val fakeExpectations = CountryOutcomeExpectations(1, "desc", 2000..2001, 1..2, CohortRestriction(),
-            listOf(Country("AFG", "")),
-            listOf())
-
-    private fun mockExpectationsRepository(): ExpectationsRepository = mock {
-        on { getExpectationsForResponsibility(responsibilityId) } doReturn ExpectationMapping(fakeExpectations, listOf(), disease)
-    }
-
-    private fun mockGroupRepository(): ModellingGroupRepository = mock {
-        on { getModellingGroup(groupId) } doReturn ModellingGroup(groupId, "description")
-    }
-
-    private val validData = sequenceOf(
-            BurdenEstimateWithRunId("yf", null, 2000, 1, "AFG", "Afghanistan", 1000F, mapOf(
-                    "deaths" to 10F,
-                    "cases" to 100F
-            )),
-            BurdenEstimateWithRunId("yf", null, 2001, 1, "AFG", "Afghanistan", 1000F, mapOf(
-                    "deaths" to 10F,
-                    "cases" to 100F
-            )),
-            BurdenEstimateWithRunId("yf", null, 2000, 2, "AFG", "Afghanistan", 1000F, mapOf(
-                    "deaths" to 10F,
-                    "cases" to 100F
-            )),
-            BurdenEstimateWithRunId("yf", null, 2001, 2, "AFG", "Afghanistan", 1000F, mapOf(
-                    "deaths" to 10F,
-                    "cases" to 100F
-            )))
-
-    @Test
-    fun `cannot upload data with multiple diseases`()
-    {
-        val data = sequenceOf(
-                BurdenEstimateWithRunId("yf", null, 2000, 1, "AFG", "Afghanistan", 1000F, mapOf(
-                        "deaths" to 10F,
-                        "cases" to 100F
-                )),
-                BurdenEstimateWithRunId("menA", null, 2001, 2, "AFG", "Afghanistan", 2000F, mapOf(
-                        "deaths" to 20F,
-                        "dalys" to 73.6F
-                )))
-        val estimateWriter = mockWriter()
-        val estimatesRepo = mockEstimatesRepository(estimateWriter)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), estimatesRepo, mockExpectationsRepository(), mock(), mock())
-        Assertions.assertThatThrownBy {
-            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, data, null)
-        }.isInstanceOf(InconsistentDataError::class.java)
-                .hasMessageContaining("disease")
-    }
-
-    @Test
-    fun `can populate burden estimate set`()
-    {
-        val writer = mockWriter()
-        val repo = mockEstimatesRepository(writer)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-
-        verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
-    }
-
-    @Test
-    fun `set is marked as partial`()
-    {
-        val repo = mockEstimatesRepository()
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.PARTIAL)
-    }
-
-    @Test
-    fun `original filename is updated`()
-    {
-        val repo = mockEstimatesRepository()
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, "file.csv")
-        verify(repo).updateBurdenEstimateSetFilename(setId, "file.csv")
-    }
-
-    @Test
-    fun `gets estimate writer from repo`()
-    {
-        val repo = mockEstimatesRepository()
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-        verify(repo).getEstimateWriter(defaultEstimateSet)
-    }
 
     @Test
     fun `gets burden estimate set data`()
@@ -192,7 +62,7 @@ class BurdenEstimateLogicTests : MontaguTests()
             on { getBurdenEstimateOutcomesSequence(any(), any(), any(), any()) } doReturn testOutcomeData
             on { getExpectedOutcomesForBurdenEstimateSet(any()) } doReturn listOf("dalys", "deaths")
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         val result = sut.getBurdenEstimateData(1, groupId, touchstoneVersionId, scenarioId)
 
@@ -252,7 +122,7 @@ class BurdenEstimateLogicTests : MontaguTests()
             on { getBurdenEstimateOutcomesSequence(any(), any(), any(), any()) } doReturn testOutcomeData
             on { getExpectedOutcomesForBurdenEstimateSet(any()) } doReturn listOf("cases", "cases_acute", "dalys", "deaths")
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         val result = sut.getBurdenEstimateData(1, groupId, touchstoneVersionId, scenarioId)
 
@@ -378,7 +248,7 @@ class BurdenEstimateLogicTests : MontaguTests()
             on { getBurdenEstimateOutcomesSequence(any(), any(), any(), any()) } doReturn testOutcomeData
             on { getExpectedOutcomesForBurdenEstimateSet(any()) } doReturn listOf("cases", "dalys", "deaths")
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         val result = sut.getBurdenEstimateData(1, groupId, touchstoneVersionId, scenarioId)
 
@@ -455,42 +325,6 @@ class BurdenEstimateLogicTests : MontaguTests()
         expectedOutcomes.forEach { (key, value) -> Assertions.assertThat(estimateObj.outcomes[key]).isEqualTo(value) }
     }
 
-
-    @Test
-    fun `can populate a set if status is partial`()
-    {
-        val writer = mockWriter()
-        val repo = mock<BurdenEstimateRepository> {
-            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
-                    .copy(status = BurdenEstimateSetStatus.PARTIAL)
-            on { getResponsibilityInfo(any(), any(), any()) } doReturn
-                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
-            on { getEstimateWriter(any()) } doReturn writer
-        }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-        verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
-    }
-
-    @Test
-    fun `cannot populate a set if status is complete`()
-    {
-        val repo = mock<BurdenEstimateRepository> {
-            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
-                    .copy(status = BurdenEstimateSetStatus.COMPLETE)
-            on { getResponsibilityInfo(any(), any(), any()) } doReturn
-                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
-        }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
-
-        Assertions.assertThatThrownBy {
-            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-        }.isInstanceOf(InvalidOperationError::class.java)
-                .hasMessageContaining("You must create a new set if you want to upload any new estimates.")
-
-    }
-
     @Test
     fun `modelling-group id is checked before closing burden estimate set`()
     {
@@ -498,7 +332,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
         val repo = mockEstimatesRepository(writer)
         val groupRepo = mockGroupRepository()
-        val sut = RepositoriesBurdenEstimateLogic(groupRepo, repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(groupRepo, repo, mockExpectationsRepository(), mock(), mock(), mock())
         sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
         verify(groupRepo).getModellingGroup(groupId)
     }
@@ -509,7 +343,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val writer = mockWriter()
         Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
         val repo = mockEstimatesRepository(writer)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
         sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
         verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.COMPLETE)
     }
@@ -520,7 +354,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         val writer = mockWriter()
         Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(true)
         val repo = mockEstimatesRepository(writer)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         assertThatThrownBy {
             sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
@@ -536,7 +370,7 @@ class BurdenEstimateLogicTests : MontaguTests()
             on { getResponsibilityInfo(any(), any(), any()) } doReturn
                     ResponsibilityInfo(responsibilityId, disease, "open", setId)
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         assertThatThrownBy {
             sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
@@ -550,7 +384,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
         val repo = mockEstimatesRepository(writer)
         Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(fakeExpectations.expectedRowLookup())
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         assertThatThrownBy {
             sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
@@ -582,7 +416,7 @@ class BurdenEstimateLogicTests : MontaguTests()
         Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
         val repo = mockEstimatesRepository(writer)
         Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(rowPresenceLookup)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         assertThatThrownBy {
             sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
@@ -606,7 +440,7 @@ AGO, age 12, year 2005""")
                     UnknownObjectError(scenarioId, "responsibility")
             on { getEstimateWriter(defaultEstimateSet) } doReturn writer
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         Assertions.assertThatThrownBy {
             sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
@@ -626,7 +460,7 @@ AGO, age 12, year 2005""")
             on { getResponsibilityInfo(any(), any(), any()) } doReturn
                     ResponsibilityInfo(responsibilityId, disease, "open", setId)
         }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
 
         val result = sut.getEstimates(1, groupId, touchstoneVersionId, scenarioId, "test-outcome")
         assertThat(result.data).containsAllEntriesOf(fakeEstimates)
@@ -640,7 +474,7 @@ AGO, age 12, year 2005""")
             on { checkScenarioDescriptionExists("s1") } doThrow UnknownObjectError("TEST", "scenario-description")
         }
 
-        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), repo, mock())
+        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), repo, mock(), mock())
         assertThatThrownBy {
             sut.getBurdenEstimateSets("g1", "t1", "s1")
         }.isInstanceOf(UnknownObjectError::class.java)
@@ -653,7 +487,7 @@ AGO, age 12, year 2005""")
             on { checkScenarioDescriptionExists("s1") } doThrow UnknownObjectError("TEST", "scenario-description")
         }
 
-        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), repo, mock())
+        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), repo, mock(), mock())
         assertThatThrownBy {
             sut.getBurdenEstimateSet("g1", "t1", "s1", 1)
         }.isInstanceOf(UnknownObjectError::class.java)
@@ -670,7 +504,7 @@ AGO, age 12, year 2005""")
             on { getBurdenEstimateSets("g1", "t1", "s1") } doReturn fakeEstimateSets
         }
 
-        val sut = RepositoriesBurdenEstimateLogic(mock(), repo, mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mock(), repo, mock(), mock(), mock(), mock())
         val result = sut.getBurdenEstimateSets("g1", "t1", "s1")
         assertThat(result).hasSameElementsAs(fakeEstimateSets)
     }
@@ -697,7 +531,7 @@ AGO, age 12, year 2005""")
             on { touchstoneVersions } doReturn mockTouchstoneVersions
         }
 
-        val sut = RepositoriesBurdenEstimateLogic(groupRepo, mock(), mock(), scenarioRepo, touchstoneRepo)
+        val sut = RepositoriesBurdenEstimateLogic(groupRepo, mock(), mock(), scenarioRepo, touchstoneRepo, mock())
 
         sut.validateResponsibilityPath(path, statusList)
 
@@ -725,7 +559,7 @@ AGO, age 12, year 2005""")
             on { touchstoneVersions } doReturn mockTouchstoneVersions
         }
 
-        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), mock(), touchstoneRepo)
+        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), mock(), touchstoneRepo, mock())
 
         assertThatThrownBy {
             sut.validateResponsibilityPath(path, statusList)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
@@ -56,7 +56,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     @Test
     fun `creates burden estimate set for incomplete responsibility set`()
     {
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock(), mock())
         val result =
                 sut.createBurdenEstimateSet(groupId,
                         touchstoneVersionId,
@@ -70,7 +70,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     @Test
     fun `cannot create burden estimate set if responsibility set status is submitted`()
     {
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.SUBMITTED), mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.SUBMITTED), mock(), mock(), mock(), mock())
         assertThatThrownBy {
             sut.createBurdenEstimateSet(groupId,
                     touchstoneVersionId,
@@ -87,7 +87,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     @Test
     fun `cannot create burden estimate set if responsibility set status is approved`()
     {
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.APPROVED), mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.APPROVED), mock(), mock(), mock(), mock())
         assertThatThrownBy {
             sut.createBurdenEstimateSet(groupId,
                     touchstoneVersionId,
@@ -107,7 +107,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     {
         val properties = defaultProperties.copy(modelRunParameterSet = 111)
         val mockRepo = getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock(), mock())
         sut.createBurdenEstimateSet(groupId,
                 touchstoneVersionId,
                 scenarioId,
@@ -122,7 +122,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     fun `does not check model run parameter set exists if not provided`()
     {
         val mockRepo = getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, mockRepo, mock(), mock(), mock(), mock())
         sut.createBurdenEstimateSet(groupId,
                 touchstoneVersionId,
                 scenarioId,
@@ -135,7 +135,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     @Test
     fun `creates model run parameter set`()
     {
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock(), mock())
 
         val result = sut.addModelRunParameterSet(groupId, touchstoneVersionId, disease,
                 listOf(ModelRun("run1", mapOf())), "uploader", Instant.now())
@@ -145,7 +145,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
     @Test
     fun `cannot create model run parameter set if no model runs provided`()
     {
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepo, getBurdenRepo(ResponsibilitySetStatus.INCOMPLETE), mock(), mock(), mock(), mock())
 
         Assertions.assertThatThrownBy {
             sut.addModelRunParameterSet(groupId, touchstoneVersionId, disease,

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/PopulateBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/PopulateBurdenEstimateLogicTests.kt
@@ -112,15 +112,4 @@ class PopulateBurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
         sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
         verify(repo).getEstimateWriter(defaultEstimateSet)
     }
-
-    @Test
-    fun `notifies when a set has been populated`()
-    {
-        val repo = mockEstimatesRepository()
-        val mockNotifier = mock<Notifier>()
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mockNotifier)
-
-        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
-        verify(mockNotifier).notify("A burden estimate set has just been uploaded for $groupId")
-    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/PopulateBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/PopulateBurdenEstimateLogicTests.kt
@@ -1,0 +1,126 @@
+package org.vaccineimpact.api.tests.logic.BurdenEstimateLogic
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.vaccineimpact.api.app.errors.InconsistentDataError
+import org.vaccineimpact.api.app.errors.InvalidOperationError
+import org.vaccineimpact.api.app.logic.Notifier
+import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
+import org.vaccineimpact.api.models.BurdenEstimateSetStatus
+import org.vaccineimpact.api.models.BurdenEstimateWithRunId
+
+class PopulateBurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
+{
+
+    @Test
+    fun `can populate a set if status is partial`()
+    {
+        val writer = mockWriter()
+        val repo = mock<BurdenEstimateRepository> {
+            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
+                    .copy(status = BurdenEstimateSetStatus.PARTIAL)
+            on { getResponsibilityInfo(any(), any(), any()) } doReturn
+                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
+            on { getEstimateWriter(any()) } doReturn writer
+        }
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+        verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
+    }
+
+    @Test
+    fun `cannot populate a set if status is complete`()
+    {
+        val repo = mock<BurdenEstimateRepository> {
+            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
+                    .copy(status = BurdenEstimateSetStatus.COMPLETE)
+            on { getResponsibilityInfo(any(), any(), any()) } doReturn
+                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
+        }
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+        }.isInstanceOf(InvalidOperationError::class.java)
+                .hasMessageContaining("You must create a new set if you want to upload any new estimates.")
+
+    }
+
+    @Test
+    fun `cannot populate with data with multiple diseases`()
+    {
+        val data = sequenceOf(
+                BurdenEstimateWithRunId("yf", null, 2000, 1, "AFG", "Afghanistan", 1000F, mapOf(
+                        "deaths" to 10F,
+                        "cases" to 100F
+                )),
+                BurdenEstimateWithRunId("menA", null, 2001, 2, "AFG", "Afghanistan", 2000F, mapOf(
+                        "deaths" to 20F,
+                        "dalys" to 73.6F
+                )))
+        val estimateWriter = mockWriter()
+        val estimatesRepo = mockEstimatesRepository(estimateWriter)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), estimatesRepo, mockExpectationsRepository(), mock(), mock(), mock())
+        Assertions.assertThatThrownBy {
+            sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, data, null)
+        }.isInstanceOf(InconsistentDataError::class.java)
+                .hasMessageContaining("disease")
+    }
+
+    @Test
+    fun `can populate burden estimate set`()
+    {
+        val writer = mockWriter()
+        val repo = mockEstimatesRepository(writer)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+
+        verify(writer).addEstimatesToSet(eq(setId), any(), eq(disease))
+    }
+
+    @Test
+    fun `set is marked as partial after being populated`()
+    {
+        val repo = mockEstimatesRepository()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.PARTIAL)
+    }
+
+    @Test
+    fun `original filename is updated`()
+    {
+        val repo = mockEstimatesRepository()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, "file.csv")
+        verify(repo).updateBurdenEstimateSetFilename(setId, "file.csv")
+    }
+
+    @Test
+    fun `gets estimate writer from repo`()
+    {
+        val repo = mockEstimatesRepository()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+        verify(repo).getEstimateWriter(defaultEstimateSet)
+    }
+
+    @Test
+    fun `notifies when a set has been populated`()
+    {
+        val repo = mockEstimatesRepository()
+        val mockNotifier = mock<Notifier>()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mockNotifier)
+
+        sut.populateBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId, validData, null)
+        verify(mockNotifier).notify("A burden estimate set has just been uploaded for $groupId")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/SlackNotifierTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/SlackNotifierTests.kt
@@ -1,0 +1,38 @@
+package org.vaccineimpact.api.tests.logic
+
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Test
+import org.vaccineimpact.api.app.logic.HttpClient
+import org.vaccineimpact.api.app.logic.SlackNotifier
+import org.vaccineimpact.api.db.ConfigWrapper
+
+class SlackNotifierTests
+{
+    @Test
+    fun `posts correctly formatted Slack message`()
+    {
+        val mockHttpClient = mock<HttpClient>()
+        val mockConfig = mock<ConfigWrapper> {
+            on { get("slack.url") } doReturn "http://fake-url.com"
+        }
+        val sut = SlackNotifier(mockHttpClient, mockConfig)
+        sut.notify("some message")
+        verify(mockHttpClient).post("http://fake-url.com",
+                mapOf("Content-type" to "application/json"),
+                mapOf("text" to "some message"))
+    }
+
+    @Test
+    fun `errors are caught`()
+    {
+        val mockHttpClient = mock<HttpClient> {
+            on { post(any(), any(), any()) } doThrow Exception("whatever")
+        }
+        val mockConfig = mock<ConfigWrapper> {
+            on { get("slack.url") } doReturn "http://fake-url.com"
+        }
+        val sut = SlackNotifier(mockHttpClient, mockConfig)
+        sut.notify("some message")
+    }
+
+}

--- a/src/blackboxTests/src/test/resources/config.properties
+++ b/src/blackboxTests/src/test/resources/config.properties
@@ -14,3 +14,5 @@ testdb.template_name=${testdb_template_name}
 annex.template_name=${annex_template_name}
 
 app.url=${app_url}
+
+slack.url=${slack_url}

--- a/src/config/default.properties
+++ b/src/config/default.properties
@@ -43,3 +43,5 @@ email_port=587
 email_sender=montagu-notifications@imperial.ac.uk
 email_username=montagu
 email_password=none
+
+slack_url=


### PR DESCRIPTION
Hard (impossible?) to write automated integration tests for this but can be confirmed working by putting the correct config value in locally and running a Blackbox test that populates estimates  https://vimc.slack.com/archives/CMDP3V361/p1565889533000500

PR to inject the real webhook url during deployment: https://github.com/vimc/montagu/pull/161