### PR TITLE
vimc-4318 endpoint for ingesting coverage

### DIFF
--- a/docs/schemas/CoverageIngestion.csvschema.json
+++ b/docs/schemas/CoverageIngestion.csvschema.json
@@ -1,0 +1,14 @@
+{
+    "columns": {
+        "vaccine": "String",
+        "country": "String",
+        "activity_type": "String",
+        "gavi_support": "String",
+        "year": "Int",
+        "age_first": "Int",
+        "age_last": "Int",
+        "target": "Decimal",
+        "coverage": "Decimal"
+    },
+    "additionalColumnsAllowed": false
+}

--- a/docs/schemas/CoverageIngestion.csvschema.json
+++ b/docs/schemas/CoverageIngestion.csvschema.json
@@ -7,6 +7,7 @@
         "year": "Int",
         "age_first": "Int",
         "age_last": "Int",
+        "gender": "String",
         "target": "Decimal",
         "coverage": "Decimal"
     },

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
@@ -13,6 +13,10 @@ object CoverageRouteConfig : RouteConfig
             "*/coverage.read"
     )
 
+    private val writePermissions = setOf(
+            "*/coverage.write"
+    )
+
     override val endpoints: List<EndpointDefinition> = listOf(
 
             Endpoint("$baseUrl/coverage/", controller, "getCoverageDataAndMetadataForTouchstoneVersion")
@@ -33,7 +37,7 @@ object CoverageRouteConfig : RouteConfig
 
             Endpoint("/touchstones/:touchstone-version-id/coverage/", controller, "ingestCoverage")
                     .post()
-                    .secure(permissions)
+                    .secure(writePermissions)
     )
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
@@ -29,6 +29,10 @@ object CoverageRouteConfig : RouteConfig
             //above two routes.
             Endpoint("$baseUrl/coverage/csv/", controller, "getCoverageDataForTouchstoneVersion")
                     .csv().streamed()
