### PR TITLE
vimc-4238 add utc and scenario to celery task

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/BurdenEstimates/BaseBurdenEstimateController.kt
@@ -41,7 +41,7 @@ abstract class BaseBurdenEstimateController(context: ActionContext,
         return try
         {
             estimatesLogic.closeBurdenEstimateSet(setId, groupId, touchstoneVersionId, scenarioId)
-            taskQueueClient.runDiagnosticReport(groupId, disease, touchstoneVersionId, uploaderEmail)
+            taskQueueClient.runDiagnosticReport(groupId, disease, touchstoneVersionId, scenarioId, uploaderEmail)
             okayResponse().asResult()
         }
         catch (error: MissingRowsError)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/clients/CeleryClientTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/clients/CeleryClientTests.kt
@@ -18,6 +18,7 @@ class CeleryClientTests : MontaguTests()
     {
         val client = CeleryClient()
         val task = client.runDiagnosticReport("testGroup", "testDisease", "testTouchstone",
+                "testScenario",
                 "test.user@example.com")
 
         val result = task.get().mapValues { DiagnosticReportTaskResult(it.value["published"] ?: false) }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/BurdenEstimatesControllerTests.kt
@@ -137,7 +137,7 @@ class BurdenEstimatesControllerTests : BurdenEstimateControllerTestsBase()
                 .closeBurdenEstimateSet()
         verify(logic).closeBurdenEstimateSet(1, groupId, touchstoneVersionId, scenarioId)
         verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId,
-                userEmail)
+                scenarioId, userEmail)
         verifyValidResponsibilityPathChecks(mockResponsibilitiesLogic, mockContext)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/PopulatingEstimatesTests.kt
@@ -46,7 +46,7 @@ class PopulatingEstimatesTests : UploadBurdenEstimatesControllerTests()
         assertThat(result.data).isEqualTo("OK")
         verify(logic).populateBurdenEstimateSet(eq(1), eq(groupId), eq(touchstoneVersionId), eq(scenarioId), any(), eq("file.csv"))
         verify(logic).closeBurdenEstimateSet(1, groupId, touchstoneVersionId, scenarioId)
-        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId, userEmail)
+        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId, scenarioId, userEmail)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/BurdenEstimates/UploadBurdenEstimatesControllerTests.kt
@@ -219,7 +219,7 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
 
         val fakeCache = makeFakeCacheWithChunkedFile("uid", uploadFinished = true)
         val sut = BurdenEstimateUploadController(mockContext, mock(), mock(),
-                mock(), mock(), mock(),mock(), fakeCache)
+                mock(), mock(), mock(), mock(), fakeCache)
 
         assertThatThrownBy { sut.uploadBurdenEstimateFile() }
                 .isInstanceOf(BadRequest::class.java)
@@ -356,7 +356,7 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
                 groupId, touchstoneVersionId, scenarioId)
         verifyValidResponsibilityPathChecks(responsibilitiesLogic, mockContext)
         verify(mockTaskQueueClient, timesExpected).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId,
-                userEmail)
+                scenarioId, userEmail)
     }
 
     protected fun mockActionContext(user: String = username, keepOpen: String? = null): ActionContext
@@ -421,7 +421,8 @@ open class UploadBurdenEstimatesControllerTests : BurdenEstimateControllerTestsB
                 },
                 anyOrNull()
         )
-        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId, uploaderEmail)
+        verify(mockTaskQueueClient).runDiagnosticReport(groupId, diseaseId, touchstoneVersionId,
+                scenarioId, uploaderEmail)
         verifyValidResponsibilityPathChecks(responsibilitiesLogic, actionContext)
     }
 


### PR DESCRIPTION
The build is error-ing because of the updates to the celery task. This just adds UTC time and scenario id to the task so that it passes. I'm not totally sure if scenario id is what's wanted, or scenario description, but this gets the build passing for now at least.