### PR TITLE
mrc-1816 remove temp fix for buildkite agents 

### DIFF
--- a/scripts/start-orderly-web.sh
+++ b/scripts/start-orderly-web.sh
@@ -21,7 +21,7 @@ else
   pip3 install orderly-web --user
 fi
 
-export PATH=$PATH:/var/lib/buildkite-agent/.local/bin
+#export PATH=$PATH:/var/lib/buildkite-agent/.local/bin
 orderly-web start $HERE $OPTION_MAPPING
 
 $HERE/orderly-web-cli.sh add-users user@test.com

--- a/scripts/start-orderly-web.sh
+++ b/scripts/start-orderly-web.sh
@@ -21,7 +21,6 @@ else
   pip3 install orderly-web --user
 fi
 
-#export PATH=$PATH:/var/lib/buildkite-agent/.local/bin
 orderly-web start $HERE $OPTION_MAPPING
 
 $HERE/orderly-web-cli.sh add-users user@test.com


### PR DESCRIPTION
This removes the temporary setting of the PATH env var in the build script, as this has now been added to all build agents.