+                    .secure(permissions),
+
+            Endpoint("/touchstones/:touchstone-version-id/coverage/", controller, "ingestCoverage")
+                    .post()
                     .secure(permissions)
     )
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.api.app.controllers
 
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.context.ActionContext
-import org.vaccineimpact.api.app.context.RequestBodySource
 import org.vaccineimpact.api.app.context.RequestDataSource
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.logic.CoverageLogic
@@ -21,12 +20,11 @@ import org.vaccineimpact.api.serialization.StreamSerializable
 class CoverageController(
         actionContext: ActionContext,
         private val coverageLogic: CoverageLogic,
-        private val touchstoneRepository: TouchstoneRepository,
         private val postDataHelper: PostDataHelper = PostDataHelper()
 ) : Controller(actionContext)
 {
     constructor(context: ActionContext, repositories: Repositories)
-            : this(context, RepositoriesCoverageLogic(repositories), repositories.touchstone)
+            : this(context, RepositoriesCoverageLogic(repositories))
 
     fun getCoverageDataFromCSV(): Sequence<CoverageIngestionRow>
     {
@@ -37,7 +35,7 @@ class CoverageController(
     fun ingestCoverage(): String
     {
         val sequence = getCoverageDataFromCSV()
-        touchstoneRepository.saveCoverage(context.params(":touchstone-version-id"), sequence)
+        coverageLogic.saveCoverageForTouchstone(context.params(":touchstone-version-id"), sequence)
         return okayResponse()
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -3,30 +3,42 @@ package org.vaccineimpact.api.app.controllers
 import org.vaccineimpact.api.app.app_start.Controller
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.RequestBodySource
+import org.vaccineimpact.api.app.context.RequestDataSource
 import org.vaccineimpact.api.app.controllers.helpers.ResponsibilityPath
 import org.vaccineimpact.api.app.logic.CoverageLogic
 import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
 import org.vaccineimpact.api.app.repositories.Repositories
-import org.vaccineimpact.api.app.requests.csvData
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.requests.PostDataHelper
+import org.vaccineimpact.api.app.requests.csvData
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
-import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.models.CoverageIngestionRow
+import org.vaccineimpact.api.models.CoverageRow
+import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
 import org.vaccineimpact.api.serialization.SplitData
 import org.vaccineimpact.api.serialization.StreamSerializable
 
 class CoverageController(
         actionContext: ActionContext,
         private val coverageLogic: CoverageLogic,
+        private val touchstoneRepository: TouchstoneRepository,
         private val postDataHelper: PostDataHelper = PostDataHelper()
 ) : Controller(actionContext)
 {
     constructor(context: ActionContext, repositories: Repositories)
-            : this(context, RepositoriesCoverageLogic(repositories))
+            : this(context, RepositoriesCoverageLogic(repositories), repositories.touchstone)
 
     fun getCoverageDataFromCSV(): Sequence<CoverageIngestionRow>
     {
-        val source = RequestBodySource(context)
+        val source = RequestDataSource.fromContentType(context)
         return postDataHelper.csvData(from = source)
+    }
+
+    fun ingestCoverage(): String
+    {
+        val sequence = getCoverageDataFromCSV()
+        touchstoneRepository.saveCoverage(context.params(":touchstone-version-id"), sequence)
+        return okayResponse()
     }
 
     fun getCoverageSetsForGroup(): ScenarioTouchstoneAndCoverageSets

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -68,7 +68,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                     coverage = it.target.toBigDecimal()
             )
         }.toList()
-        touchstoneRepository.saveCoverage(touchstoneVersionId, records)
+        touchstoneRepository.saveCoverageForTouchstone(touchstoneVersionId, records)
     }
 
     constructor(repositories: Repositories) : this(repositories.modellingGroup,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -65,7 +65,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                     ageFrom = BigDecimal(it.ageFirst),
                     ageTo = BigDecimal(it.ageLast),
                     target = it.target.toBigDecimal(),
-                    coverage = it.target.toBigDecimal()
+                    coverage = it.coverage.toBigDecimal()
             )
         }.toList()
         touchstoneRepository.saveCoverageForTouchstone(touchstoneVersionId, records)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.api.app.logic
 
+import okhttp3.internal.userAgent
 import org.vaccineimpact.api.app.errors.BadRequest
 import org.vaccineimpact.api.app.getLongCoverageRowDataTable
 import org.vaccineimpact.api.app.getWideCoverageRowDataTable
@@ -45,6 +46,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
 
     override fun saveCoverageForTouchstone(touchstoneVersionId: String, rows: Sequence<CoverageIngestionRow>)
     {
+        val genders = touchstoneRepository.getGenders()
         val setDeterminants = mutableListOf<Triple<ActivityType, GAVISupportLevel, String>>()
         val setIds = mutableListOf<Int>()
         val records = rows.map {
@@ -64,6 +66,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                     it.year,
                     ageFrom = BigDecimal(it.ageFirst),
                     ageTo = BigDecimal(it.ageLast),
+                    gender = genders[it.gender]!!,
                     target = it.target.toBigDecimal(),
                     coverage = it.coverage.toBigDecimal()
             )

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -32,12 +32,14 @@ interface TouchstoneRepository : Repository
             scenarioDescriptionId: String)
             : List<CoverageSet>
 
+    fun getGenders(): Map<GenderEnum, Int>
     fun saveCoverageForTouchstone(touchstoneVersionId: String, records: List<CoverageRecord>)
     fun newCoverageRowRecord(coverageSetId: Int,
                              country: String,
                              year: Int,
                              ageFrom: BigDecimal,
                              ageTo: BigDecimal,
+                             gender: Int,
                              target: BigDecimal?,
                              coverage: BigDecimal?): CoverageRecord
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -2,10 +2,10 @@ package org.vaccineimpact.api.app.repositories
 
 import org.jooq.Record
 import org.vaccineimpact.api.app.filters.ScenarioFilterParameters
-import org.vaccineimpact.api.db.tables.Coverage
+import org.vaccineimpact.api.db.tables.records.CoverageRecord
 import org.vaccineimpact.api.models.*
-import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.serialization.SplitData
+import java.math.BigDecimal
 
 interface TouchstoneRepository : Repository
 {
@@ -32,7 +32,14 @@ interface TouchstoneRepository : Repository
             scenarioDescriptionId: String)
             : List<CoverageSet>
 
-    fun saveCoverage(touchstoneVersionId: String, rows: Sequence<CoverageIngestionRow>)
+    fun saveCoverage(touchstoneVersionId: String, records: List<CoverageRecord>)
+    fun newCoverageRowRecord(coverageSetId: Int,
+                             country: String,
+                             year: Int,
+                             ageFrom: BigDecimal,
+                             ageTo: BigDecimal,
+                             target: BigDecimal?,
+                             coverage: BigDecimal?): CoverageRecord
 
     fun getDemographicDatasets(touchstoneVersionId: String): List<DemographicDataset>
     fun getDemographicData(statisticTypeCode: String, source: String,
@@ -41,4 +48,5 @@ interface TouchstoneRepository : Repository
 
     fun mapTouchstone(records: List<Record>): Touchstone
     fun mapTouchstoneVersion(record: Record): TouchstoneVersion
+    fun createCoverageSet(touchstoneVersionId: String, vaccine: String, activityType: ActivityType, supportLevel: GAVISupportLevel): Int
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -32,6 +32,8 @@ interface TouchstoneRepository : Repository
             scenarioDescriptionId: String)
             : List<CoverageSet>
 
+    fun saveCoverage(touchstoneVersionId: String, rows: Sequence<CoverageIngestionRow>)
+
     fun getDemographicDatasets(touchstoneVersionId: String): List<DemographicDataset>
     fun getDemographicData(statisticTypeCode: String, source: String,
                            touchstoneVersionId: String,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -32,7 +32,7 @@ interface TouchstoneRepository : Repository
             scenarioDescriptionId: String)
             : List<CoverageSet>
 
-    fun saveCoverage(touchstoneVersionId: String, records: List<CoverageRecord>)
+    fun saveCoverageForTouchstone(touchstoneVersionId: String, records: List<CoverageRecord>)
     fun newCoverageRowRecord(coverageSetId: Int,
                              country: String,
                              year: Int,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -40,6 +40,7 @@ interface TouchstoneRepository : Repository
                              ageFrom: BigDecimal,
                              ageTo: BigDecimal,
                              gender: Int,
+                             gaviSupport: Boolean,
                              target: BigDecimal?,
                              coverage: BigDecimal?): CoverageRecord
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
@@ -3,5 +3,9 @@ package org.vaccineimpact.api.app.repositories.jooq
 import org.jooq.DSLContext
 import org.vaccineimpact.api.app.repositories.Repository
 import org.vaccineimpact.api.app.repositories.jooq.mapping.MappingHelper
+import org.vaccineimpact.api.db.tables.records.CoverageRecord
+import java.math.BigDecimal
 
 abstract class JooqRepository(val dsl: DSLContext): Repository
+{
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqRepository.kt
@@ -2,10 +2,5 @@ package org.vaccineimpact.api.app.repositories.jooq
 
 import org.jooq.DSLContext
 import org.vaccineimpact.api.app.repositories.Repository
-import org.vaccineimpact.api.app.repositories.jooq.mapping.MappingHelper
-import org.vaccineimpact.api.db.tables.records.CoverageRecord
-import java.math.BigDecimal
 
 abstract class JooqRepository(val dsl: DSLContext): Repository
-{
-}

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -226,7 +226,7 @@ class JooqTouchstoneRepository(
         return record.id
     }
 
-    override fun saveCoverage(touchstoneVersionId: String, records: List<CoverageRecord>)
+    override fun saveCoverageForTouchstone(touchstoneVersionId: String, records: List<CoverageRecord>)
     {
         dsl.batchStore(records).execute()
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -247,6 +247,7 @@ class JooqTouchstoneRepository(
                                       ageFrom: BigDecimal,
                                       ageTo: BigDecimal,
                                       gender: Int,
+                                      gaviSupport: Boolean,
                                       target: BigDecimal?,
                                       coverage: BigDecimal?) = this.dsl.newRecord(COVERAGE).apply {
         this.coverageSet = coverageSetId
@@ -257,6 +258,7 @@ class JooqTouchstoneRepository(
         this.target = target
         this.coverage = coverage
         this.gender = gender
+        this.gaviSupport = gaviSupport
     }
 
     private fun coverageDimensions(): Array<Field<*>>

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -213,7 +213,7 @@ class JooqTouchstoneRepository(
                                    supportLevel: GAVISupportLevel): Int
     {
 
-        val support = supportLevel.toString().toLowerCase().replace('_', '-')
+        val support = supportLevel.toString().toLowerCase()
         val activity = activityType.toString().toLowerCase().replace('_', '-')
         val record = this.dsl.newRecord(COVERAGE_SET).apply {
             this.touchstone = touchstoneVersionId

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -242,12 +242,13 @@ class JooqTouchstoneRepository(
     }
 
     override fun newCoverageRowRecord(coverageSetId: Int,
-                                     country: String,
-                                     year: Int,
-                                     ageFrom: BigDecimal,
-                                     ageTo: BigDecimal,
-                                     target: BigDecimal?,
-                                     coverage: BigDecimal?) = this.dsl.newRecord(COVERAGE).apply {
+                                      country: String,
+                                      year: Int,
+                                      ageFrom: BigDecimal,
+                                      ageTo: BigDecimal,
+                                      gender: Int,
+                                      target: BigDecimal?,
+                                      coverage: BigDecimal?) = this.dsl.newRecord(COVERAGE).apply {
         this.coverageSet = coverageSetId
         this.country = country
         this.year = year
@@ -255,6 +256,7 @@ class JooqTouchstoneRepository(
         this.ageTo = ageTo
         this.target = target
         this.coverage = coverage
+        this.gender = gender
     }
 
     private fun coverageDimensions(): Array<Field<*>>
@@ -474,6 +476,13 @@ class JooqTouchstoneRepository(
                 .on(DEMOGRAPHIC_STATISTIC.DEMOGRAPHIC_VARIANT.eq(field(name("v", "id"), Int::class.java)))
                 .where(DEMOGRAPHIC_STATISTIC.DEMOGRAPHIC_STATISTIC_TYPE.eq(statisticType.id))
                 .and(DEMOGRAPHIC_STATISTIC.GENDER.eq(genderId))
+    }
+
+    override fun getGenders(): Map<GenderEnum, Int>
+    {
+        return dsl.fetch(GENDER).associate {
+            GenderEnum.valueOf(it.name.toUpperCase()) to it.id
+        }
     }
 
     private fun getGenderId(statisticType: DemographicStatisticTypeRecord, gender: String): Int

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
@@ -21,7 +21,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic).getCoverageSetsForGroup()
+        CoverageController(context, logic, mock()).getCoverageSetsForGroup()
 
         verify(logic).getCoverageSetsForGroup(eq("gId"), eq("tId"), eq("sId"))
     }
@@ -32,7 +32,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(false)
         Assertions.assertThatThrownBy {
-            CoverageController(context, logic).getCoverageSetsForGroup()
+            CoverageController(context, logic, mock()).getCoverageSetsForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -41,7 +41,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic).getCoverageDataForGroup()
+        CoverageController(context, logic, mock()).getCoverageDataForGroup()
         verify(logic).getCoverageDataForGroup(eq("gId"), eq("tId"), eq("sId"), eq(false), isNull())
     }
 
@@ -57,7 +57,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = CoverageController(context, logic)
+        val data = CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         Assertions.assertThat(data.first() is LongCoverageRow).isTrue()
     }
@@ -74,7 +74,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic)
+        CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", true, null)
     }
@@ -91,7 +91,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic)
+        CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -107,7 +107,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic)
+        CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -118,7 +118,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
 
