### PR TITLE
vimc-3567 bug with column ordering in some burden estimate downloads

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -152,6 +152,7 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
         }
 
         val expectedOutcomes = burdenEstimateRepository.getExpectedOutcomesForBurdenEstimateSet(setId)
+                .sortedBy { it.first } // sort by id
         val disease = scenarioRepository.getScenarioForTouchstone(touchstoneVersionId, scenarioId).disease
 
         val rows = burdenEstimateRepository.getBurdenEstimateOutcomesSequence(setId, expectedOutcomes, disease)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -232,8 +232,10 @@ class JooqBurdenEstimateRepository(
                 .where(BURDEN_OUTCOME.CODE.eq("cohort_size"))
                 .fetchAnyInto(Short::class.java)
 
+        val outcomesIncludingCohort = outcomes +  Pair(cohortSize, "cohort_size")
+
         return countryLookup.keys.asSequence().map { k ->
-            val cursor = dsl.fetchLazy(getBurdenEstimateQueryForCountry(burdenEstimateSetId, outcomes, cohortSize, k))
+            val cursor = dsl.fetchLazy(getBurdenEstimateQueryForCountry(burdenEstimateSetId, outcomesIncludingCohort, k))
             generateSequence {
                 cursor.fetchNext()?.map { record ->
                     val country = countryLookup.getValue(record.get("country", Short::class.java))
@@ -255,16 +257,15 @@ class JooqBurdenEstimateRepository(
 
     private fun getBurdenEstimateQueryForCountry(setId: Int,
                                                  outcomes: List<Pair<Short, String>>,
-                                                 cohortSize: Short,
                                                  country: Short): String
     {
-        val outcomeIdQuery = "select ${outcomes.map { it.first }.joinToString(" union select ")} union select $cohortSize order by 1"
-        val expectedOutcomeCodes = "${outcomes.joinToString(" real,") { it.second }} real, cohort_size real"
+        val outcomeIdQuery = "select ${outcomes.map { it.first }.joinToString(" union select ")} order by 1"
+        val expectedOutcomeCodes = "${outcomes.joinToString(" real,") { it.second }} real"
         val compoundRowKey = "year || '':''|| age"
         return "SELECT * FROM crosstab" +
                 "(" +
                 "'SELECT $compoundRowKey,year,country,age,burden_outcome,value FROM burden_estimate" +
-                " where burden_estimate_set = $setId and country = $country order by year, age'," +
+                " where burden_estimate_set = $setId and country = $country order by year, age, burden_outcome'," +
                 "'$outcomeIdQuery'" +
                 ")" +
                 "AS" +

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqBurdenEstimateRepository.kt
@@ -232,7 +232,7 @@ class JooqBurdenEstimateRepository(
                 .where(BURDEN_OUTCOME.CODE.eq("cohort_size"))
                 .fetchAnyInto(Short::class.java)
 
-        val outcomesIncludingCohort = outcomes +  Pair(cohortSize, "cohort_size")
+        val outcomesIncludingCohort = (outcomes +  Pair(cohortSize, "cohort_size")).sortedBy { it.first }
 
         return countryLookup.keys.asSequence().map { k ->
             val cursor = dsl.fetchLazy(getBurdenEstimateQueryForCountry(burdenEstimateSetId, outcomesIncludingCohort, k))

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/RetrieveBurdenEstimateTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/BurdenEstimates/RetrieveBurdenEstimateTests.kt
@@ -107,31 +107,31 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         JooqContext().use {
 
             val outcomes = listOf(
-                Outcome("cases", "cases name"),
-                Outcome("dalys", "dalys name"),
-                Outcome("deaths", "deaths name")
+                Outcome("hepb_chronic_symptomatic_in_acute_phase", "cases name"),
+                Outcome("hepb_deaths_acute", "dalys name"),
+                Outcome("dalys", "deaths name")
             )
 
             val setId = setUpWithBurdenEstimateSet(it, expectedOutcomes = outcomes)
             it.addCountries(listOf("ABC", "DEF"))
             it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "cohort_size", value = 100F)
-            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "cases", value = 40F)
+            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "hepb_chronic_symptomatic_in_acute_phase", value = 40F)
             it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "dalys", value = 25.5f)
-            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "deaths", value = 2F)
+            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 20, outcome = "hepb_deaths_acute", value = 2F)
 
-            it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "cases", value = 10F)
+            it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "hepb_chronic_symptomatic_in_acute_phase", value = 10F)
             it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "dalys", value = 5.5f)
-            it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "deaths", value = 1F)
+            it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "hepb_deaths_acute", value = 1F)
             it.addBurdenEstimate(setId, "DEF", year = 2000, age = 20, outcome = "cohort_size", value = 50F)
 
             it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "dalys", value = 35.5f)
             it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "cohort_size", value = 200F)
