### PR TITLE
vimc-4020 integrate task queue into burden estimate upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ before_script:
 script:
   - ./src/gradlew -p src :testLibrary :stopTestAPI
 # need to stop and re-start orderly-web on host network for blackbox tests against app running on metal
-# and stop and restart the database so it doesn't have the task queue user anymore
-  - ./src/gradlew -p src :stopDatabase :stopOrderlyWeb :startDatabase
+  - ./scripts/stop-orderly-web.sh host
   - ./scripts/start-orderly-web.sh host
   - nohup ./src/gradlew -p src :run > /dev/null 2>&1 &
   - ./src/gradlew -p src :blackboxTests:test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - sudo mkdir -p /etc/montagu/api/ && sudo touch /etc/montagu/api/go_signal
   - ./src/gradlew -p src :startDatabase :startOrderlyWeb :startTaskQueue :startTestAPI
 script:
-  - ./src/gradlew -p src :testLibrary :stopTaskQueue :stopTestAPI
+  - ./src/gradlew -p src :testLibrary :stopTestAPI
 # need to stop and re-start orderly-web on host network for blackbox tests against app running on metal
 # and stop and restart the database so it doesn't have the task queue user anymore
   - ./src/gradlew -p src :stopDatabase :stopOrderlyWeb :startDatabase

--- a/buildkite/run-blackbox-tests.sh
+++ b/buildkite/run-blackbox-tests.sh
@@ -12,6 +12,7 @@ BRANCH_TAG=$TAG:$GIT_BRANCH
 $HERE/../scripts/start-database.sh
 $HERE/../scripts/start-orderly-web.sh
 $HERE/../scripts/start-api.sh $GIT_SHA
+$HERE/../scripts/start-task-queue.sh
 
 # Build an image that can run blackbox tests
 docker build -f ./docker/blackbox.Dockerfile -t $NAME .

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/clients/CeleryClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/clients/CeleryClient.kt
@@ -7,7 +7,11 @@ import org.vaccineimpact.api.db.Config
 typealias CeleryTaskResult = Map<String, Map<String, Boolean>>
 typealias CeleryTaskArguments = Array<out Any>
 