-        val data = CoverageController(context, logic)
+        val data = CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
 
         // test data includes 5 years
@@ -146,7 +146,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = CoverageController(context, logic)
+        val data = CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
 
         Assertions.assertThat(data.count()).isEqualTo(0)
@@ -161,7 +161,7 @@ class CoverageControllerTests : MontaguTests()
         val context = mockContextForSpecificResponsibility(false)
 
         Assertions.assertThatThrownBy {
-            CoverageController(context, logic).getCoverageDataForGroup()
+            CoverageController(context, logic, mock()).getCoverageDataForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
@@ -21,7 +21,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic, mock()).getCoverageSetsForGroup()
+        CoverageController(context, logic).getCoverageSetsForGroup()
 
         verify(logic).getCoverageSetsForGroup(eq("gId"), eq("tId"), eq("sId"))
     }
@@ -32,7 +32,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(false)
         Assertions.assertThatThrownBy {
-            CoverageController(context, logic, mock()).getCoverageSetsForGroup()
+            CoverageController(context, logic).getCoverageSetsForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -41,7 +41,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic, mock()).getCoverageDataForGroup()
+        CoverageController(context, logic).getCoverageDataForGroup()
         verify(logic).getCoverageDataForGroup(eq("gId"), eq("tId"), eq("sId"), eq(false), isNull())
     }
 
@@ -91,7 +91,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic, mock())
+        CoverageController(context, logic)
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -107,7 +107,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic, mock())
+        CoverageController(context, logic)
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -118,7 +118,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
 
-        val data = CoverageController(context, logic, mock())
+        val data = CoverageController(context, logic)
                 .getCoverageDataForGroup().data
 
         // test data includes 5 years
