### PR TITLE
vimc-4365 endpoint to get coverage upload template

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/Router.kt
@@ -59,14 +59,25 @@ class Router(val config: RouteConfig,
 
         logger.info("Mapping $fullUrl to ${endpoint.actionName} on ${endpoint.controller.simpleName}")
 
-        when (endpoint.method)
+        if (contentType.contains("json"))
         {
-            HttpMethod.get -> Spark.get(fullUrl, contentType, route, this::transform)
-            HttpMethod.post -> Spark.post(fullUrl, contentType, route, this::transform)
-            HttpMethod.put -> Spark.put(fullUrl, contentType, route, this::transform)
-            HttpMethod.patch -> Spark.patch(fullUrl, contentType, route, this::transform)
-            HttpMethod.delete -> Spark.delete(fullUrl, contentType, route, this::transform)
-            else -> throw UnsupportedValueException(endpoint.method)
+            when (endpoint.method)
+            {
+                HttpMethod.get -> Spark.get(fullUrl, contentType, route, this::transform)
+                HttpMethod.post -> Spark.post(fullUrl, contentType, route, this::transform)
+                HttpMethod.put -> Spark.put(fullUrl, contentType, route, this::transform)
+                HttpMethod.patch -> Spark.patch(fullUrl, contentType, route, this::transform)
+                HttpMethod.delete -> Spark.delete(fullUrl, contentType, route, this::transform)
+                else -> throw UnsupportedValueException(endpoint.method)
+            }
+        }
+        else
+        {
+            when (endpoint.method)
+            {
+                HttpMethod.get -> Spark.get(fullUrl, contentType, route)
+                else -> throw UnsupportedValueException(endpoint.method)
+            }
         }
 
         endpoint.additionalSetup(fullUrl, webTokenHelper, repositoryFactory)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
@@ -37,7 +37,12 @@ object CoverageRouteConfig : RouteConfig
 
             Endpoint("/touchstones/:touchstone-version-id/coverage/", controller, "ingestCoverage")
                     .post()
+                    .secure(writePermissions),
+
+            Endpoint("/coverage/template/", controller, "getCoverageUploadTemplate")
+                    .csv()
                     .secure(writePermissions)
+
     )
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -13,9 +13,11 @@ import org.vaccineimpact.api.app.requests.csvData
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
 import org.vaccineimpact.api.models.CoverageIngestionRow
 import org.vaccineimpact.api.models.CoverageRow
+import org.vaccineimpact.api.models.GenderedLongCoverageRow
 import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
-import org.vaccineimpact.api.serialization.SplitData
-import org.vaccineimpact.api.serialization.StreamSerializable
+import org.vaccineimpact.api.serialization.*
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.primaryConstructor
 
 class CoverageController(
         actionContext: ActionContext,
@@ -25,6 +27,15 @@ class CoverageController(
 {
     constructor(context: ActionContext, repositories: Repositories)
             : this(context, RepositoriesCoverageLogic(repositories))
+
+    fun getCoverageUploadTemplate(): String
+    {
+        val filename = "coverage_template.csv"
+        context.addAttachmentHeader(filename)
+        return CoverageIngestionRow::class.primaryConstructor!!.parameters.map {
+            "\"${MontaguSerializer.instance.convertFieldName(it.name!!)}\""
+        }.joinToString(", ")
+    }
 
     fun getCoverageDataFromCSV(): Sequence<CoverageIngestionRow>
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -15,6 +15,13 @@ import org.vaccineimpact.api.test_helpers.MontaguTests
 class PopulatingCoverageTests : MontaguTests()
 {
     @Test
+    fun `can get coverage upload template`() {
+        val sut = CoverageController(mock(), mock(), PostDataHelper())
+        val result = sut.getCoverageUploadTemplate()
+        assertThat(result).isEqualTo("\"vaccine\", \"country\", \"activity_type\", \"gavi_support\", \"year\", \"age_first\", \"age_last\", \"gender\", \"target\", \"coverage\"")
+    }
+
+    @Test
     fun `can deserialize coverage`()
     {
         val mockContext = mock<ActionContext> {

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -112,6 +112,15 @@ class PopulateCoverageTests : CoverageTests()
         verifyCorrectRows()
     }
 
+    @Test
+    fun `can get coverage upload template`()
+    {
+        val token = TestUserHelper.setupTestUserAndGetToken(requiredPermissions, includeCanLogin = true)
+        val response = RequestHelper().get("/coverage/template/", token = token, acceptsContentType = "text/csv")
+        assertThat(response.text).isEqualTo("\"vaccine\", \"country\", \"activity_type\", \"gavi_support\", \"year\", \"age_first\", \"age_last\", \"gender\", \"target\", \"coverage\"")
+        assertThat(response.headers["Content-Disposition"]).isEqualTo("attachment; filename=\"coverage_template.csv\"")
+    }
+
     private fun setup()
     {
         JooqContext().use { db ->


### PR DESCRIPTION
Was going to just add this in the portal, but figured it might actually be more useful to have the API return it so that if the coverage format changes, that gets reflected automatically without having to manually keep the portal template up to date.