### PR TITLE
VIMC-3097 Notify when all responsibilities (scenarios) have a complete estimate sets

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
@@ -1,23 +1,27 @@
 package org.vaccineimpact.api.app.controllers.BurdenEstimates
 
 import org.vaccineimpact.api.app.app_start.Controller
+import org.vaccineimpact.api.app.asResult
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.RepositoriesResponsibilitiesLogic
+import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.app.security.getAllowableTouchstoneStatusList
 import org.vaccineimpact.api.models.Result
-import org.vaccineimpact.api.app.asResult
 
 abstract class BaseBurdenEstimateController(context: ActionContext,
-                                            private val estimatesLogic: BurdenEstimateLogic) : Controller(context)
+                                            private val estimatesLogic: BurdenEstimateLogic,
+                                            private val responsibilitiesLogic: ResponsibilitiesLogic) : Controller(context)
 {
 
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            RepositoriesBurdenEstimateLogic(repos))
+            RepositoriesBurdenEstimateLogic(repos),
+            RepositoriesResponsibilitiesLogic(repos.modellingGroup, repos.scenario, repos.touchstone))
 
     protected fun closeEstimateSetAndReturnMissingRowError(setId: Int, groupId: String, touchstoneVersionId: String,
                                                            scenarioId: String): Result
@@ -37,7 +41,7 @@ abstract class BaseBurdenEstimateController(context: ActionContext,
     protected fun getValidResponsibilityPath(): ResponsibilityPath
     {
         val result = ResponsibilityPath(context)
-        estimatesLogic.validateResponsibilityPath(
+        responsibilitiesLogic.validateResponsibilityPath(
                 result,
                 context.getAllowableTouchstoneStatusList())
         return result

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -12,6 +12,8 @@ import org.vaccineimpact.api.app.errors.InvalidOperationError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.RepositoriesResponsibilitiesLogic
+import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
 import org.vaccineimpact.api.app.models.ChunkedFile
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.Repositories
@@ -28,21 +30,22 @@ import org.vaccineimpact.api.serialization.Serializer
 import java.io.File
 
 class BurdenEstimateUploadController(context: ActionContext,
-                                     private val repositories: Repositories,
                                      private val estimatesLogic: BurdenEstimateLogic,
+                                     private val responsibilitiesLogic: ResponsibilitiesLogic,
                                      private val estimateRepository: BurdenEstimateRepository,
                                      private val postDataHelper: PostDataHelper = PostDataHelper(),
                                      private val tokenHelper: WebTokenHelper = WebTokenHelper(KeyHelper.keyPair),
                                      private val chunkedFileCache: Cache<ChunkedFile> = ChunkedFileCache.instance,
                                      private val chunkedFileManager: ChunkedFileManager = ChunkedFileManager(),
                                      private val serializer: Serializer = MontaguSerializer.instance)
-    : BaseBurdenEstimateController(context, estimatesLogic)
+    : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic)
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
-            repos,
             RepositoriesBurdenEstimateLogic(repos),
+            RepositoriesResponsibilitiesLogic(repos.modellingGroup, repos.scenario, repos.touchstone),
             repos.burdenEstimates)
+
 
     fun getUploadToken(): String
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -4,6 +4,8 @@ import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.RepositoriesResponsibilitiesLogic
+import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.app.repositories.Repositories
 import org.vaccineimpact.api.models.*
@@ -13,13 +15,15 @@ import java.time.Instant
 open class BurdenEstimatesController(
         context: ActionContext,
         private val estimatesLogic: BurdenEstimateLogic,
-        private val estimateRepository: BurdenEstimateRepository
-) : BaseBurdenEstimateController(context, estimatesLogic)
+        private val estimateRepository: BurdenEstimateRepository,
+        private val responsibilitiesLogic: ResponsibilitiesLogic
+) : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic)
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
             RepositoriesBurdenEstimateLogic(repos),