@@ -146,7 +146,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = CoverageController(context, logic, mock())
+        val data = CoverageController(context, logic)
                 .getCoverageDataForGroup().data
 
         Assertions.assertThat(data.count()).isEqualTo(0)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -22,7 +22,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn normalCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThat(result.toList()).containsExactly(
                 CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
@@ -36,7 +36,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidSupportLevelCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThatThrownBy { result.toList() }
                 .isInstanceOf(ValidationException::class.java)
@@ -48,7 +48,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidActivityTypeCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThatThrownBy { result.toList() }
                 .isInstanceOf(ValidationException::class.java)
@@ -60,7 +60,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidHeadersCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
 
         assertThatThrownBy {  sut.getCoverageDataFromCSV() }
                 .isInstanceOf(ValidationException::class.java)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -22,7 +22,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn normalCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThat(result.toList()).containsExactly(
                 CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
@@ -36,7 +36,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidSupportLevelCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThatThrownBy { result.toList() }
                 .isInstanceOf(ValidationException::class.java)
@@ -48,7 +48,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidActivityTypeCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThatThrownBy { result.toList() }
                 .isInstanceOf(ValidationException::class.java)
@@ -60,7 +60,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { this.getInputStream() } doReturn invalidHeadersCSVDataString.byteInputStream()
         }
-        val sut = CoverageController(mockContext, mock(), mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), PostDataHelper())
 
         assertThatThrownBy {  sut.getCoverageDataFromCSV() }
                 .isInstanceOf(ValidationException::class.java)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -20,6 +20,7 @@ class PopulatingCoverageTests : MontaguTests()
     fun `can deserialize coverage`()
     {
         val mockContext = mock<ActionContext> {
+            on { contentType() } doReturn "text/csv"
             on { this.getInputStream() } doReturn normalCSVDataString.byteInputStream()
         }
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
@@ -34,6 +35,7 @@ class PopulatingCoverageTests : MontaguTests()
     fun `deserializing coverage throws error on invalid gavi support level`()
     {
         val mockContext = mock<ActionContext> {
+            on { contentType() } doReturn "text/csv"
             on { this.getInputStream() } doReturn invalidSupportLevelCSVDataString.byteInputStream()
         }
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
@@ -46,6 +48,7 @@ class PopulatingCoverageTests : MontaguTests()
     fun `deserializing coverage throws error on invalid activity type`()
     {
         val mockContext = mock<ActionContext> {
+            on { contentType() } doReturn "text/csv"
             on { this.getInputStream() } doReturn invalidActivityTypeCSVDataString.byteInputStream()
         }
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
@@ -58,11 +61,11 @@ class PopulatingCoverageTests : MontaguTests()
     fun `deserializing coverage throws error on invalid column headers`()
     {
         val mockContext = mock<ActionContext> {
+            on { contentType() } doReturn "text/csv"
             on { this.getInputStream() } doReturn invalidHeadersCSVDataString.byteInputStream()
         }
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
-
-        assertThatThrownBy {  sut.getCoverageDataFromCSV() }
+        assertThatThrownBy { sut.getCoverageDataFromCSV() }
                 .isInstanceOf(ValidationException::class.java)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -24,22 +24,9 @@ class PopulatingCoverageTests : MontaguTests()
         val sut = CoverageController(mockContext, mock(), PostDataHelper())
         val result = sut.getCoverageDataFromCSV()
         assertThat(result.toList()).containsExactly(
-                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
-                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, GenderEnum.FEMALE, 100F, 65.5F)
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, true, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
+                CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, false, 2021, 1, 10, GenderEnum.FEMALE, 100F, 65.5F)
         )
-    }
-
-    @Test
-    fun `deserializing coverage throws error on invalid gavi support level`()
-    {
-        val mockContext = mock<ActionContext> {
-            on { contentType() } doReturn "text/csv"
-            on { this.getInputStream() } doReturn invalidSupportLevelCSVDataString.byteInputStream()
-        }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
-        val result = sut.getCoverageDataFromCSV()
-        assertThatThrownBy { result.toList() }
-                .isInstanceOf(ValidationException::class.java)
     }
 
     @Test
@@ -69,23 +56,18 @@ class PopulatingCoverageTests : MontaguTests()
 
     private val normalCSVDataString = """
 "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    "both", 100, 78.8
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    "Female", 100, 65.5
-"""
-
-    private val invalidSupportLevelCSVDataString = """
-"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "withsupport",  "2020",         1,     10,    "both", 100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "True",  "2020",         1,     10,    "both", 100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "false",  "2021",         1,      10,    "Female", 100, 65.5
 """
 
     private val invalidActivityTypeCSVDataString = """
 "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
-   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    100, "both", 78.8
+   "HepB_BD",   "AFG",    "a campaign",     "true",  "2020",         1,     10,    100, "both", 78.8
 """
 
     private val invalidHeadersCSVDataString = """
 "vaccine", "country code", "activity", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
-   "HepB_BD",   "AFG",    "a campaign",     "with",  "2020",         1,     10,    "both", 100, 78.8
+   "HepB_BD",   "AFG",    "a campaign",     "true",  "2020",         1,     10,    "both", 100, 78.8
 """
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/GetCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/GetCoverageTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.api.tests.logic
+package org.vaccineimpact.api.tests.logic.CoverageLogic
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -24,7 +24,7 @@ import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.math.BigDecimal
 import java.util.*
 
-class CoverageLogicTests : MontaguTests()
+class GetCoverageTests : MontaguTests()
 {
     private val fakeScenario = Scenario("sId", "scDesc", "disease", listOf("t-1"))
     private val fakeTouchstoneVersion = TouchstoneVersion("touchstone-1", "touchstone", 1,

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -16,15 +16,13 @@ class SaveCoverageTests : MontaguTests()
 {
     private val testSequence = sequenceOf(
             // each of these belongs to a new coverage set
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2022, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT, 2023, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT, 2024, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
-            CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
-            CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN,  true, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, false, 2022, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, true, 2026, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
 
             // belongs to same coverage set as the first row
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, GenderEnum.BOTH, 100F, 78.8F)
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, true, 2021, 1, 10, GenderEnum.BOTH, 100F, 78.8F)
     )
 
     @Test
@@ -37,11 +35,9 @@ class SaveCoverageTests : MontaguTests()
         sut.saveCoverageForTouchstone("t1", testSequence)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITH)
-        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT)
-        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.ROUTINE, GAVISupportLevel.WITH)
-        verify(mockRepo, Times(7)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(5)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any(), any(), any())
         verify(mockRepo).saveCoverageForTouchstone(any(), any())
         verify(mockRepo).getGenders()
         verifyNoMoreInteractions(mockRepo)
@@ -62,8 +58,18 @@ class SaveCoverageTests : MontaguTests()
                 BigDecimal(1),
                 BigDecimal(10),
                 111,
+                true,
                 100F.toBigDecimal(),
                 78.8.toBigDecimal())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(1,
+                "AFG",
+                2022,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                false,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
     }
 
     @Test
@@ -73,16 +79,16 @@ class SaveCoverageTests : MontaguTests()
             on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
             on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 1
             on { createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 2
-            on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT) } doReturn 3
-            on { createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT) } doReturn 4
+            on { createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 3
+            on { createCoverageSet("t1", "HepB", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 4
         }
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
         sut.saveCoverageForTouchstone("t1", testSequence)
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2020), any(), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2021), any(), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(2), any(), eq(2022), any(), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(3), any(), eq(2023), any(), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2024), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2020), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2021), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(2), any(), eq(2022), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(3), any(), eq(2025), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2026), any(), any(), any(), any(), any(), any())
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.models.ActivityType
 import org.vaccineimpact.api.models.CoverageIngestionRow
 import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.models.GenderEnum
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.math.BigDecimal
 
@@ -15,21 +16,23 @@ class SaveCoverageTests : MontaguTests()
 {
     private val testSequence = sequenceOf(
             // each of these belongs to a new coverage set
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2022, 1, 10, 100F, 65.5F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT, 2023, 1, 10, 100F, 65.5F),
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT, 2024, 1, 10, 100F, 65.5F),
-            CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2025, 1, 10, 100F, 65.5F),
-            CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2025, 1, 10, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2022, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT, 2023, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT, 2024, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
 
             // belongs to same coverage set as the first row
