### PR TITLE
VIMC-3098 countries should be presented alphabetically

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.api.app
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
-import org.vaccineimpact.api.models.RowLookup
+import org.vaccineimpact.api.models.expectations.RowLookup
 
 // This passes through the original sequence without affecting it, and the
 // sequence remains lazily evaluated, but as the elements "pass through"

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ExpectationsController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/ExpectationsController.kt
@@ -4,7 +4,7 @@ import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.repositories.ExpectationsRepository
 import org.vaccineimpact.api.app.repositories.Repositories
-import org.vaccineimpact.api.models.TouchstoneModelExpectations
+import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
 
 class ExpectationsController(context: ActionContext,
                         private val repo: ExpectationsRepository)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupResponsibilityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/GroupResponsibilityController.kt
@@ -13,6 +13,8 @@ import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
 import org.vaccineimpact.api.app.security.filterByPermission
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.ExpectedRow
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityDetails
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithExpectations
 import org.vaccineimpact.api.serialization.NullToEmptyStringSerializer

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -11,6 +11,10 @@ import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.app.validate
 import org.vaccineimpact.api.app.validateStochastic
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.AgeLookup
+import org.vaccineimpact.api.models.expectations.firstAgeWithMissingRows
+import org.vaccineimpact.api.models.expectations.firstMissingYear
+import org.vaccineimpact.api.models.expectations.hasMissingAges
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetStatus
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import java.time.Instant

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/ExpectationsLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/ExpectationsLogic.kt
@@ -6,7 +6,7 @@ import org.vaccineimpact.api.app.repositories.ExpectationsRepository
 import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.models.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
 import org.vaccineimpact.api.models.ModellingGroup
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityDetails
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithExpectations

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/BurdenEstimateRepository.kt
@@ -5,6 +5,7 @@ import org.vaccineimpact.api.app.models.BurdenEstimateOutcome
 import org.vaccineimpact.api.app.repositories.burdenestimates.BurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.RowLookup
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import java.time.Instant
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.api.app.repositories
 
-import org.vaccineimpact.api.models.ExpectationMapping
-import org.vaccineimpact.api.models.TouchstoneModelExpectations
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
 
 interface ExpectationsRepository : Repository
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -2,10 +2,8 @@ package org.vaccineimpact.api.app.repositories.jooq
 
 import org.jooq.DSLContext
 import org.jooq.JoinType
-import org.jooq.impl.DSL.inline
 import org.jooq.impl.DSL.sum
 import org.vaccineimpact.api.app.errors.BadRequest
-import org.vaccineimpact.api.app.errors.DatabaseContentsError
 import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.models.BurdenEstimateOutcome
@@ -21,7 +19,6 @@ import org.vaccineimpact.api.db.Tables.*
 import org.vaccineimpact.api.db.fromJoinPath
 import org.vaccineimpact.api.db.joinPath
 import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetStatus
 import org.vaccineimpact.api.serialization.FlexibleDataTable
 import java.beans.ConstructorProperties
 import java.sql.Timestamp
@@ -29,7 +26,7 @@ import java.time.Instant
 import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.fetchSequence
 import org.vaccineimpact.api.db.tables.records.BurdenEstimateRecord
-import java.lang.reflect.Type
+import org.vaccineimpact.api.models.expectations.RowLookup
 
 data class ResponsibilityInfo
 @ConstructorProperties("id", "disease", "status", "setId")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -15,6 +15,7 @@ import org.vaccineimpact.api.db.tables.BurdenEstimateExpectation
 import org.vaccineimpact.api.db.tables.BurdenEstimateOutcomeExpectation
 import org.vaccineimpact.api.db.tables.records.BurdenEstimateExpectationRecord
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.*
 
 data class ApplicableScenariosAndDisease(val scenarios: List<String>, val disease: String)
 
@@ -198,6 +199,7 @@ class JooqExpectationsRepository(dsl: DSLContext)
         return dsl.select(COUNTRY.ID, COUNTRY.NAME)
                 .fromJoinPath(Tables.countries, COUNTRY)
                 .where(Tables.countries.BURDEN_ESTIMATE_EXPECTATION.eq(basicData.id))