-class CeleryClient
+interface TaskQueueClient {
+    fun runDiagnosticReport(group: String, disease: String, touchstone: String): Any
+}
+
+class CeleryClient: TaskQueueClient
 {
     private val broker = Config["celery.broker"]
     private val backend = Config["celery.backend"]
@@ -16,7 +20,7 @@ class CeleryClient
             .backendUri(backend)
             .build()
 
-    fun runDiagnosticReport(group: String, disease: String, touchstone: String): ListenableFuture<CeleryTaskResult>
+    override fun runDiagnosticReport(group: String, disease: String, touchstone: String): ListenableFuture<CeleryTaskResult>
     {
         val args = arrayOf(group, disease, touchstone) as CeleryTaskArguments
         return client.submit<CeleryTaskResult>("run-diagnostic-reports", args)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -44,7 +44,7 @@ class BurdenEstimateUploadController(context: ActionContext,
                                      private val chunkedFileCache: Cache<ChunkedFile> = ChunkedFileCache.instance,
                                      private val chunkedFileManager: ChunkedFileManager = ChunkedFileManager(),
                                      private val serializer: Serializer = MontaguSerializer.instance,
-                                     taskQueueClient: TaskQueueClient = CeleryClient())
+                                     private val taskQueueClient: TaskQueueClient = CeleryClient())
     : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic, taskQueueClient)
 {
     constructor(context: ActionContext, repos: Repositories)
@@ -185,7 +185,6 @@ class BurdenEstimateUploadController(context: ActionContext,
         }
         else
         {
-            taskQueueClient.runDiagnosticReport(path.groupId, info.disease, path.touchstoneVersionId)
             okayResponse().asResult()
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimateUploadController.kt
@@ -6,6 +6,8 @@ import org.vaccineimpact.api.app.ChunkedFileCache
 import org.vaccineimpact.api.app.ChunkedFileManager
 import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
 import org.vaccineimpact.api.app.asResult
+import org.vaccineimpact.api.app.clients.CeleryClient
+import org.vaccineimpact.api.app.clients.TaskQueueClient
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.RequestDataSource
 import org.vaccineimpact.api.app.errors.BadRequest
@@ -41,8 +43,9 @@ class BurdenEstimateUploadController(context: ActionContext,
                                      private val tokenHelper: WebTokenHelper = WebTokenHelper(KeyHelper.keyPair),
                                      private val chunkedFileCache: Cache<ChunkedFile> = ChunkedFileCache.instance,
                                      private val chunkedFileManager: ChunkedFileManager = ChunkedFileManager(),
-                                     private val serializer: Serializer = MontaguSerializer.instance)
-    : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic)
+                                     private val serializer: Serializer = MontaguSerializer.instance,
+                                     taskQueueClient: TaskQueueClient = CeleryClient())
+    : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic, taskQueueClient)
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
@@ -134,7 +137,10 @@ class BurdenEstimateUploadController(context: ActionContext,
 
             chunkedFileCache.remove(file.uniqueIdentifier)
 
-            closeEstimateSetAndReturnMissingRowError(path.setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
+            val info = estimateRepository.getResponsibilityInfo(path.groupId, path.touchstoneVersionId, path.scenarioId)
+
+            closeEstimateSetAndReturnMissingRowError(path.setId,
+                    path.groupId, info.disease, path.touchstoneVersionId, path.scenarioId)
         }
         else
         {
@@ -168,14 +174,18 @@ class BurdenEstimateUploadController(context: ActionContext,
                 data,
                 filename = null)
 
+        val info = estimateRepository.getResponsibilityInfo(path.groupId, path.touchstoneVersionId, path.scenarioId)
+
         // Then, maybe close the burden estimate set
         val keepOpen = context.queryParams("keepOpen")?.toBoolean() ?: false
+
         return if (!keepOpen)
         {
-            closeEstimateSetAndReturnMissingRowError(setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
+            closeEstimateSetAndReturnMissingRowError(setId, path.groupId, info.disease, path.touchstoneVersionId, path.scenarioId)
         }
         else
         {
+            taskQueueClient.runDiagnosticReport(path.groupId, info.disease, path.touchstoneVersionId)
             okayResponse().asResult()
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BurdenEstimatesController.kt
@@ -1,5 +1,7 @@
 package org.vaccineimpact.api.app.controllers.BurdenEstimates
 
+import org.vaccineimpact.api.app.clients.CeleryClient
+import org.vaccineimpact.api.app.clients.TaskQueueClient
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
@@ -16,8 +18,9 @@ open class BurdenEstimatesController(
         context: ActionContext,
         private val estimatesLogic: BurdenEstimateLogic,
         private val estimateRepository: BurdenEstimateRepository,
-        private val responsibilitiesLogic: ResponsibilitiesLogic
-) : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic)
+        private val responsibilitiesLogic: ResponsibilitiesLogic,
+        taskQueueClient: TaskQueueClient = CeleryClient()
+) : BaseBurdenEstimateController(context, estimatesLogic, responsibilitiesLogic, taskQueueClient)
 {
     constructor(context: ActionContext, repos: Repositories)
             : this(context,
@@ -89,7 +92,8 @@ open class BurdenEstimatesController(
     {
         val path = getValidResponsibilityPath()
         val setId = context.params(":set-id").toInt()
-        return closeEstimateSetAndReturnMissingRowError(setId, path.groupId, path.touchstoneVersionId, path.scenarioId)
+        val info = estimateRepository.getResponsibilityInfo(path.groupId, path.touchstoneVersionId, path.scenarioId)
+        return closeEstimateSetAndReturnMissingRowError(setId, path.groupId, info.disease, path.touchstoneVersionId, path.scenarioId)
     }
 
     fun getBurdenEstimateSetData(): StreamSerializable<BurdenEstimate>

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimateControllerTestsBase.kt
@@ -4,16 +4,21 @@ import com.nhaarman.mockito_kotlin.*
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.logic.BurdenEstimateLogic
 import org.vaccineimpact.api.app.logic.ResponsibilitiesLogic
-import org.vaccineimpact.api.app.repositories.*
+import org.vaccineimpact.api.app.repositories.BurdenEstimateRepository
+import org.vaccineimpact.api.app.repositories.SimpleDataSet
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.app.repositories.jooq.ResponsibilityInfo
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Instant
 
-abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
+abstract class BurdenEstimateControllerTestsBase : MontaguTests()
+{
 
     protected val groupId = "group-1"
     protected val touchstoneVersionId = "touchstone-1"
     protected val scenarioId = "scenario-1"
+    protected val diseaseId = "disease-1"
 
     protected fun mockTouchstones() = mock<SimpleDataSet<TouchstoneVersion, String>> {
         on { get(touchstoneVersionId) } doReturn TouchstoneVersion(touchstoneVersionId, "touchstone", 1, "Description", TouchstoneStatus.OPEN)
@@ -32,6 +37,8 @@ abstract class BurdenEstimateControllerTestsBase: MontaguTests() {
     {
         val touchstoneRepo = mockTouchstoneRepository(touchstoneVersionSet)
         return mock {
+            on { getResponsibilityInfo(groupId, touchstoneVersionId, scenarioId) } doReturn
+                    ResponsibilityInfo(1, diseaseId, "status", 1)
             on { touchstoneRepository } doReturn touchstoneRepo
             on { getBurdenEstimateSet(any(), any(), any(), any()) } doReturn existingBurdenEstimateSet
         }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -4,6 +4,8 @@ import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito
+import org.vaccineimpact.api.app.clients.CeleryClient
+import org.vaccineimpact.api.app.clients.TaskQueueClient
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.postData
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimatesController
@@ -128,8 +130,11 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":scenario-id") } doReturn scenarioId
         }
         val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
-        BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic).closeBurdenEstimateSet()
+        val mockTaskQueueClient = mock<TaskQueueClient>()
+        BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic, mockTaskQueueClient)
+                .closeBurdenEstimateSet()
         verify(logic).closeBurdenEstimateSet(1, groupId, touchstoneVersionId, scenarioId)
+        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId)
         verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 
@@ -147,7 +152,7 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
             on { params(":scenario-id") } doReturn scenarioId
         }
         val mockResponsibilitiesLogic = mock<ResponsibilitiesLogic>()
-        val result = BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic)
+        val result = BurdenEstimatesController(mockContext, logic, repo, mockResponsibilitiesLogic, mock())
                 .closeBurdenEstimateSet()
         assertThat(result.status).isEqualTo(ResultStatus.FAILURE)
         verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -38,7 +38,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
         val mockTaskQueueClient = mock<TaskQueueClient>()
         val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(),
-                mockTokenHelper, cache, mock(), mock(), mockTaskQueueClient)
+                mockTokenHelper, cache, taskQueueClient = mockTaskQueueClient)
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
@@ -124,7 +124,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
         val sut = BurdenEstimateUploadController(mockContext, logic, mock(),
-                repo, mock(), mockTokenHelper, cache, mock(), mock(), mock())
+                repo, mock(), mockTokenHelper, cache, taskQueueClient = mock())
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.vaccineimpact.api.app.ChunkedFileManager.Companion.UPLOAD_DIR
+import org.vaccineimpact.api.app.clients.TaskQueueClient
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.BurdenEstimates.BurdenEstimateUploadController
 import org.vaccineimpact.api.app.errors.BadRequest