-            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, 100F, 78.8F)
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, GenderEnum.BOTH, 100F, 78.8F)
     )
 
     @Test
     fun `new coverage sets are created as needed`()
     {
-        val mockRepo = mock<TouchstoneRepository>()
+        val mockRepo = mock<TouchstoneRepository>() {
+            on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
+        }
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
         sut.saveCoverageForTouchstone("t1", testSequence)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
@@ -38,8 +41,9 @@ class SaveCoverageTests : MontaguTests()
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
         verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.ROUTINE, GAVISupportLevel.WITH)
-        verify(mockRepo, Times(7)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(7)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any(), any())
         verify(mockRepo).saveCoverageForTouchstone(any(), any())
+        verify(mockRepo).getGenders()
         verifyNoMoreInteractions(mockRepo)
     }
 
@@ -47,6 +51,7 @@ class SaveCoverageTests : MontaguTests()
     fun `rows are created correctly`()
     {
         val mockRepo = mock<TouchstoneRepository> {
+            on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
             on { createCoverageSet(any(), any(), any(), any()) } doReturn 1
         }
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
@@ -56,6 +61,7 @@ class SaveCoverageTests : MontaguTests()
                 2020,
                 BigDecimal(1),
                 BigDecimal(10),
+                111,
                 100F.toBigDecimal(),
                 78.8.toBigDecimal())
     }
@@ -64,6 +70,7 @@ class SaveCoverageTests : MontaguTests()
     fun `coverage records are saved to correct coverage set`()
     {
         val mockRepo = mock<TouchstoneRepository> {
+            on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
             on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 1
             on { createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 2
             on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT) } doReturn 3
@@ -71,11 +78,11 @@ class SaveCoverageTests : MontaguTests()
         }
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
         sut.saveCoverageForTouchstone("t1", testSequence)
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2020), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2021), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(2), any(), eq(2022), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(3), any(), eq(2023), any(), any(), any(), any())
-        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2024), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2020), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2021), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(2), any(), eq(2022), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(3), any(), eq(2023), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2024), any(), any(), any(), any(), any())
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.api.models.ActivityType
 import org.vaccineimpact.api.models.CoverageIngestionRow
 import org.vaccineimpact.api.models.GAVISupportLevel
 import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.math.BigDecimal
 
 class SaveCoverageTests : MontaguTests()
 {
@@ -42,6 +43,22 @@ class SaveCoverageTests : MontaguTests()
         verifyNoMoreInteractions(mockRepo)
     }
 
+    @Test
+    fun `rows are created correctly`()
+    {
+        val mockRepo = mock<TouchstoneRepository> {
+            on { createCoverageSet(any(), any(), any(), any()) } doReturn 1
+        }
+        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
+        sut.saveCoverageForTouchstone("t1", testSequence)
+        verify(mockRepo, Times(1)).newCoverageRowRecord(1,
+                "AFG",
+                2020,
+                BigDecimal(1),
+                BigDecimal(10),
+                100F.toBigDecimal(),
+                78.8.toBigDecimal())
+    }
 
     @Test
     fun `coverage records are saved to correct coverage set`()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -1,0 +1,64 @@
+package org.vaccineimpact.api.tests.logic.CoverageLogic
+
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Test
+import org.mockito.internal.verification.Times
+import org.vaccineimpact.api.app.logic.RepositoriesCoverageLogic
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
+import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.CoverageIngestionRow
+import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.test_helpers.MontaguTests
+
+class SaveCoverageTests : MontaguTests()
+{
+    private val testSequence = sequenceOf(
+            // each of these belongs to a new coverage set
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2020, 1, 10, 100F, 78.8F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2022, 1, 10, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT, 2023, 1, 10, 100F, 65.5F),
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT, 2024, 1, 10, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2025, 1, 10, 100F, 65.5F),
+            CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, GAVISupportLevel.WITH, 2025, 1, 10, 100F, 65.5F),
+
+            // belongs to same coverage set as the first row
+            CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, 2021, 1, 10, 100F, 78.8F)
+    )
+
+    @Test
+    fun `new coverage sets are created as needed`()
+    {
+        val mockRepo = mock<TouchstoneRepository>()
+        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
+        sut.saveCoverageForTouchstone("t1", testSequence)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITH)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH)
+        verify(mockRepo, Times(1)).createCoverageSet("t1", "HepB", ActivityType.ROUTINE, GAVISupportLevel.WITH)
+        verify(mockRepo, Times(7)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any())
+        verify(mockRepo).saveCoverageForTouchstone(any(), any())
+        verifyNoMoreInteractions(mockRepo)
+    }
+
+
+    @Test
+    fun `coverage records are saved to correct coverage set`()
+    {
+        val mockRepo = mock<TouchstoneRepository> {
+            on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 1
+            on { createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 2
+            on { createCoverageSet("t1", "HepB_BD", ActivityType.CAMPAIGN, GAVISupportLevel.WITHOUT) } doReturn 3
+            on { createCoverageSet("t1", "HepB_BD", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT) } doReturn 4
+        }
+        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
+        sut.saveCoverageForTouchstone("t1", testSequence)
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2020), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(1), any(), eq(2021), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(2), any(), eq(2022), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(3), any(), eq(2023), any(), any(), any(), any())
+        verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2024), any(), any(), any(), any())
+    }
+
+}

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -80,9 +80,9 @@ class PopulateCoverageTests : CoverageTests()
     }
 
     private val csvData = """
-"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    100, 78.8
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    100, 65.5
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    "female", 100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    "female", 100, 65.5
 """
 
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -69,7 +69,7 @@ class PopulateCoverageTests : CoverageTests()
     private fun verifyCorrectRows()
     {
         JooqContext().use {
-            val expectedNumberOfSets = 18 * 2 * 2 // vaccines, activities, support levels
+            val expectedNumberOfSets = 18 * 2 // vaccines, activities
             val coverageSets = it.dsl.selectFrom(COVERAGE_SET).fetch()
             assertThat(coverageSets.count()).isEqualTo(expectedNumberOfSets)
 
@@ -81,8 +81,8 @@ class PopulateCoverageTests : CoverageTests()
 
     private val csvData = """
 "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    "female", 100, 78.8
-   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    "female", 100, 65.5
+   "HepB_BD",   "AFG",    "campaign",     "true",  "2020",         1,     10,    "female", 100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "true",  "2021",         1,      10,    "female", 100, 65.5
 """
 
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -16,7 +16,7 @@ import org.vaccineimpact.api.validateSchema.JSONValidator
 import spark.route.HttpMethod
 import java.io.File
 
-class UploadCoverageTests : CoverageTests()
+class PopulateCoverageTests : CoverageTests()
 {
     private val requiredPermissions = PermissionSet("*/coverage.write")
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -32,7 +32,10 @@ class PopulateCoverageTests : CoverageTests()
             requiredPermissions
         } andCheckHasStatus 200..299
 
-        verifyCorrectRows()
+        JooqContext().use {
+            val coverage = it.dsl.selectFrom(COVERAGE).fetch()
+            assertThat(coverage.count()).isEqualTo(2)
+        }
     }
 
     @Test

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -23,14 +23,11 @@ class PopulateCoverageTests : CoverageTests()
     @Test
     fun `can populate coverage`()
     {
-        // this data is somewhat realistically sized - in practice will likely be fewer vaccines,
-        // but for some vaccines more gavi support levels
-        val data = File("coverage.csv").readText()
         setup()
         validate("/touchstones/$touchstoneVersionId/coverage/", method = HttpMethod.post) withRequestSchema {
             CSVSchema("CoverageIngestion")
         } sending {
-           data
+           csvData
         } withPermissions {
             requiredPermissions
         } andCheckHasStatus 200..299
@@ -78,4 +75,11 @@ class PopulateCoverageTests : CoverageTests()
             assertThat(coverage.count()).isEqualTo(expectedNumberOfRows)
         }
     }