-            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "cases", value = 80F)
-            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "deaths", value = 3F)
+            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "hepb_chronic_symptomatic_in_acute_phase", value = 80F)
+            it.addBurdenEstimate(setId, "ABC", year = 2000, age = 21, outcome = "hepb_deaths_acute", value = 3F)
 
-            it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "deaths", value = 4F)
+            it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "hepb_deaths_acute", value = 4F)
             it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "cohort_size", value = 150F)
-            it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "cases", value = 60F)
+            it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "hepb_chronic_symptomatic_in_acute_phase", value = 60F)
             it.addBurdenEstimate(setId, "ABC", year = 2001, age = 20, outcome = "dalys", value = 30.5f)
         }
 
@@ -160,9 +160,9 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         Assertions.assertThat(firstRow[3]).isEqualTo("country")
         Assertions.assertThat(firstRow[4]).isEqualTo("country_name")
         Assertions.assertThat(firstRow[5]).isEqualTo("cohort_size")
-        Assertions.assertThat(firstRow[6]).isEqualTo("cases")
-        Assertions.assertThat(firstRow[7]).isEqualTo("dalys")
-        Assertions.assertThat(firstRow[8]).isEqualTo("deaths")
+        Assertions.assertThat(firstRow[6]).isEqualTo("dalys")
+        Assertions.assertThat(firstRow[7]).isEqualTo("hepb_deaths_acute")
+        Assertions.assertThat(firstRow[8]).isEqualTo("hepb_chronic_symptomatic_in_acute_phase")
 
         var dataRow = csv.drop(1).first().toList()
 
@@ -173,9 +173,9 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         Assertions.assertThat(dataRow[3]).isEqualTo("ABC")
         Assertions.assertThat(dataRow[4]).isEqualTo("ABC-Name")
         Assertions.assertThat(dataRow[5]).isEqualTo("100.0")
-        Assertions.assertThat(dataRow[6]).isEqualTo("40.0")
-        Assertions.assertThat(dataRow[7]).isEqualTo("25.5")
-        Assertions.assertThat(dataRow[8]).isEqualTo("2.0")
+        Assertions.assertThat(dataRow[6]).isEqualTo("25.5")
+        Assertions.assertThat(dataRow[7]).isEqualTo("2.0")
+        Assertions.assertThat(dataRow[8]).isEqualTo("40.0")
 
         dataRow = csv.drop(2).first().toList()
 
@@ -186,9 +186,9 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         Assertions.assertThat(dataRow[3]).isEqualTo("ABC")
         Assertions.assertThat(dataRow[4]).isEqualTo("ABC-Name")
         Assertions.assertThat(dataRow[5]).isEqualTo("200.0")
-        Assertions.assertThat(dataRow[6]).isEqualTo("80.0")
-        Assertions.assertThat(dataRow[7]).isEqualTo("35.5")
-        Assertions.assertThat(dataRow[8]).isEqualTo("3.0")
+        Assertions.assertThat(dataRow[6]).isEqualTo("35.5")
+        Assertions.assertThat(dataRow[7]).isEqualTo("3.0")
+        Assertions.assertThat(dataRow[8]).isEqualTo("80.0")
 
         dataRow = csv.drop(3).first().toList()
 
@@ -199,9 +199,9 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         Assertions.assertThat(dataRow[3]).isEqualTo("ABC")
         Assertions.assertThat(dataRow[4]).isEqualTo("ABC-Name")
         Assertions.assertThat(dataRow[5]).isEqualTo("150.0")
-        Assertions.assertThat(dataRow[6]).isEqualTo("60.0")
-        Assertions.assertThat(dataRow[7]).isEqualTo("30.5")
-        Assertions.assertThat(dataRow[8]).isEqualTo("4.0")
+        Assertions.assertThat(dataRow[6]).isEqualTo("30.5")
+        Assertions.assertThat(dataRow[7]).isEqualTo("4.0")
+        Assertions.assertThat(dataRow[8]).isEqualTo("60.0")
 
         dataRow = csv.drop(4).first().toList()
 
@@ -212,9 +212,9 @@ class RetrieveBurdenEstimateTests : BurdenEstimateTests()
         Assertions.assertThat(dataRow[3]).isEqualTo("DEF")
         Assertions.assertThat(dataRow[4]).isEqualTo("DEF-Name")
         Assertions.assertThat(dataRow[5]).isEqualTo("50.0")
-        Assertions.assertThat(dataRow[6]).isEqualTo("10.0")
-        Assertions.assertThat(dataRow[7]).isEqualTo("5.5")
-        Assertions.assertThat(dataRow[8]).isEqualTo("1.0")
+        Assertions.assertThat(dataRow[6]).isEqualTo("5.5")
+        Assertions.assertThat(dataRow[7]).isEqualTo("1.0")
+        Assertions.assertThat(dataRow[8]).isEqualTo("10.0")
     }
 
     @Test


### PR DESCRIPTION
Looks like these were just not being sorted, so it was pure chance if they were in step with the headings :woman_facepalming: 