@@ -35,15 +36,17 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val repo = mockEstimatesRepository(touchstoneSet)
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true, fileName = "file.csv")
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
-
-        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
+        val mockTaskQueueClient = mock<TaskQueueClient>()
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(),
+                mockTokenHelper, cache, mock(), mock(), mockTaskQueueClient)
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
         assertThat(result.status).isEqualTo(ResultStatus.SUCCESS)
         assertThat(result.data).isEqualTo("OK")
-        verify(logic).populateBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"), any(), eq("file.csv"))
-        verify(logic).closeBurdenEstimateSet(eq(1), eq("g1"), eq("t1"), eq("s1"))
+        verify(logic).populateBurdenEstimateSet(eq(1), eq(groupId), eq(touchstoneVersionId), eq(scenarioId), any(), eq("file.csv"))
+        verify(logic).closeBurdenEstimateSet(1, groupId, touchstoneVersionId, scenarioId)
+        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId)
     }
 
     @Test
@@ -120,7 +123,8 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         val cache = makeFakeCacheWithChunkedFile(uid, uploadFinished = true)
         val mockTokenHelper = getMockTokenHelper("user.name", uid)
 
-        val sut = BurdenEstimateUploadController(mockContext, logic, mock(), repo, mock(), mockTokenHelper, cache)
+        val sut = BurdenEstimateUploadController(mockContext, logic, mock(),
+                repo, mock(), mockTokenHelper, cache, mock(), mock(), mock())
 
         val result = sut.populateBurdenEstimateSetFromLocalFile()
 