-            repos.burdenEstimates)
+            repos.burdenEstimates,
+            RepositoriesResponsibilitiesLogic(repos.modellingGroup, repos.scenario, repos.touchstone))
 
     fun getBurdenEstimateSets(): List<BurdenEstimateSet>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -243,7 +243,7 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
                             it.currentEstimateSet?.status == BurdenEstimateSetStatus.COMPLETE
                 })
         {
-            notifier.notify("Group $groupId have uploaded complete estimate sets for all scenarios in $touchstoneVersionId")
+            notifier.notify("Group $groupId have uploaded complete estimate sets for all $disease scenarios in $touchstoneVersionId")
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/ResponsibilitiesLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/ResponsibilitiesLogic.kt
@@ -1,0 +1,39 @@
+package org.vaccineimpact.api.app.logic
+
+import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
+import org.vaccineimpact.api.app.errors.UnknownObjectError
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.ScenarioRepository
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.models.TouchstoneStatus
+import org.vaccineimpact.api.models.TouchstoneVersion
+
+interface ResponsibilitiesLogic
+{
+    fun validateResponsibilityPath(path: ResponsibilityPath, validTouchstoneStatusList: List<TouchstoneStatus>)
+}
+
+class RepositoriesResponsibilitiesLogic(
+        private val modellingGroupRepository: ModellingGroupRepository,
+        private val scenarioRepository: ScenarioRepository,
+        private val touchstoneRepository: TouchstoneRepository
+) : ResponsibilitiesLogic
+{
+
+    override fun validateResponsibilityPath(
+            path: ResponsibilityPath,
+            validTouchstoneStatusList: List<TouchstoneStatus>
+    )
+    {
+        //Check that modelling group exists
+        modellingGroupRepository.getModellingGroup(path.groupId)
+        //Check touchstone and is accessible for this user
+        val touchstoneVersion = touchstoneRepository.touchstoneVersions.get(path.touchstoneVersionId)
+        if (!validTouchstoneStatusList.contains(touchstoneVersion.status))
+        {
+            throw UnknownObjectError(touchstoneVersion.id, TouchstoneVersion::class)
+        }
+
+        scenarioRepository.checkScenarioDescriptionExists(path.scenarioId)
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.api.tests.controllers.BurdenEstimates
 import com.nhaarman.mockito_kotlin.*
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
 import org.vaccineimpact.api.app.repositories.*
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.test_helpers.MontaguTests
@@ -48,9 +49,9 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
         }
     }
 
-    protected fun verifyValidResponsibilityPathChecks(burdenEstimatesLogic: BurdenEstimateLogic, context: ActionContext)
+    protected fun verifyValidResponsibilityPathChecks(responsibilitiesLogic: ResponsibilitiesLogic, context: ActionContext)
     {
-        verify(burdenEstimatesLogic).validateResponsibilityPath(any(), any())
+        verify(responsibilitiesLogic).validateResponsibilityPath(any(), any())
         verify(context).hasPermission(any())
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimatesController
 import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
+import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
 import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.DataTableDeserializer
@@ -45,9 +46,10 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":touchstone-version-id") } doReturn touchstoneVersionId
             on { params(":scenario-id") } doReturn scenarioId
         }
-        assertThat(BurdenEstimatesController(context, logic, repo).getBurdenEstimateSets())
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        assertThat(BurdenEstimatesController(context, logic, repo, mockResponsibilitiesLogic).getBurdenEstimateSets())
                 .hasSameElementsAs(data.toList())
-        verifyValidResponsibilityPathChecks(logic, context)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, context)
     }
 
 
@@ -73,9 +75,10 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":scenario-id") } doReturn scenarioId
             on { params(":set-id") } doReturn "1"
         }
-        assertThat(BurdenEstimatesController(context, logic, repo).getBurdenEstimateSet())
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        assertThat(BurdenEstimatesController(context, logic, repo, mockResponsibilitiesLogic).getBurdenEstimateSet())
                 .isEqualTo(data)
-        verifyValidResponsibilityPathChecks(logic, context)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, context)
     }
 
     @Test
@@ -98,8 +101,8 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         }
 
         val logic = mockLogic()
-
-        val url = BurdenEstimatesController(mockContext, logic, repo).createBurdenEstimateSet()
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        val url = BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic).createBurdenEstimateSet()
         val after = Instant.now()
 
         assertThat(url).endsWith("/modelling-groups/$groupId/responsibilities/$touchstoneVersionId/$scenarioId/estimate-sets/1/")
@@ -110,7 +113,7 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 eq(properties),
                 eq("username"),
                 timestamp = check { it > before && it < after })
-        verifyValidResponsibilityPathChecks(logic, mockContext)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 
     @Test
