### PR TITLE
vimc-3289 upload race condition bug

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
@@ -34,10 +34,6 @@ class ChunkedFileCache(private val flushInterval: Long = TimeUnit.HOURS.toMillis
         {
             memoryCache[item.uniqueIdentifier] = MutablePair(item, System.currentTimeMillis())
         }
-        else
-        {
-            memoryCache[item.uniqueIdentifier]!!.left.uploadedChunks.putAll(item.uploadedChunks)
-        }
     }
 
     override fun remove(uniqueIdentifier: String)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.app.controllers.BurdenEstimates
 
+import org.slf4j.LoggerFactory
 import org.vaccineimpact.api.app.Cache
 import org.vaccineimpact.api.app.ChunkedFileCache
 import org.vaccineimpact.api.app.ChunkedFileManager
@@ -46,7 +47,7 @@ class BurdenEstimateUploadController(context: ActionContext,
             RepositoriesResponsibilitiesLogic(repos.modellingGroup, repos.scenario, repos.touchstone),
             repos.burdenEstimates)
 
-
+    private val logger = LoggerFactory.getLogger(BurdenEstimateUploadController::class.java)
     fun getUploadToken(): String
     {
         val path = getValidResponsibilityPath()
@@ -77,6 +78,10 @@ class BurdenEstimateUploadController(context: ActionContext,
                 ?: throw BadRequest("Missing required query parameter: chunkNumber")
 
         val metadata = getFileMetadata()
+
+        val alreadyUploadedKeys = metadata.uploadedChunks.keys().toList().joinToString(",")
+        logger.info("Uploading chunk: $chunkNumber")
+        logger.info("These chunks have already been uploaded: $alreadyUploadedKeys")
 
         // Get file from context (supports multi-part or octet stream)
         val source = RequestDataSource.fromContentType(context)
@@ -130,6 +135,8 @@ class BurdenEstimateUploadController(context: ActionContext,
         }
         else
         {
+            val alreadyUploadedKeys = file.uploadedChunks.keys().toList().joinToString(",")
+            logger.info("These chunks have been uploaded: $alreadyUploadedKeys")
             throw InvalidOperationError("This file has not been fully uploaded")
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -215,7 +215,7 @@ class BurdenEstimateUploadController(context: ActionContext,
         else
         {
             chunkedFileCache.put(providedMetadata)
-            providedMetadata
+            chunkedFileCache[uniqueIdentifier]!!
         }
     }
 


### PR DESCRIPTION
I identified the race condition as happening at the start of file uploads. Once the cache entry for a particular file exists, recording new chunks is thread safe. But *creating* the cache entry in the first place is not thread safe, and the first 3 simultaneous chunk uploads may overwrite one another.

This PR makes the race condiiton tighter. A full solution would be to have an initial endpoint that just sets up the cache entry, before any chunks are posted.