### PR TITLE
vimc-4318 method to deserialise coverage from CSV

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.tests.controllers
+package org.vaccineimpact.api.tests.controllers.coverage
 
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -8,9 +8,7 @@ import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.controllers.CoverageController
 import org.vaccineimpact.api.app.requests.PostDataHelper
-import org.vaccineimpact.api.models.ActivityType
-import org.vaccineimpact.api.models.CoverageIngestionRow
-import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import org.vaccineimpact.api.test_helpers.MontaguTests
 
@@ -25,8 +23,8 @@ class PopulatingCoverageTests : MontaguTests()
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThat(result.toList()).containsExactly(
-                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
-                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, 100F, 65.5F)
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, GenderEnum.FEMALE, 100F, 65.5F)
         )
     }
 
@@ -67,24 +65,24 @@ class PopulatingCoverageTests : MontaguTests()
     }
 
     private val normalCSVDataString = """
-"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    100, 78.8
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    100, 65.5
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    "both", 100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    "Female", 100, 65.5
 """
 
     private val invalidSupportLevelCSVDataString = """
-"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "withsupport",  "2020",         1,     10,    100, 78.8
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "withsupport",  "2020",         1,     10,    "both", 100, 78.8
 """
 
     private val invalidActivityTypeCSVDataString = """
-"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
-   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, 78.8
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, "both", 78.8
 """
 
     private val invalidHeadersCSVDataString = """
-"vaccine", "country code", "activity", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
-   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, 78.8
+"vaccine", "country code", "activity", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    "both", 100, 78.8
 """
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -1,0 +1,90 @@
+package org.vaccineimpact.api.tests.controllers.coverage
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.vaccineimpact.api.app.context.ActionContext
+import org.vaccineimpact.api.app.controllers.CoverageController
+import org.vaccineimpact.api.app.requests.PostDataHelper
+import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.CoverageIngestionRow
+import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.serialization.validation.ValidationException
+import org.vaccineimpact.api.test_helpers.MontaguTests
+
+class PopulatingCoverageTests : MontaguTests()
+{
+    @Test
+    fun `can deserialize coverage`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { this.getInputStream() } doReturn normalCSVDataString.byteInputStream()
+        }
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val result = sut.getCoverageDataFromCSV()
+        assertThat(result.toList()).containsExactly(
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, 100F, 65.5F)
+        )
+    }
+
+    @Test
+    fun `deserializing coverage throws error on invalid gavi support level`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { this.getInputStream() } doReturn invalidSupportLevelCSVDataString.byteInputStream()
+        }
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val result = sut.getCoverageDataFromCSV()
+        assertThatThrownBy { result.toList() }
+                .isInstanceOf(ValidationException::class.java)
+    }
+
+    @Test
+    fun `deserializing coverage throws error on invalid activity type`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { this.getInputStream() } doReturn invalidActivityTypeCSVDataString.byteInputStream()
+        }
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val result = sut.getCoverageDataFromCSV()
+        assertThatThrownBy { result.toList() }
+                .isInstanceOf(ValidationException::class.java)
+    }
+
+    @Test
+    fun `deserializing coverage throws error on invalid column headers`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { this.getInputStream() } doReturn invalidHeadersCSVDataString.byteInputStream()
+        }
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+
+        assertThatThrownBy {  sut.getCoverageDataFromCSV() }
+                .isInstanceOf(ValidationException::class.java)
+    }
+
+    private val normalCSVDataString = """
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    100, 65.5
+"""
+
+    private val invalidSupportLevelCSVDataString = """
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "withsupport",  "2020",         1,     10,    100, 78.8
+"""
+
+    private val invalidActivityTypeCSVDataString = """
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
+   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, 78.8
+"""
+
+    private val invalidHeadersCSVDataString = """
+"vaccine", "country code", "activity", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
+   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, 78.8
+"""
+
+}

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -1,5 +1,7 @@
 package org.vaccineimpact.api.serialization
 
+import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.GAVISupportLevel
 import java.lang.UnsupportedOperationException
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
@@ -33,6 +35,8 @@ class Deserializer
             Int::class.createType() -> raw.toInt()
             Short::class.createType() -> raw.toShort()
             Float::class.createType() -> raw.toFloat()
+            ActivityType::class.createType() -> ActivityType.valueOf(raw.toUpperCase())
+            GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.toUpperCase())
             else -> throw UnsupportedOperationException("org.vaccineimpact.api.serialization.Deserializer does not support target type $targetType")
         }
     }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.api.serialization
 
 import org.vaccineimpact.api.models.ActivityType
 import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.models.GenderEnum
 import java.lang.UnsupportedOperationException
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
@@ -37,6 +38,7 @@ class Deserializer
             Float::class.createType() -> raw.toFloat()
             ActivityType::class.createType() -> ActivityType.valueOf(raw.toUpperCase())
             GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.toUpperCase())
+            GenderEnum::class.createType() -> GenderEnum.valueOf(raw.toUpperCase())
             else -> throw UnsupportedOperationException("org.vaccineimpact.api.serialization.Deserializer does not support target type $targetType")
         }
     }


### PR DESCRIPTION
So here's the tiniest of first PRs - a model for the coverage rows, support for deserializing the GAVISupportLevel and ActivityType enums (also a convenient way of validating them), and a method that just reads in a CSV from the POST body and returns a sequence of rows.