@@ -124,9 +127,10 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":touchstone-version-id") } doReturn touchstoneVersionId
             on { params(":scenario-id") } doReturn scenarioId
         }
-        BurdenEstimatesController(mockContext, logic, repo).closeBurdenEstimateSet()
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic).closeBurdenEstimateSet()
         verify(logic).closeBurdenEstimateSet(1, groupId, touchstoneVersionId, scenarioId)
-        verifyValidResponsibilityPathChecks(logic, mockContext)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 
     @Test
@@ -142,10 +146,11 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":touchstone-version-id") } doReturn touchstoneVersionId
             on { params(":scenario-id") } doReturn scenarioId
         }
-        val result = BurdenEstimatesController(mockContext, logic, repo)
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        val result = BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic)
                 .closeBurdenEstimateSet()
         assertThat(result.status).isEqualTo(ResultStatus.FAILURE)
-        verifyValidResponsibilityPathChecks(logic, mockContext)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 
     @Test
@@ -184,13 +189,14 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         val repo = mock<BurdenEstimateRepository> {
             on { touchstoneRepository } doReturn touchstones
         }
-        val sut = BurdenEstimatesController(context, logic, repo)
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        val sut = BurdenEstimatesController(context, logic, repo, mockResponsibilitiesLogic)
         sut.getEstimatesForOutcome()
 
         verify(logic).getEstimates(eq(1), eq(groupId), eq(touchstoneVersionId), eq(scenarioId),
                 eq("test-outcome"),
                 eq(BurdenEstimateGrouping.AGE))
-        verifyValidResponsibilityPathChecks(logic, context)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, context)
     }
 
     @Test
@@ -209,13 +215,14 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
         val repo = mock<BurdenEstimateRepository> {
             on { touchstoneRepository } doReturn touchstones
         }
-        val sut = BurdenEstimatesController(context, logic, repo)
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        val sut = BurdenEstimatesController(context, logic, repo, mockResponsibilitiesLogic)
         sut.getEstimatesForOutcome()
 
         verify(logic).getEstimates(eq(1), eq(groupId), eq(touchstoneVersionId), eq(scenarioId),
                 eq("deaths"),
                 eq(BurdenEstimateGrouping.YEAR))
-        verifyValidResponsibilityPathChecks(logic, context)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, context)
     }
 
     @Test
@@ -229,9 +236,10 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":touchstone-version-id") } doReturn touchstoneVersionId
             on { params(":scenario-id") } doReturn scenarioId
         }
-        BurdenEstimatesController(mockContext, logic, repo).getBurdenEstimateSetData()
+        val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
+        BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic).getBurdenEstimateSetData()
         verify(logic).getBurdenEstimateData(1, groupId, touchstoneVersionId, scenarioId)
-        verifyValidResponsibilityPathChecks(logic, mockContext)
+        verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -1,12 +1,11 @@
 package org.vaccineimpact.api.tests.controllers.BurdenEstimates
 
-import org.junit.Test
-import org.vaccineimpact.api.app.context.ActionContext
-import java.io.File
-import org.assertj.core.api.Assertions.*
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
 import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
+import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.errors.InvalidOperationError
@@ -17,9 +16,8 @@ import org.vaccineimpact.api.models.BurdenEstimateWithRunId
 import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.ResultStatus
 import org.vaccineimpact.api.security.KeyHelper
-import org.vaccineimpact.api.security.TokenValidationException
 import org.vaccineimpact.api.security.WebTokenHelper
-import java.lang.NullPointerException
+import java.io.File
 
 class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
 {
@@ -38,7 +36,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true, fileName = "file.csv")
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
-        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
@@ -70,7 +68,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
-        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
         assertThat(result.status).isEqualTo(ResultStatus.FAILURE)