+                .orderBy(COUNTRY.ID)
                 .fetchInto(Country::class.java)
                 .toList()
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ExpectationsControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ExpectationsControllerTests.kt
@@ -7,10 +7,10 @@ import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.ExpectationsController
 import org.vaccineimpact.api.app.repositories.ExpectationsRepository
-import org.vaccineimpact.api.models.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CohortRestriction
 import org.vaccineimpact.api.models.Outcome
-import org.vaccineimpact.api.models.TouchstoneModelExpectations
-import org.vaccineimpact.api.models.OutcomeExpectations
+import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
+import org.vaccineimpact.api.models.expectations.OutcomeExpectations
 import org.vaccineimpact.api.test_helpers.MontaguTests
 
 
@@ -22,15 +22,15 @@ class ExpectationsControllerTests : MontaguTests()
 
         val expectations = listOf(
                 TouchstoneModelExpectations("t1-v1", "group1", "disease1",
-                       OutcomeExpectations(1, "description", 1980..2000, 0..80,
+                        OutcomeExpectations(1, "description", 1980..2000, 0..80,
                                 CohortRestriction(1900, 2000),
                                 listOf(Outcome("deaths", "All deaths"), Outcome("DALYs", "All DALYs"))),
-                                listOf("routine")),
+                        listOf("routine")),
                 TouchstoneModelExpectations("t2-v2", "group2", "disease2",
                         OutcomeExpectations(2, "description2", 1981..2001, 0..90,
                                 CohortRestriction(1890, 2000),
                                 listOf(Outcome("deaths", "All deaths"), Outcome("cases", "All cases"))),
-                                listOf("campaign", "routine")))
+                        listOf("campaign", "routine")))
 
         val mockRepo = mock<ExpectationsRepository> {
             on { this.getAllExpectations() } doReturn expectations

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/ResponsibilityControllerTests.kt
@@ -12,6 +12,9 @@ import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.repositories.inmemory.InMemoryDataSet
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
 import org.vaccineimpact.api.models.permissions.ReifiedPermission
 import org.vaccineimpact.api.models.responsibilities.Responsibility
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityDetails

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/extensions/ExpectationsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/extensions/ExpectationsTests.kt
@@ -2,9 +2,9 @@ package org.vaccineimpact.api.tests.extensions
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.models.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CohortRestriction
 import org.vaccineimpact.api.models.Country
-import org.vaccineimpact.api.models.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
 import org.vaccineimpact.api.models.Outcome
 import org.vaccineimpact.api.test_helpers.MontaguTests
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BaseBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BaseBurdenEstimateLogicTests.kt
@@ -10,6 +10,9 @@ import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
 import org.vaccineimpact.api.app.repositories.burdenestimates.BurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Instant
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/BurdenEstimateLogicTests.kt
@@ -396,8 +396,8 @@ class BurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
     @Test
     fun `missing rows message contains all country names and one example row`()
     {
-        val expectations = fakeExpectations.copy(years = 2000..2010, ages = 10..15, countries = listOf(Country("AFG", ""), Country("AGO", ""),
-                Country("NGA", "")))
+        val expectations = fakeExpectations.copy(years = 2000..2010, ages = 10..15, countries =
+        listOf(Country("AFG", ""), Country("AGO", ""), Country("NGA", "")))
 
         val rowPresenceLookup = expectations.expectedRowLookup()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ExpecationsLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ExpecationsLogicTests.kt
@@ -14,6 +14,9 @@ import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.repositories.inmemory.InMemoryDataSet
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityAndTouchstone
 import org.vaccineimpact.api.models.responsibilities.ResponsibilityDetails
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithExpectations

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
@@ -6,9 +6,9 @@ import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.validate
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
-import org.vaccineimpact.api.models.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CohortRestriction
 import org.vaccineimpact.api.models.Country
-import org.vaccineimpact.api.models.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
 import org.vaccineimpact.api.test_helpers.MontaguTests
 
 class ValidateBurdenEstimateSequenceTests : MontaguTests()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -10,6 +10,9 @@ import org.vaccineimpact.api.databaseTests.RepositoryTests
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
 import org.vaccineimpact.api.test_helpers.exampleExpectations
 import org.vaccineimpact.api.test_helpers.exampleOutcomeExpectations
 
@@ -76,16 +79,16 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
     fun `can pull country expectations`()
     {
         val responsibilityId = addResponsibilityAnd { db, _, responsibilityId ->
-            db.addCountries(listOf("ABC", "DEF", "GHI"))
+            db.addCountries(listOf("GHI", "ABC", "DEF"))
             db.addExpectations(
                     responsibilityId,
-                    countries = listOf("ABC", "DEF")
+                    countries = listOf("DEF", "ABC")
             )
             responsibilityId
         }
         withRepo { repo ->
             val result = repo.getExpectationsForResponsibility(responsibilityId).expectation
-            assertThat(result.countries).hasSameElementsAs(listOf(
+            assertThat(result.countries).containsExactlyElementsOf(listOf(
                     Country("ABC", "ABC-Name"),
                     Country("DEF", "DEF-Name")
             ))
@@ -278,9 +281,9 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
             val result = repo.getAllExpectations()
             assertThat(result).isEqualTo(listOf(
                     TouchstoneModelExpectations(touchstoneVersionId, groupId, "YF",
-                            exampleOutcomeExpectations(outcomes=listOf(deathsOutcome)), listOf(scenarioId)),
+                            exampleOutcomeExpectations(outcomes = listOf(deathsOutcome)), listOf(scenarioId)),
                     TouchstoneModelExpectations("touchstone2-2", otherGroupId, "HepB",
-                            exampleOutcomeExpectations(id=2, outcomes=listOf(casesOutcome, deathsOutcome)),
+                            exampleOutcomeExpectations(id = 2, outcomes = listOf(casesOutcome, deathsOutcome)),
                             listOf(otherScenarioId, "scenario3"))
             ))
         }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/burdenEstimateRepository/PopulateBurdenEstimateSetTests.kt
@@ -9,6 +9,8 @@ import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.direct.addBurdenEstimate
 import org.vaccineimpact.api.db.direct.addCountries
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
 import java.time.Instant
 
 class PopulateBurdenEstimateSetTests : BurdenEstimateRepositoryTests()

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/ExampleObjects.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/ExampleObjects.kt
@@ -1,6 +1,10 @@
 package org.vaccineimpact.api.test_helpers
 
 import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.expectations.CohortRestriction
+import org.vaccineimpact.api.models.expectations.CountryOutcomeExpectations
+import org.vaccineimpact.api.models.expectations.ExpectationMapping
+import org.vaccineimpact.api.models.expectations.OutcomeExpectations
 import org.vaccineimpact.api.models.responsibilities.*
 import org.vaccineimpact.api.security.InternalUser
 import org.vaccineimpact.api.security.UserProperties


### PR DESCRIPTION
The missing rows message when uploading an incomplete burden estimate set can currently look something like 

```
Missing rows for GTM, FJI, PNG, SLB, SLE, STP, MHL, CUB, SDN, SLV, GMB, FSM, CMR, GUY, AZE, GEO, TON, KEN, GNB, ARM, UZB, BTN, SEN, TGO, ERI, MAR, BDI, IRQ, MRT, BLZ, PHL, COD, COG, COM, BEN, ZMB, SOM, VUT, ALB, SWZ, ETH, NER, TZA, PAK, LAO, BFA, UKR, KGZ, GHA, DJI, CHN, CPV, PRK, MDA, MLI, KHM, MDG, IDN, TJK, VNM, PRY, RWA, LBR, BGD, BOL, PSE, LKA, ZWE, CAF, NGA, LSO, SYR, GIN, CIV, MMR, TCD, KIR, TKM, HTI, IND, YEM, AFG, MNG, NPL, TLS, MWI, BIH, SSD, AGO, NIC, TUN, UGA, WSM, XK, TUV, EGY, MOZ, HND
For example:
GTM, age 1, year 2031
```

It would be easier to parse if the countries were ordered alphabetically!

I also just moved all the many expectation related models into their own subdirectory so they'd be easier to find: https://github.com/vimc/montagu-webmodels/pull/87