### PR TITLE
mrc-4347 Handle special vaccine program values in vaccine column during coverage import

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -159,7 +159,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
         return when (vaccine.toUpperCase())
         {
             "PENTA", "PENTAVALENT" -> listOf("Hib3", "HepB", "DTP3")
-            "MR1" -> listOf("MCV1", "RCV1")
+            "MR1" -> listOf("MCV1", "Rubella")
             "MR2" -> listOf("MCV2", "RCV2")
             else -> listOf(vaccine)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -155,7 +155,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
 
     private fun mapVaccineForCoverageSet(vaccine: String) : List<String>
     {
-        // GAVI may provide vaccine programs rather tha individual vaccines in some coverage rows
+        // GAVI may provide combination vaccines rather than individual vaccines in some coverage rows
         return when (vaccine.toUpperCase())
         {
             "PENTA", "PENTAVALENT" -> listOf("Hib3", "HepB", "DTP3")

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -91,4 +91,133 @@ class SaveCoverageTests : MontaguTests()
         verify(mockRepo, Times(1)).newCoverageRowRecord(eq(4), any(), eq(2026), any(), any(), any(), any(), any(), any())
     }
 
+    @Test
+    fun `Vaccine programs are mapped to vaccines correctly`()
+    {
+        val vaxProgSequence = sequenceOf(
+                CoverageIngestionRow("Penta", "AFG", ActivityType.CAMPAIGN,  true, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
+                CoverageIngestionRow("pentavalent", "AFG", ActivityType.CAMPAIGN, false, 2022, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+                CoverageIngestionRow("mr1", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F),
+                CoverageIngestionRow("MR2", "AFG", ActivityType.ROUTINE, true, 2026, 1, 10, GenderEnum.BOTH, 100F, 65.5F)
+        )
+
+        val mockRepo = mock<TouchstoneRepository> {
+            on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
+            on { createCoverageSet("t1", "Hib3", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 1
+            on { createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 2
+            on { createCoverageSet("t1", "DTP3", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 3
+            on { createCoverageSet("t1", "MCV1", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 4
+            on { createCoverageSet("t1", "RCV1", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 5
+            on { createCoverageSet("t1", "MCV2", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 6
+            on { createCoverageSet("t1", "RCV2", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 7
+        }
+
+        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock())
+        sut.saveCoverageForTouchstone("t1", vaxProgSequence)
+
+        //Penta
+        verify(mockRepo, Times(1)).newCoverageRowRecord(1,
+                "AFG",
+                2020,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                78.8.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(2,
+                "AFG",
+                2020,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                78.8.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(3,
+                "AFG",
+                2020,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                78.8.toBigDecimal())
+
+        //pentavalent
+        verify(mockRepo, Times(1)).newCoverageRowRecord(1,
+                "AFG",
+                2022,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                false,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(2,
+                "AFG",
+                2022,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                false,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(3,
+                "AFG",
+                2022,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                false,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        //mr1
+        verify(mockRepo, Times(1)).newCoverageRowRecord(4,
+                "AFG",
+                2025,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(5,
+                "AFG",
+                2025,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        //MR2
+        verify(mockRepo, Times(1)).newCoverageRowRecord(6,
+                "AFG",
+                2026,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+        verify(mockRepo, Times(1)).newCoverageRowRecord(7,
+                "AFG",
+                2026,
+                BigDecimal(1),
+                BigDecimal(10),
+                111,
+                true,
+                100F.toBigDecimal(),
+                65.5.toBigDecimal())
+
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -107,7 +107,7 @@ class SaveCoverageTests : MontaguTests()
             on { createCoverageSet("t1", "HepB", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 2
             on { createCoverageSet("t1", "DTP3", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 3
             on { createCoverageSet("t1", "MCV1", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 4
-            on { createCoverageSet("t1", "RCV1", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 5
+            on { createCoverageSet("t1", "Rubella", ActivityType.CAMPAIGN, GAVISupportLevel.WITH) } doReturn 5
             on { createCoverageSet("t1", "MCV2", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 6
             on { createCoverageSet("t1", "RCV2", ActivityType.ROUTINE, GAVISupportLevel.WITH) } doReturn 7
         }


### PR DESCRIPTION
The ticket refers to 'HepB3' but from the script I think it should just be 'HepB'
https://github.com/vimc/montagu-imports/blob/4624ca785525ae20808bf8918cd0bbfce93376fa/2020-03-10_op17_201912gavi_1/R/fun_transform.R#L95

The script also appears to expect 'Pentavelent' but from some of the ticket threads it seemed that 'Penta' might be expected too. 
I've made the checks case insensitive. 

UPDATE: clarified a couple of things with Xiang: https://teams.microsoft.com/l/message/19:1ed98499f20b43f7a7d3b25fb00f4fd8@thread.tacv2/1604396049906?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=993c3b2e-8a31-496a-a485-eb466f411c31&parentMessageId=1604396049906&teamName=VIMC&channelName=Science&createdTime=1604396049906 
'Rubella' rather than 'RCV1', and 'HepB' rather than 'HepB3'