@@ -99,7 +97,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
-        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
 
         assertThatThrownBy {
             sut.populateBurdenEstimateSetFromLocalFile()
@@ -122,7 +120,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
-        val sut = BurdenEstimateUploadController(mockContext, mock(), logic, repo, mock(), mockTokenHelper, cache)
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
@@ -1,0 +1,234 @@
+package org.vaccineimpact.api.tests.logic.BurdenEstimateLogic
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.internal.verification.Times
+import org.vaccineimpact.api.app.errors.InvalidOperationError
+import org.vaccineimpact.api.app.errors.MissingRowsError
+import org.vaccineimpact.api.app.errors.UnknownObjectError
+import org.vaccineimpact.api.app.logic.Notifier
+import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
+import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.ResponsibilitiesRepository
+import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
+import org.vaccineimpact.api.models.BurdenEstimateSetStatus
+import org.vaccineimpact.api.models.Country
+import org.vaccineimpact.api.models.Scenario
+import org.vaccineimpact.api.models.responsibilities.Responsibility
+import org.vaccineimpact.api.models.responsibilities.ResponsibilitySet
+import org.vaccineimpact.api.models.responsibilities.ResponsibilityStatus
+
+class CloseBurdenEstimateSetLogicTests : BaseBurdenEstimateLogicTests()
+{
+    private fun getResponsibilitiesRepository(): ResponsibilitiesRepository
+    {
+        return mock {
+            on {
+                getResponsibilitiesForGroup(eq(groupId), eq(touchstoneVersionId),
+                        argThat { this.disease == disease })
+            } doReturn ResponsibilitySet(touchstoneVersionId, groupId, null, listOf())
+        }
+    }
+
+    @Test
+    fun `modelling-group id is checked before closing burden estimate set`()
+    {
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+        val repo = mockEstimatesRepository(writer)
+        val groupRepo = mockGroupRepository()
+        val sut = RepositoriesBurdenEstimateLogic(groupRepo, repo, mockExpectationsRepository(), mock(),
+                getResponsibilitiesRepository(), mock())
+        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        verify(groupRepo).getModellingGroup(groupId)
+    }
+
+    @Test
+    fun `can close non-empty burden estimate set`()
+    {
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+        val repo = mockEstimatesRepository(writer)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(),
+                getResponsibilitiesRepository(), mock())
+        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.COMPLETE)
+    }
+
+    @Test
+    fun `cannot close empty burden estimate set`()
+    {
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(true)
+        val repo = mockEstimatesRepository(writer)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(),
+                getResponsibilitiesRepository(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(InvalidOperationError::class.java)
+    }
+
+    @Test
+    fun `cannot close burden estimate set which is already complete`()
+    {
+        val repo = mock<BurdenEstimateRepository> {
+            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
+                    .copy(status = BurdenEstimateSetStatus.COMPLETE)
+            on { getResponsibilityInfo(any(), any(), any()) } doReturn
+                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
+        }
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(InvalidOperationError::class.java).hasMessageContaining("This burden estimate set has already been closed")
+    }
+
+    @Test
+    fun `closing a burden estimate set with missing rows marks it as invalid`()
+    {
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+        val repo = mockEstimatesRepository(writer)
+        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(fakeExpectations.expectedRowLookup())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(MissingRowsError::class.java)
+        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.INVALID)
+    }
+
+    @Test
+    fun `missing rows message contains all country names and one example row`()
+    {
+        val expectations = fakeExpectations.copy(years = 2000..2010, ages = 10..15, countries = listOf(Country("AFG", ""), Country("AGO", ""),
+                Country("NGA", "")))
+
+        val rowPresenceLookup = expectations.expectedRowLookup()
+
+        for (year in 2000..2010)
+        {
+            for (age in 10..15)
+            {
+                rowPresenceLookup["AFG"]!![age.toShort()]!![year.toShort()] = true
+
+                if (year < 2005 || age < 12)
+                {
+                    rowPresenceLookup["AGO"]!![age.toShort()]!![year.toShort()] = true
+                }
+            }
+        }
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+        val repo = mockEstimatesRepository(writer)
+        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(rowPresenceLookup)
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(MissingRowsError::class.java)
+                .hasMessage("""the following problems occurred:
+Missing rows for AGO, NGA
+For example:
+AGO, age 12, year 2005""")
+    }
+
+    @Test
+    fun `cannot close burden estimate set when responsibility lookup throws an error`()
+    {
+        val writer = mockWriter()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+
+        val repo = mock<BurdenEstimateRepository> {
+            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
+                    .copy(status = BurdenEstimateSetStatus.PARTIAL)
+            on { getResponsibilityInfo(groupId, touchstoneVersionId, scenarioId) } doThrow
+                    UnknownObjectError(scenarioId, "responsibility")
+            on { getEstimateWriter(defaultEstimateSet) } doReturn writer
+        }
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining(scenarioId)
+    }
+
+    @Test
+    fun `notifies when a set is marked as complete`()
+    {
+        val repo = mockEstimatesRepository()
+        val mockNotifier = mock<Notifier>()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(),
+                mock(), getResponsibilitiesRepository(), mockNotifier)
+
+        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        verify(mockNotifier).notify("A complete burden estimate set has just been uploaded for $groupId - $disease - $scenarioId")
+    }
+
+    @Test
+    fun `notifies when a set is closed but has missing rows`()
+    {
+        val writer = mockWriter()
+        val mockNotifier = mock<Notifier>()
+        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
+        val repo = mockEstimatesRepository(writer)
+        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(fakeExpectations.expectedRowLookup())
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mockNotifier)
+
+        Assertions.assertThatThrownBy {
+            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        }.isInstanceOf(MissingRowsError::class.java)
+        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.INVALID)
+        verify(mockNotifier).notify("A burden estimate set with missing rows has just been uploaded for $groupId - $disease - $scenarioId")
+    }
+
+    @Test
+    fun `notifies when all responsibilities have been fulfilled`()
+    {
+        val responsibilitiesRepository = mock<ResponsibilitiesRepository> {
+            on {
+                getResponsibilitiesForGroup(eq(groupId), eq(touchstoneVersionId),
+                        argThat { this.disease == disease })
+            } doReturn ResponsibilitySet(touchstoneVersionId, groupId, null, listOf(responsibilityWithCompleteEstimateSet))
+        }
+
+        val repo = mockEstimatesRepository()
+        val mockNotifier = mock<Notifier>()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(),
+                mock(), responsibilitiesRepository, mockNotifier)
+
+        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        verify(mockNotifier).notify("Group $groupId have uploaded complete estimate sets for all scenarios in $touchstoneVersionId")
+    }
+
+    @Test
+    fun `does not notify all responsibilities have been fulfilled if some have an incomplete estimate set`()
+    {
+        val responsibilitiesRepository = mock<ResponsibilitiesRepository> {
+            on {
+                getResponsibilitiesForGroup(eq(groupId), eq(touchstoneVersionId),
+                        argThat { this.disease == disease })
+            } doReturn ResponsibilitySet(touchstoneVersionId, groupId, null,
+                    listOf(responsibilityWithCompleteEstimateSet, responsibilityWithoutCompleteEstimateSet))
+        }
+
+        val repo = mockEstimatesRepository()
+        val mockNotifier = mock<Notifier>()
+        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(),
+                mock(), responsibilitiesRepository, mockNotifier)
+
+        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
+        verify(mockNotifier, Times(0)).notify("Group $groupId have uploaded complete estimate sets for all scenarios in $touchstoneVersionId")
+    }
+
+    private val responsibilityWithCompleteEstimateSet = Responsibility(Scenario("s1", "desc", "d1", listOf()),
+            ResponsibilityStatus.VALID, listOf(),
+            defaultEstimateSet.copy(status = BurdenEstimateSetStatus.COMPLETE))
+    private val responsibilityWithoutCompleteEstimateSet = responsibilityWithCompleteEstimateSet
+            .copy(currentEstimateSet = defaultEstimateSet)
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
@@ -202,7 +202,7 @@ AGO, age 12, year 2005""")
                 mock(), responsibilitiesRepository, mockNotifier)
 
         sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        verify(mockNotifier).notify("Group $groupId have uploaded complete estimate sets for all scenarios in $touchstoneVersionId")
+        verify(mockNotifier).notify("Group $groupId have uploaded complete estimate sets for all $disease scenarios in $touchstoneVersionId")
     }
 
     @Test
@@ -222,7 +222,8 @@ AGO, age 12, year 2005""")
                 mock(), responsibilitiesRepository, mockNotifier)
 
         sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        verify(mockNotifier, Times(0)).notify("Group $groupId have uploaded complete estimate sets for all scenarios in $touchstoneVersionId")