+
+    private val csvData = """
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "target", "coverage"
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2020",         1,     10,    100, 78.8
+   "HepB_BD",   "AFG",    "campaign",     "with",  "2021",         1,      10,    100, 65.5
+"""
+
 }

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/UploadCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/UploadCoverageTests.kt
@@ -1,0 +1,78 @@
+package org.vaccineimpact.api.blackboxTests.tests.Coverage
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.joda.time.DateTime
+import org.junit.Test
+import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
+import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
+import org.vaccineimpact.api.db.JooqContext
+import org.vaccineimpact.api.db.Tables.COVERAGE
+import org.vaccineimpact.api.db.direct.addCoverageSet
+import org.vaccineimpact.api.db.direct.addTouchstoneVersion
+import org.vaccineimpact.api.models.permissions.PermissionSet
+import org.vaccineimpact.api.validateSchema.JSONValidator
+import java.io.File
+
+class UploadCoverageTests : CoverageTests()
+{
+    val minimumPermissions = PermissionSet("*/can-login", "*/scenarios.read", "*/coverage.read")
+
+    @Test
+    fun `can populate coverage`()
+    {
+        JooqContext().use { db ->
+
+            db.addTouchstoneVersion("touchstone", 1, "description", "open", addTouchstone = true)
+            var i = 0
+            listOf("HepB_BD", "HepB", "Hib3", "HPV", "JE", "MCV1", "MCV2",
+                    "Measles", "MenA", "PCV3", "Rota", "Rubella", "YF",
+                    "DTP3", "RCV2", "HepB_BD_home", "Cholera", "Typhoid")
+                    .forEach {
+                        db.addCoverageSet(
+                                touchstoneVersionId,
+                                "coverage set name",
+                                it,
+                                "without",
+                                "routine",
+                                coverageSetId + i,
+                                addVaccine = true)
+                        i++
+                        db.addCoverageSet(
+                                touchstoneVersionId,
+                                "coverage set name",
+                                it,
+                                "with",
+                                "routine",
+                                coverageSetId + i)
+                        i++
+                        db.addCoverageSet(
+                                touchstoneVersionId,
+                                "coverage set name",
+                                it,
+                                "without",
+                                "campaign",
+                                coverageSetId + i)
+                        i++
+                        db.addCoverageSet(
+                                touchstoneVersionId,
+                                "coverage set name",
+                                it,
+                                "with",
+                                "campaign",
+                                coverageSetId + i)
+                        i++
+                    }
+        }
+        val token = TestUserHelper.setupTestUserAndGetToken(minimumPermissions, includeCanLogin = true)
+        val file = File("coverage.csv")
+        val response = RequestHelper().postFile("/touchstones/$touchstoneVersionId/coverage/", file.readText(), token = token)
+        JSONValidator().validateSuccess(response.text)
+
+        JooqContext().use {
+            val coverage = it.dsl.selectFrom(COVERAGE).fetch()
+            val expectedNumberOfRows = 18 * 11 * 2 * 2 * 73 // vaccines, years, activities, support levels, countries
+            assertThat(coverage.count()).isEqualTo(expectedNumberOfRows)
+        }
+    }
+
+}

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/UploadCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/UploadCoverageTests.kt
@@ -1,14 +1,14 @@
 package org.vaccineimpact.api.blackboxTests.tests.Coverage
 
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
-import org.joda.time.DateTime
 import org.junit.Test
 import org.vaccineimpact.api.blackboxTests.helpers.RequestHelper
 import org.vaccineimpact.api.blackboxTests.helpers.TestUserHelper
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables.COVERAGE
-import org.vaccineimpact.api.db.direct.addCoverageSet
+import org.vaccineimpact.api.db.Tables.COVERAGE_SET
 import org.vaccineimpact.api.db.direct.addTouchstoneVersion
+import org.vaccineimpact.api.db.direct.addVaccine
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.validateSchema.JSONValidator
 import java.io.File
@@ -23,44 +23,11 @@ class UploadCoverageTests : CoverageTests()
         JooqContext().use { db ->
 
             db.addTouchstoneVersion("touchstone", 1, "description", "open", addTouchstone = true)
-            var i = 0
             listOf("HepB_BD", "HepB", "Hib3", "HPV", "JE", "MCV1", "MCV2",
                     "Measles", "MenA", "PCV3", "Rota", "Rubella", "YF",
                     "DTP3", "RCV2", "HepB_BD_home", "Cholera", "Typhoid")
                     .forEach {
-                        db.addCoverageSet(
-                                touchstoneVersionId,
-                                "coverage set name",
-                                it,
-                                "without",
-                                "routine",
-                                coverageSetId + i,
-                                addVaccine = true)
-                        i++
-                        db.addCoverageSet(
-                                touchstoneVersionId,
-                                "coverage set name",
-                                it,
-                                "with",
-                                "routine",
-                                coverageSetId + i)
-                        i++
-                        db.addCoverageSet(
-                                touchstoneVersionId,
-                                "coverage set name",
-                                it,
-                                "without",
-                                "campaign",
-                                coverageSetId + i)
-                        i++
-                        db.addCoverageSet(
-                                touchstoneVersionId,
-                                "coverage set name",
-                                it,
-                                "with",
-                                "campaign",
-                                coverageSetId + i)
-                        i++
+                        db.addVaccine(it)
                     }
         }
         val token = TestUserHelper.setupTestUserAndGetToken(minimumPermissions, includeCanLogin = true)
