### PR TITLE
vimc-4229 always get the db image from docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - emails:/tmp/montagu_emails
   db:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-db:${MONTAGU_DB_VERSION}
+    image: vimc/montagu-db:${MONTAGU_DB_VERSION}
     command: /etc/montagu/postgresql.test.conf
   orderly_web:
     image: vimc/orderly-web:master

--- a/scripts/generate-test-data.sh
+++ b/scripts/generate-test-data.sh
@@ -2,7 +2,7 @@
 set -ex
 
 registry=docker.montagu.dide.ic.ac.uk:5000
-public_registry=vimc
+org=vimc
 name=montagu-generate-test-data
 commit=$(git rev-parse --short=7 HEAD)
 branch=$(git symbolic-ref --short HEAD)
@@ -16,7 +16,7 @@ docker network create test-data
 docker run -d --rm \
   --name db \
   --network=test-data \
-  $registry/montagu-db:$db_version /etc/montagu/postgresql.test.conf
+  $org/montagu-db:$db_version /etc/montagu/postgresql.test.conf
 
 # Teardown on exit
 function cleanup {
@@ -28,7 +28,7 @@ trap cleanup EXIT
 
 docker exec db montagu-wait.sh
 
-docker run --rm --network=test-data $registry/montagu-migrate:$db_version
+docker run --rm --network=test-data $org/montagu-migrate:$db_version
 
 # Generate the test data
 docker build --tag $name -f generate-test-data.Dockerfile .

--- a/scripts/run-blackbox-tests.sh
+++ b/scripts/run-blackbox-tests.sh
@@ -7,8 +7,9 @@ root=$(realpath $here/..)
 export MONTAGU_API_VERSION=$(git rev-parse --short=7 HEAD)
 export MONTAGU_DB_VERSION=$(<src/config/db_version)
 MONTAGU_API_BRANCH=$(git symbolic-ref --short HEAD)
+ORG=vimc
 registry=docker.montagu.dide.ic.ac.uk:5000
-migrate_image=$registry/montagu-migrate:$MONTAGU_DB_VERSION
+migrate_image=$ORG/montagu-migrate:$MONTAGU_DB_VERSION
 
 $here/run-orderly-web-deps.sh
 

--- a/src/config/db_version
+++ b/src/config/db_version
@@ -1,2 +1,1 @@
-master
-
+vimc-4229

--- a/travis/start-database.sh
+++ b/travis/start-database.sh
@@ -9,9 +9,9 @@ set -ex
 DB_VERSION=master
 PORT_MAPPING="-p 5432:5432"
 PG_CONFIG=/etc/montagu/postgresql.test.conf
-REGISTRY=vimc
-DB_IMAGE=$REGISTRY/montagu-db:$DB_VERSION
-MIGRATE_IMAGE=$REGISTRY/montagu-migrate:$DB_VERSION
+ORG=vimc
+DB_IMAGE=$ORG/montagu-db:$DB_VERSION
+MIGRATE_IMAGE=$ORG/montagu-migrate:$DB_VERSION
 
 DB_CONTAINER=db
 NETWORK=db_nw


### PR DESCRIPTION
Once https://github.com/vimc/montagu-db/pull/149 is merged the db submodule and configured version can be pointed back to master