+        verify(mockNotifier).notify("A complete burden estimate set has just been uploaded for $groupId - $disease - $scenarioId")
+        verify(mockNotifier, Times(1))
     }
 
     private val responsibilityWithCompleteEstimateSet = Responsibility(Scenario("s1", "desc", "d1", listOf()),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CloseBurdenEstimateSetLogicTests.kt
@@ -223,7 +223,7 @@ AGO, age 12, year 2005""")
 
         sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
         verify(mockNotifier).notify("A complete burden estimate set has just been uploaded for $groupId - $disease - $scenarioId")
-        verify(mockNotifier, Times(1))
+        verify(mockNotifier, Times(1)).notify(any())
     }
 
     private val responsibilityWithCompleteEstimateSet = Responsibility(Scenario("s1", "desc", "d1", listOf()),

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/GetBurdenEstimatesLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/GetBurdenEstimatesLogicTests.kt
@@ -6,25 +6,18 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.mockito.Mockito
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
-import org.vaccineimpact.api.app.errors.InconsistentDataError
-import org.vaccineimpact.api.app.errors.InvalidOperationError
-import org.vaccineimpact.api.app.errors.MissingRowsError
 import org.vaccineimpact.api.app.errors.UnknownObjectError
-import org.vaccineimpact.api.app.logic.Notifier
 import org.vaccineimpact.api.app.logic.RepositoriesBurdenEstimateLogic
 import org.vaccineimpact.api.app.models.BurdenEstimateOutcome
 import org.vaccineimpact.api.app.repositories.*
-import org.vaccineimpact.api.app.repositories.burdenestimates.BurdenEstimateWriter
 import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import java.time.Instant
 
-class BurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
+class GetBurdenEstimatesLogicTests : BaseBurdenEstimateLogicTests()
 {
 
     @Test
@@ -327,128 +320,6 @@ class BurdenEstimateLogicTests : BaseBurdenEstimateLogicTests()
     }
 
     @Test
-    fun `modelling-group id is checked before closing burden estimate set`()
-    {
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-        val repo = mockEstimatesRepository(writer)
-        val groupRepo = mockGroupRepository()
-        val sut = RepositoriesBurdenEstimateLogic(groupRepo, repo, mockExpectationsRepository(), mock(), mock(), mock())
-        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        verify(groupRepo).getModellingGroup(groupId)
-    }
-
-    @Test
-    fun `can close non-empty burden estimate set`()
-    {
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-        val repo = mockEstimatesRepository(writer)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.COMPLETE)
-    }
-
-    @Test
-    fun `cannot close empty burden estimate set`()
-    {
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(true)
-        val repo = mockEstimatesRepository(writer)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-
-        assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(InvalidOperationError::class.java)
-    }
-
-    @Test
-    fun `cannot close burden estimate set which is already complete`()
-    {
-        val repo = mock<BurdenEstimateRepository> {
-            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
-                    .copy(status = BurdenEstimateSetStatus.COMPLETE)
-            on { getResponsibilityInfo(any(), any(), any()) } doReturn
-                    ResponsibilityInfo(responsibilityId, disease, "open", setId)
-        }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-
-        assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(InvalidOperationError::class.java).hasMessageContaining("This burden estimate set has already been closed")
-    }
-
-    @Test
-    fun `closing a burden estimate set with missing rows marks it as invalid`()
-    {
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-        val repo = mockEstimatesRepository(writer)
-        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(fakeExpectations.expectedRowLookup())
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-
-        assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(MissingRowsError::class.java)
-        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.INVALID)
-    }
-
-    @Test
-    fun `missing rows message contains all country names and one example row`()
-    {
-        val expectations = fakeExpectations.copy(years = 2000..2010, ages = 10..15, countries = listOf(Country("AFG", ""), Country("AGO", ""),
-                Country("NGA", "")))
-
-        val rowPresenceLookup = expectations.expectedRowLookup()
-
-        for (year in 2000..2010)
-        {
-            for (age in 10..15)
-            {
-                rowPresenceLookup["AFG"]!![age.toShort()]!![year.toShort()] = true
-
-                if (year < 2005 || age < 12)
-                {
-                    rowPresenceLookup["AGO"]!![age.toShort()]!![year.toShort()] = true
-                }
-            }
-        }
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-        val repo = mockEstimatesRepository(writer)
-        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(rowPresenceLookup)
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-
-        assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(MissingRowsError::class.java)
-                .hasMessage("""the following problems occurred:
-Missing rows for AGO, NGA
-For example:
-AGO, age 12, year 2005""")
-    }
-
-    @Test
-    fun `cannot close burden estimate set when responsibility lookup throws an error`()
-    {
-        val writer = mockWriter()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-
-        val repo = mock<BurdenEstimateRepository> {
-            on { getBurdenEstimateSetForResponsibility(any(), any()) } doReturn defaultEstimateSet
-                    .copy(status = BurdenEstimateSetStatus.PARTIAL)
-            on { getResponsibilityInfo(groupId, touchstoneVersionId, scenarioId) } doThrow
-                    UnknownObjectError(scenarioId, "responsibility")
-            on { getEstimateWriter(defaultEstimateSet) } doReturn writer
-        }
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mock())
-
-        Assertions.assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining(scenarioId)
-    }
-
-    @Test
     fun `can get estimated deaths for responsibility`()
     {
         val fakeEstimates: Map<Short, List<BurdenEstimateDataPoint>> =
@@ -509,91 +380,4 @@ AGO, age 12, year 2005""")
         val result = sut.getBurdenEstimateSets("g1", "t1", "s1")
         assertThat(result).hasSameElementsAs(fakeEstimateSets)
     }