@@ -191,9 +195,9 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         return mock {
             on { username } doReturn user
             on { params(":set-id") } doReturn "1"
-            on { params(":group-id") } doReturn "group-1"
-            on { params(":touchstone-version-id") } doReturn "touchstone-1"
-            on { params(":scenario-id") } doReturn "scenario-1"
+            on { params(":group-id") } doReturn groupId
+            on { params(":touchstone-version-id") } doReturn touchstoneVersionId
+            on { params(":scenario-id") } doReturn scenarioId
             on { params(":token") } doReturn "faketoken"
         }
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -339,14 +339,17 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
         val repo = mockEstimatesRepository()
         val mockContext = mockActionContext(keepOpen = keepOpen)
         val mockPostData = mockCSVPostData(normalCSVData)
+        val mockTaskQueueClient = mock<TaskQueueClient>()
         BurdenEstimateUploadController(mockContext,
                 estimatesLogic,
                 responsibilitiesLogic,
                 repo,
-                postDataHelper = mockPostData, celeryClient = mock()).populateBurdenEstimateSet()
+                postDataHelper = mockPostData,
+                taskQueueClient = mockTaskQueueClient).populateBurdenEstimateSet()
         verify(estimatesLogic, timesExpected).closeBurdenEstimateSet(defaultEstimateSet.id,
                 groupId, touchstoneVersionId, scenarioId)
         verifyValidResponsibilityPathChecks(responsibilitiesLogic, mockContext)
+        verify(mockTaskQueueClient, timesExpected).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId)
     }
 
     protected fun mockActionContext(user: String = "username", keepOpen: String? = null): ActionContext
@@ -399,7 +402,7 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
                 responsibilitiesLogic,
                 repo,
                 postDataHelper = postDataHelper,
-                celeryClient = mockTaskQueueClient)
+                taskQueueClient = mockTaskQueueClient)
 
         sut.populateBurdenEstimateSet()
         verify(estimatesLogic).populateBurdenEstimateSet(eq(1),

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/UserTests.kt
@@ -249,8 +249,8 @@ class UserTests : DatabaseTest()
             PermissionSet("*/users.read")
         } andCheckArray {
 
-            // the above 2 users plus standard test user
-            Assertions.assertThat(it.size).isEqualTo(3)
+            // the above 2 users plus standard test user and task q user
+            Assertions.assertThat(it.size).isEqualTo(4)
 
             Assertions.assertThat(it).contains(json {
                 obj(

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
@@ -98,6 +98,7 @@ open class MontaguSerializer : Serializer
     override fun convertFieldName(name: String): String
     {
         val builder = StringBuilder()
+
         for (char in name)
         {
             if (char.isUpperCase())


### PR DESCRIPTION
This PR actually queues the diagnostic report task when a burden estimate set is marked as closed.

Contains commits from https://github.com/vimc/montagu-api/pull/431

After that is merged, master should be merged into this branch and the base of the PR set back to master.