@@ -69,9 +36,15 @@ class UploadCoverageTests : CoverageTests()
         JSONValidator().validateSuccess(response.text)
 
         JooqContext().use {
+            val expectedNumberOfSets = 18 * 2 * 2 // vaccines, activities, support levels
+            val coverageSets = it.dsl.selectFrom(COVERAGE_SET).fetch()
+            assertThat(coverageSets.count()).isEqualTo(expectedNumberOfSets)
+
             val coverage = it.dsl.selectFrom(COVERAGE).fetch()
-            val expectedNumberOfRows = 18 * 11 * 2 * 2 * 73 // vaccines, years, activities, support levels, countries
+            val expectedNumberOfRows = expectedNumberOfSets * 11 * 73 // sets, years, countries
             assertThat(coverage.count()).isEqualTo(expectedNumberOfRows)
+
+
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -125,6 +125,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
                     BigDecimal(0),
                     BigDecimal(5),
                     1,
+                    true,
                     BigDecimal(100),
                     BigDecimal(200))
         }
@@ -137,6 +138,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
         assertThat(result.target).isEqualTo(BigDecimal(100))
         assertThat(result.coverage).isEqualTo(BigDecimal(200))
         assertThat(result.gender).isEqualTo(1)
+        assertThat(result.gaviSupport).isEqualTo(true)
     }
 
     @Test
@@ -154,6 +156,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
                     BigDecimal(0),
                     BigDecimal(5),
                     1,
+                    true,
                     BigDecimal(100),
                     BigDecimal(200))
             it.saveCoverageForTouchstone("t1", listOf(row))
@@ -170,6 +173,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
         assertThat(result[COVERAGE.TARGET]).isEqualTo(BigDecimal(100))
         assertThat(result[COVERAGE.COVERAGE_]).isEqualTo(BigDecimal(200))
         assertThat(result[COVERAGE.GENDER]).isEqualTo(1)
+        assertThat(result[COVERAGE.GAVI_SUPPORT]).isEqualTo(true)
     }
 
     @Test

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -1,7 +1,9 @@
 package org.vaccineimpact.api.databaseTests.tests.touchstoneRepository
 
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy
 import org.junit.Test
+import org.vaccineimpact.api.app.errors.UnknownObjectError
 import org.vaccineimpact.api.db.Tables.COVERAGE
 import org.vaccineimpact.api.db.Tables.COVERAGE_SET
 import org.vaccineimpact.api.db.direct.addCoverageSet
@@ -31,6 +33,19 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
             assertThat(set[COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("routine")
             assertThat(set[COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("without")
             assertThat(set[COVERAGE_SET.NAME]).isEqualTo("v1: v1, without, routine")
+        }
+    }
+
+    @Test
+    fun `create coverage set will throw unknown object error for invalid vaccines`()
+    {
+        withDatabase {
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+        }
+        withRepo {
+            assertThatThrownBy {
+                it.createCoverageSet("t-1", "v1", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT)
+            }.isInstanceOf(UnknownObjectError::class.java)
         }
     }
 

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -171,4 +171,15 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
         assertThat(result[COVERAGE.COVERAGE_]).isEqualTo(BigDecimal(200))
         assertThat(result[COVERAGE.GENDER]).isEqualTo(1)
     }
+
+    @Test
+    fun `can get genders`()
+    {
+        val genders = withRepo {
+            it.getGenders()
+        }
+        assertThat(genders[GenderEnum.BOTH]).isEqualTo(1)
+        assertThat(genders[GenderEnum.MALE]).isEqualTo(2)
+        assertThat(genders[GenderEnum.FEMALE]).isEqualTo(3)
+    }
 }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -1,0 +1,154 @@