-
-    @Test
-    fun `can validate Responsibility Path`()
-    {
-        val path = ResponsibilityPath(groupId, touchstoneVersionId, scenarioId)
-
-        val statusList = mutableListOf(TouchstoneStatus.OPEN, TouchstoneStatus.FINISHED)
-
-        val groupRepo = mock<ModellingGroupRepository>()
-
-        val touchstoneVersion = TouchstoneVersion(touchstoneVersionId, "touchstone", 1,
-                "description", TouchstoneStatus.OPEN)
-
-        val mockTouchstoneVersions = mock<SimpleDataSet<TouchstoneVersion, String>> {
-            on { get(touchstoneVersionId) } doReturn touchstoneVersion
-        }
-
-        val scenarioRepo = mock<ScenarioRepository>()
-
-        val touchstoneRepo = mock<TouchstoneRepository> {
-            on { touchstoneVersions } doReturn mockTouchstoneVersions
-        }
-
-        val sut = RepositoriesBurdenEstimateLogic(groupRepo, mock(), mock(), scenarioRepo, touchstoneRepo, mock())
-
-        sut.validateResponsibilityPath(path, statusList)
-
-        verify(groupRepo).getModellingGroup(groupId)
-        verify(touchstoneRepo).touchstoneVersions
-        verify(mockTouchstoneVersions).get(touchstoneVersionId)
-        verify(scenarioRepo).checkScenarioDescriptionExists(scenarioId)
-    }
-
-    @Test
-    fun `throws UnknownObjectError when validating Responsibility Path if touchstone status is not in allowable list`()
-    {
-        val path = ResponsibilityPath(groupId, touchstoneVersionId, scenarioId)
-
-        val statusList = mutableListOf(TouchstoneStatus.OPEN, TouchstoneStatus.FINISHED)
-
-        val touchstoneVersion = TouchstoneVersion(touchstoneVersionId, "touchstone", 1,
-                "description", TouchstoneStatus.IN_PREPARATION)
-
-        val mockTouchstoneVersions = mock<SimpleDataSet<TouchstoneVersion, String>> {
-            on { get(touchstoneVersionId) } doReturn touchstoneVersion
-        }
-
-        val touchstoneRepo = mock<TouchstoneRepository> {
-            on { touchstoneVersions } doReturn mockTouchstoneVersions
-        }
-
-        val sut = RepositoriesBurdenEstimateLogic(mock(), mock(), mock(), mock(), touchstoneRepo, mock())
-
-        assertThatThrownBy {
-            sut.validateResponsibilityPath(path, statusList)
-        }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining("Unknown touchstone-version with id 'touchstone-1'")
-
-    }
-
-    @Test
-    fun `notifies when a set is marked as complete`()
-    {
-        val repo = mockEstimatesRepository()
-        val mockNotifier = mock<Notifier>()
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mockNotifier)
-
-        sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        verify(mockNotifier).notify("A complete burden estimate set has just been uploaded for $groupId - $disease - $scenarioId")
-    }
-
-    @Test
-    fun `notifies when a set is closed but has missing rows`()
-    {
-        val writer = mockWriter()
-        val mockNotifier = mock<Notifier>()
-        Mockito.`when`(writer.isSetEmpty(defaultEstimateSet.id)).doReturn(false)
-        val repo = mockEstimatesRepository(writer)
-        Mockito.`when`(repo.validateEstimates(any(), any())).doReturn(fakeExpectations.expectedRowLookup())
-        val sut = RepositoriesBurdenEstimateLogic(mockGroupRepository(), repo, mockExpectationsRepository(), mock(), mock(), mockNotifier)
-
-        assertThatThrownBy {
-            sut.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-        }.isInstanceOf(MissingRowsError::class.java)
-        verify(repo).changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.INVALID)
-        verify(mockNotifier).notify("A burden estimate set with missing rows has just been uploaded for $groupId - $disease - $scenarioId")
-    }
-
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ResponsibilitiesLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ResponsibilitiesLogicTests.kt
@@ -1,0 +1,83 @@
+package org.vaccineimpact.api.tests.logic
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
+import org.vaccineimpact.api.app.errors.UnknownObjectError
+import org.vaccineimpact.api.app.logic.RepositoriesResponsibilitiesLogic
+import org.vaccineimpact.api.app.repositories.ModellingGroupRepository
+import org.vaccineimpact.api.app.repositories.ScenarioRepository
+import org.vaccineimpact.api.app.repositories.SimpleDataSet
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.models.TouchstoneStatus
+import org.vaccineimpact.api.models.TouchstoneVersion
+import org.vaccineimpact.api.test_helpers.MontaguTests
+
+class ResponsibilitiesLogicTests : MontaguTests()
+{
+    private val groupId = "group-1"
+    private val touchstoneVersionId = "touchstone-1"
+    private val scenarioId = "scenario-1"
+
+    @Test
+    fun `can validate Responsibility Path`()
+    {
+        val path = ResponsibilityPath(groupId, touchstoneVersionId, scenarioId)
+
+        val statusList = mutableListOf(TouchstoneStatus.OPEN, TouchstoneStatus.FINISHED)
+
+        val groupRepo = mock<ModellingGroupRepository>()
+
+        val touchstoneVersion = TouchstoneVersion(touchstoneVersionId, "touchstone", 1,
+                "description", TouchstoneStatus.OPEN)
+
+        val mockTouchstoneVersions = mock<SimpleDataSet<TouchstoneVersion, String>> {
+            on { get(touchstoneVersionId) } doReturn touchstoneVersion
+        }
+
+        val scenarioRepo = mock<ScenarioRepository>()
+
+        val touchstoneRepo = mock<TouchstoneRepository> {
+            on { touchstoneVersions } doReturn mockTouchstoneVersions
+        }
+
+        val sut = RepositoriesResponsibilitiesLogic(groupRepo, scenarioRepo, touchstoneRepo)
+
+        sut.validateResponsibilityPath(path, statusList)
+
+        verify(groupRepo).getModellingGroup(groupId)
+        verify(touchstoneRepo).touchstoneVersions
+        verify(mockTouchstoneVersions).get(touchstoneVersionId)
+        verify(scenarioRepo).checkScenarioDescriptionExists(scenarioId)
+    }
+
+    @Test
+    fun `throws UnknownObjectError when validating Responsibility Path if touchstone status is not in allowable list`()
+    {
+        val path = ResponsibilityPath(groupId, touchstoneVersionId, scenarioId)
+
+        val statusList = mutableListOf(TouchstoneStatus.OPEN, TouchstoneStatus.FINISHED)
+
+        val touchstoneVersion = TouchstoneVersion(touchstoneVersionId, "touchstone", 1,
+                "description", TouchstoneStatus.IN_PREPARATION)
+
+        val mockTouchstoneVersions = mock<SimpleDataSet<TouchstoneVersion, String>> {
+            on { get(touchstoneVersionId) } doReturn touchstoneVersion
+        }
+
+        val touchstoneRepo = mock<TouchstoneRepository> {
+            on { touchstoneVersions } doReturn mockTouchstoneVersions
+        }
+
+        val sut = RepositoriesResponsibilitiesLogic(mock(), mock(), touchstoneRepo)
+
+        Assertions.assertThatThrownBy {
+            sut.validateResponsibilityPath(path, statusList)
+        }.isInstanceOf(UnknownObjectError::class.java).hasMessageContaining("Unknown touchstone-version with id 'touchstone-1'")
+
+    }
+
+}


### PR DESCRIPTION
The actual additional logic here is small but I refactored the tests some more and also noticed a method in `BurdenEstimateLogic` which should really be in `ResponsibilitiesLogic`. Since the former has gotten quite big and unwieldy I introduced the latter, hence this PR ended up being a bit big, sorry.