+package org.vaccineimpact.api.databaseTests.tests.touchstoneRepository
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.Test
+import org.vaccineimpact.api.db.Tables.COVERAGE
+import org.vaccineimpact.api.db.Tables.COVERAGE_SET
+import org.vaccineimpact.api.db.direct.addCoverageSet
+import org.vaccineimpact.api.db.direct.addTouchstoneVersion
+import org.vaccineimpact.api.db.direct.addVaccine
+import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.GAVISupportLevel
+import java.math.BigDecimal
+
+class SaveCoverageTests : TouchstoneRepositoryTests()
+{
+    @Test
+    fun `can create coverage set`()
+    {
+        withDatabase {
+            it.addVaccine("v1")
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+        }
+        withRepo {
+            it.createCoverageSet("t-1", "v1", ActivityType.ROUTINE, GAVISupportLevel.WITHOUT)
+        }
+        withDatabase {
+            val set = it.dsl.selectFrom(COVERAGE_SET)
+                    .fetchOne()
+            assertThat(set[COVERAGE_SET.TOUCHSTONE]).isEqualTo("t-1")
+            assertThat(set[COVERAGE_SET.VACCINE]).isEqualTo("v1")
+            assertThat(set[COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("routine")
+            assertThat(set[COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("without")
+            assertThat(set[COVERAGE_SET.NAME]).isEqualTo("v1: v1, without, routine")
+        }
+    }
+
+    @Test
+    fun `can create coverage set for all activity types`()
+    {
+        withDatabase {
+            it.addVaccine("v1")
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+        }
+        withRepo { repo ->
+            listOf(ActivityType.ROUTINE, ActivityType.CAMPAIGN, ActivityType.CAMPAIGN_REACTIVE, ActivityType.NONE)
+                    .forEach {
+                        repo.createCoverageSet("t-1", "v1", it, GAVISupportLevel.WITHOUT)
+                    }
+        }
+        withDatabase {
+            val set = it.dsl.selectFrom(COVERAGE_SET)
+                    .fetch()
+            assertThat(set[0][COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("routine")
+            assertThat(set[1][COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("campaign")
+            assertThat(set[2][COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("campaign-reactive")
+            assertThat(set[3][COVERAGE_SET.ACTIVITY_TYPE]).isEqualTo("none")
+        }
+    }
+
+    @Test
+    fun `can create coverage set for all support levels`()
+    {
+        withDatabase {
+            it.addVaccine("v1")
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+        }
+        withRepo { repo ->
+            listOf(GAVISupportLevel.WITH,
+                    GAVISupportLevel.WITHOUT,
+                    GAVISupportLevel.BESTCASE,
+                    GAVISupportLevel.BESTMINUS,
+                    GAVISupportLevel.GAVI_OPTIMISTIC,
+                    GAVISupportLevel.CONTINUE,
+                    GAVISupportLevel.HIGH,
+                    GAVISupportLevel.LOW,
+                    GAVISupportLevel.HOLD2010,
+                    GAVISupportLevel.INTENSIFIED,
+                    GAVISupportLevel.NONE,
+                    GAVISupportLevel.STATUS_QUO)
+                    .forEach {
+                        repo.createCoverageSet("t-1", "v1", ActivityType.NONE, it)
+                    }
+        }
+        withDatabase {
+            val set = it.dsl.selectFrom(COVERAGE_SET)
+                    .fetch()
+            assertThat(set[0][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("with")
+            assertThat(set[1][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("without")
+            assertThat(set[2][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("bestcase")
+            assertThat(set[3][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("bestminus")
+            assertThat(set[4][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("gavi_optimistic")
+            assertThat(set[5][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("continue")
+            assertThat(set[6][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("high")
+            assertThat(set[7][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("low")
+            assertThat(set[8][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("hold2010")
+            assertThat(set[9][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("intensified")
+            assertThat(set[10][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("none")
+            assertThat(set[11][COVERAGE_SET.GAVI_SUPPORT_LEVEL]).isEqualTo("status_quo")
+        }
+    }
+
+    @Test
+    fun `can create new coverage row record`()
+    {
+        val result = withRepo {
+            it.newCoverageRowRecord(1,
+                    "AFG",
+                    2020,
+                    BigDecimal(0),
+                    BigDecimal(5),
+                    BigDecimal(100),
+                    BigDecimal(200))
+        }
+
+        assertThat(result.coverageSet).isEqualTo(1)
+        assertThat(result.country).isEqualTo("AFG")
+        assertThat(result.year).isEqualTo(2020)
+        assertThat(result.ageFrom.toInt()).isEqualTo(0)
+        assertThat(result.ageTo.toInt()).isEqualTo(5)
+        assertThat(result.target).isEqualTo(BigDecimal(100))
+        assertThat(result.coverage).isEqualTo(BigDecimal(200))
+    }
+
+    @Test
+    fun `can persist coverage rows to db`()
+    {
+        withDatabase {
+            it.addVaccine("v1")
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+            it.addCoverageSet("t-1", "name", "v1", "with", "routine", 11)
+        }
+        withRepo {
+            val row = it.newCoverageRowRecord(11,
+                    "AFG",
+                    2020,
+                    BigDecimal(0),
+                    BigDecimal(5),
+                    BigDecimal(100),
+                    BigDecimal(200))
+            it.saveCoverageForTouchstone("t1", listOf(row))
+        }
+        val result = withDatabase {
+            it.dsl.selectFrom(COVERAGE)
+                    .fetchOne()
+        }
+        assertThat(result[COVERAGE.COVERAGE_SET]).isEqualTo(11)
+        assertThat(result[COVERAGE.COUNTRY]).isEqualTo("AFG")
+        assertThat(result[COVERAGE.YEAR]).isEqualTo(2020)
+        assertThat(result[COVERAGE.AGE_FROM].toInt()).isEqualTo(0)
+        assertThat(result[COVERAGE.AGE_TO].toInt()).isEqualTo(5)
+        assertThat(result[COVERAGE.TARGET]).isEqualTo(BigDecimal(100))
+        assertThat(result[COVERAGE.COVERAGE_]).isEqualTo(BigDecimal(200))
+    }
+}

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.api.db.direct.addTouchstoneVersion
 import org.vaccineimpact.api.db.direct.addVaccine
 import org.vaccineimpact.api.models.ActivityType
 import org.vaccineimpact.api.models.GAVISupportLevel
+import org.vaccineimpact.api.models.GenderEnum
 import java.math.BigDecimal
 
 class SaveCoverageTests : TouchstoneRepositoryTests()
@@ -123,6 +124,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
                     2020,
                     BigDecimal(0),
                     BigDecimal(5),
+                    1,
                     BigDecimal(100),
                     BigDecimal(200))
         }
@@ -134,6 +136,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
         assertThat(result.ageTo.toInt()).isEqualTo(5)
         assertThat(result.target).isEqualTo(BigDecimal(100))
         assertThat(result.coverage).isEqualTo(BigDecimal(200))
+        assertThat(result.gender).isEqualTo(1)
     }
 
     @Test
@@ -150,6 +153,7 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
                     2020,
                     BigDecimal(0),
                     BigDecimal(5),
+                    1,
                     BigDecimal(100),
                     BigDecimal(200))
             it.saveCoverageForTouchstone("t1", listOf(row))
@@ -165,5 +169,6 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
         assertThat(result[COVERAGE.AGE_TO].toInt()).isEqualTo(5)
         assertThat(result[COVERAGE.TARGET]).isEqualTo(BigDecimal(100))
         assertThat(result[COVERAGE.COVERAGE_]).isEqualTo(BigDecimal(200))
+        assertThat(result[COVERAGE.GENDER]).isEqualTo(1)
     }
 }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -36,6 +36,7 @@ class Deserializer
             Int::class.createType() -> raw.toInt()
             Short::class.createType() -> raw.toShort()
             Float::class.createType() -> raw.toFloat()
+            Boolean::class.createType() -> raw.toBoolean()
             ActivityType::class.createType() -> ActivityType.valueOf(raw.toUpperCase())
             GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.toUpperCase())
             GenderEnum::class.createType() -> GenderEnum.valueOf(raw.toUpperCase())


### PR DESCRIPTION
~~Contains commits from https://github.com/vimc/montagu-api/pull/437 (needs the base of the PR pointed back to master after that is merged)~~

This PR adds an endpoint, `POST touchstones/touchstone-id/coverage`, locked down to the `coverage.write` permission. It accepts CSV data directly in the request body or as a Multipart file.

For each unique combination of vaccine, activity type and support level, it adds a new coverage set and populates it.

The validation that we get so far:
* vaccine names match those in our db
* activity types match those in our db

Validation that we do *not* get yet:
* verify the correct numbers of years and countries are provided for a coverage set
* accept vaccines other than ones in our database (i.e. does not yet intepret Pentavalent = Hib3 +HepB3 + DTP3, or MR = Measles + Rubella)