### PR TITLE
vimc-4390 endpoint to retrieve metadata about most recently uploaded coverage sets

### DIFF
--- a/docs/schemas/CoverageSetUploadMetadata.schema.json
+++ b/docs/schemas/CoverageSetUploadMetadata.schema.json
@@ -1,0 +1,24 @@
+{
+	"id": "CoverageSetUploadMetadata",
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"vaccine": {
+				"type": "string"
+			},
+			"uploaded_on": {
+				"type": "string"
+			},
+			"uploaded_by": {
+				"type": "string"
+			}
+		},
+		"additionalProperties": false,
+		"required": [
+			"vaccine",
+			"uploaded_on",
+			"uploaded_by"
+		]
+	}
+}

--- a/docs/spec/Coverage.md
+++ b/docs/spec/Coverage.md
@@ -233,4 +233,39 @@ Example wide format:
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campaign",   "AFG",    0,         2,                    NA,                      NA,            87.5,          93.4             98.2
     "menA-novacc",    "Menigitis with GAVI support",    "MenA",        "total",       "campign",    "AFG",    0,         1,                    NA,                      NA,            88.5,          90.6             98.1
 
+## GET /touchstones/{touchstone-id}/coverage/meta/
+Returns metadata about any coverage sets uploaded via the API for this touchstone.
+
+Required permissions: Global scope: `coverage.write`. 
+
+Schema: [`CoverageSetUploadMetadata.schema.json`](../schemas/CoverageSetUploadMetadata.schema.json)
+
+#### Example
+    [ 
+        { 
+            "vaccine": "YF",
+            "uploaded_on": "2017-op-1",
+            "uploaded_by"L: "test.user"
+        },
+        { 
+            "vaccine": "Measles",
+            "uploaded_on": "2017-op-1",
+            "uploaded_by"L: "test.user"
+        }
+    ]
+    
+
+## POST /touchstones/{touchstone-id}/coverage/
+Upload GAVI projected coverage data for the given touchstone. All coverage data uploaded via this endpoint
+will be recorded in a coverage set with gavi_support_level = "with".
+
+Required permissions: Global scope: `coverage.write`. 
+
+Accepts multipart/form-data with one text part named "description",
+ which can be any text, and one file part named "file",
+which must be CSV data in the following format
+
+    "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
+       "HepB_BD",   "AFG",    "campaign",     "true",  "2021",         1,     10,    "female", 100, 78.8
+       "HepB_BD",   "AFG",    "campaign",     "true",  "2022",         1,      10,    "female", 100, 65.5
 

--- a/docs/spec/Coverage.md
+++ b/docs/spec/Coverage.md
@@ -258,8 +258,6 @@ Schema: [`CoverageSetUploadMetadata.schema.json`](../schemas/CoverageSetUploadMe
 Returns template for uploading coverage data.
 Required permissions: Global scope: `coverage.write`. 
 
-Schema: [`CoverageIngestion.csvschema.json`](../schemas/CoverageIngestion.csvschema.json)
-
 Returns an empty CSV with the following headers
 
     "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"

--- a/docs/spec/Coverage.md
+++ b/docs/spec/Coverage.md
@@ -254,7 +254,7 @@ Schema: [`CoverageSetUploadMetadata.schema.json`](../schemas/CoverageSetUploadMe
         }
     ]
     
-## GET /coverage/templates/
+## GET /coverage/template/
 Returns template for uploading coverage data.
 Required permissions: Global scope: `coverage.write`. 
 

--- a/docs/spec/Coverage.md
+++ b/docs/spec/Coverage.md
@@ -244,16 +244,25 @@ Schema: [`CoverageSetUploadMetadata.schema.json`](../schemas/CoverageSetUploadMe
     [ 
         { 
             "vaccine": "YF",
-            "uploaded_on": "2017-op-1",
-            "uploaded_by"L: "test.user"
+            "uploaded_on": "2017-10-06T11:18:06Z",
+            "uploaded_by": "test.user"
         },
         { 
             "vaccine": "Measles",
-            "uploaded_on": "2017-op-1",
-            "uploaded_by"L: "test.user"
+            "uploaded_on": "2017-10-06T11:18:06Z",
+            "uploaded_by": "test.user"
         }
     ]
     
+## GET /coverage/templates/
+Returns template for uploading coverage data.
+Required permissions: Global scope: `coverage.write`. 
+
+Schema: [`CoverageIngestion.csvschema.json`](../schemas/CoverageIngestion.csvschema.json)
+
+Returns an empty CSV with the following headers
+
+    "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage"
 
 ## POST /touchstones/{touchstone-id}/coverage/
 Upload GAVI projected coverage data for the given touchstone. All coverage data uploaded via this endpoint

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/app_start/route_config/CoverageRouteConfig.kt
@@ -37,6 +37,10 @@ object CoverageRouteConfig : RouteConfig
 
             Endpoint("/touchstones/:touchstone-version-id/coverage/", controller, "ingestCoverage")
                     .post()
+                    .secure(writePermissions),
+
+            Endpoint("/touchstones/:touchstone-version-id/coverage/meta/", controller, "getCoverageUploadMetadata")
+                    .json()
                     .secure(writePermissions)
     )
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/controllers/CoverageController.kt
@@ -13,7 +13,7 @@ import org.vaccineimpact.api.app.requests.csvData
 import org.vaccineimpact.api.app.security.checkIsAllowedToSeeTouchstone
 import org.vaccineimpact.api.models.CoverageIngestionRow
 import org.vaccineimpact.api.models.CoverageRow
-import org.vaccineimpact.api.models.ModelRun
+import org.vaccineimpact.api.models.CoverageUploadMetadata
 import org.vaccineimpact.api.models.ScenarioTouchstoneAndCoverageSets
 import org.vaccineimpact.api.serialization.SplitData
 import org.vaccineimpact.api.serialization.StreamSerializable
@@ -22,11 +22,18 @@ import java.time.Instant
 class CoverageController(
         actionContext: ActionContext,
         private val coverageLogic: CoverageLogic,
+        private val touchstoneRepository: TouchstoneRepository,
         private val postDataHelper: PostDataHelper = PostDataHelper()
 ) : Controller(actionContext)
 {
     constructor(context: ActionContext, repositories: Repositories)
-            : this(context, RepositoriesCoverageLogic(repositories))
+            : this(context, RepositoriesCoverageLogic(repositories), repositories.touchstone)
+
+    fun getCoverageUploadMetadata(): List<CoverageUploadMetadata>
+    {
+        val touchstoneVersionId = context.params(":touchstone-version-id")
+        return touchstoneRepository.getCoverageUploadMetadata(touchstoneVersionId)
+    }
 
     fun getCoverageDataFromCSV(): Pair<Sequence<CoverageIngestionRow>, String>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -33,7 +33,6 @@ interface CoverageLogic
                                   uploader: String,
                                   timestamp: Instant,
                                   validate: Boolean = true)
-
 }
 
 class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingGroupRepository,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/TouchstoneRepository.kt
@@ -62,4 +62,6 @@ interface TouchstoneRepository : Repository
                           activityType: ActivityType,
                           supportLevel: GAVISupportLevel,
                           metadataId: Int): Int
+
+    fun getCoverageUploadMetadata(touchstoneVersionId: String): List<CoverageUploadMetadata>
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -250,6 +250,7 @@ class JooqTouchstoneRepository(
                 COVERAGE_SET_UPLOAD_METADATA.UPLOADED_ON)
                 .fromJoinPath(COVERAGE_SET, COVERAGE_SET_UPLOAD_METADATA)
                 .where(COVERAGE_SET.TOUCHSTONE.eq(touchstoneVersionId))
+                .orderBy(COVERAGE_SET.VACCINE)
                 .fetchInto(CoverageUploadMetadata::class.java)
                 .groupBy { it.vaccine }
                 .map { g->

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -243,6 +243,16 @@ class JooqTouchstoneRepository(
         return record.id
     }
 
+    override fun getCoverageUploadMetadata(touchstoneVersionId: String): List<CoverageUploadMetadata>
+    {
+        return dsl.select(COVERAGE_SET.VACCINE,
+                COVERAGE_SET_UPLOAD_METADATA.UPLOADED_BY,
+                COVERAGE_SET_UPLOAD_METADATA.UPLOADED_ON)
+                .fromJoinPath(COVERAGE_SET, COVERAGE_SET_UPLOAD_METADATA)
+                .where(COVERAGE_SET.TOUCHSTONE.eq(touchstoneVersionId))
+                .fetchInto(CoverageUploadMetadata::class.java)
+    }
+
     override fun saveCoverageForTouchstone(touchstoneVersionId: String, records: List<CoverageRecord>)
     {
         dsl.batchStore(records).execute()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -251,6 +251,10 @@ class JooqTouchstoneRepository(
                 .fromJoinPath(COVERAGE_SET, COVERAGE_SET_UPLOAD_METADATA)
                 .where(COVERAGE_SET.TOUCHSTONE.eq(touchstoneVersionId))
                 .fetchInto(CoverageUploadMetadata::class.java)
+                .groupBy { it.vaccine }
+                .map { g->
+                    g.value.maxBy { it.uploadedOn }!!
+                }
     }
 
     override fun saveCoverageForTouchstone(touchstoneVersionId: String, records: List<CoverageRecord>)

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/CoverageControllerTests.kt
@@ -21,7 +21,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic).getCoverageSetsForGroup()
+        CoverageController(context, logic, mock()).getCoverageSetsForGroup()
 
         verify(logic).getCoverageSetsForGroup(eq("gId"), eq("tId"), eq("sId"))
     }
@@ -32,7 +32,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(false)
         Assertions.assertThatThrownBy {
-            CoverageController(context, logic).getCoverageSetsForGroup()
+            CoverageController(context, logic, mock()).getCoverageSetsForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 
@@ -41,7 +41,7 @@ class CoverageControllerTests : MontaguTests()
     {
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
-        CoverageController(context, logic).getCoverageDataForGroup()
+        CoverageController(context, logic, mock()).getCoverageDataForGroup()
         verify(logic).getCoverageDataForGroup(eq("gId"), eq("tId"), eq("sId"), eq(false), isNull())
     }
 
@@ -57,7 +57,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = CoverageController(context, logic, mock())
+        val data = CoverageController(context, logic, mock(), mock())
                 .getCoverageDataForGroup().data
         Assertions.assertThat(data.first() is LongCoverageRow).isTrue()
     }
@@ -74,7 +74,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic, mock())
+        CoverageController(context, logic, mock(), mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", true, null)
     }
@@ -91,7 +91,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic)
+        CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -107,7 +107,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        CoverageController(context, logic)
+        CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
         verify(logic).getCoverageDataForGroup("gId", "tId", "sId", false, null)
     }
@@ -118,7 +118,7 @@ class CoverageControllerTests : MontaguTests()
         val logic = makeLogicMockingGetCoverageData(TouchstoneStatus.IN_PREPARATION)
         val context = mockContextForSpecificResponsibility(true)
 
-        val data = CoverageController(context, logic)
+        val data = CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
 
         // test data includes 5 years
@@ -146,7 +146,7 @@ class CoverageControllerTests : MontaguTests()
             on { hasPermission(any()) } doReturn true
         }
 
-        val data = CoverageController(context, logic)
+        val data = CoverageController(context, logic, mock())
                 .getCoverageDataForGroup().data
 
         Assertions.assertThat(data.count()).isEqualTo(0)
@@ -161,7 +161,7 @@ class CoverageControllerTests : MontaguTests()
         val context = mockContextForSpecificResponsibility(false)
 
         Assertions.assertThatThrownBy {
-            CoverageController(context, logic, mock()).getCoverageDataForGroup()
+            CoverageController(context, logic, mock(), mock()).getCoverageDataForGroup()
         }.hasMessageContaining("Unknown touchstone-version")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -20,7 +20,7 @@ class PopulatingCoverageTests : MontaguTests()
 {
     @Test
     fun `can get coverage upload template`() {
-        val sut = CoverageController(mock(), mock(), PostDataHelper())
+        val sut = CoverageController(mock(), mock(), mock())
         val result = sut.getCoverageUploadTemplate()
         assertThat(result).isEqualTo("\"vaccine\", \"country\", \"activity_type\", \"gavi_support\", \"year\", \"age_first\", \"age_last\", \"gender\", \"target\", \"coverage\"")
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -10,10 +10,11 @@ import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.InMemoryRequestData
 import org.vaccineimpact.api.app.controllers.CoverageController
 import org.vaccineimpact.api.app.requests.MultipartDataMap
-import org.vaccineimpact.api.app.requests.PostDataHelper
+import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import org.vaccineimpact.api.test_helpers.MontaguTests
+import java.time.Instant
 
 class PopulatingCoverageTests : MontaguTests()
 {
@@ -26,8 +27,9 @@ class PopulatingCoverageTests : MontaguTests()
                     "file" to InMemoryRequestData(normalCSVDataString)
             )
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock())
         val result = sut.getCoverageDataFromCSV().first
+
         assertThat(result.toList()).containsExactly(
                 CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, true, 2020, 1, 10, GenderEnum.BOTH, 100F, 78.8F),
                 CoverageIngestionRow("HepB_BD", "AFG", ActivityType.CAMPAIGN, false, 2021, 1, 10, GenderEnum.FEMALE, 100F, 65.5F)
@@ -43,8 +45,9 @@ class PopulatingCoverageTests : MontaguTests()
                     "file" to InMemoryRequestData(invalidActivityTypeCSVDataString)
             )
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
+        val sut = CoverageController(mockContext, mock(), mock())
         val result = sut.getCoverageDataFromCSV().first
+
         assertThatThrownBy { result.toList() }
                 .isInstanceOf(ValidationException::class.java)
     }
@@ -58,9 +61,26 @@ class PopulatingCoverageTests : MontaguTests()
                     "file" to InMemoryRequestData(invalidHeadersCSVDataString)
             )
         }
-        val sut = CoverageController(mockContext, mock(), PostDataHelper())
-        assertThatThrownBy { sut.getCoverageDataFromCSV().first }
-                .isInstanceOf(ValidationException::class.java)
+        val sut = CoverageController(mockContext, mock(), mock())
+        assertThatThrownBy {
+            sut.getCoverageDataFromCSV().first
+        }.isInstanceOf(ValidationException::class.java)
+    }
+
+    @Test
+    fun `can get coverage upload metadata`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { params(":touchstone-version-id") } doReturn "t1"
+        }
+        val fakeData = CoverageUploadMetadata("YF", "test.user", Instant.now())
+        val mockRepo = mock<TouchstoneRepository> {
+            on { getCoverageUploadMetadata("t1") } doReturn
+                    listOf(fakeData)
+        }
+        val sut = CoverageController(mockContext, mock(), mockRepo)
+        val result = sut.getCoverageUploadMetadata()
+        assertThat(result[0]).isEqualToComparingFieldByField(fakeData)
     }
 
     private val normalCSVDataString = """

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -9,13 +9,13 @@ import org.vaccineimpact.api.blackboxTests.schemas.CSVSchema
 import org.vaccineimpact.api.db.JooqContext
 import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.Tables.*
-import org.vaccineimpact.api.db.direct.addTouchstoneVersion
-import org.vaccineimpact.api.db.direct.addVaccine
+import org.vaccineimpact.api.db.direct.*
 import org.vaccineimpact.api.db.tables.Country
 import org.vaccineimpact.api.models.permissions.PermissionSet
 import org.vaccineimpact.api.validateSchema.JSONValidator
 import spark.route.HttpMethod
 import java.io.File
+import java.time.Instant
 
 class PopulateCoverageTests : CoverageTests()
 {
@@ -116,11 +116,9 @@ class PopulateCoverageTests : CoverageTests()
     @Test
     fun `can get coverage upload metadata`()
     {
-        setup()
         validate("/touchstones/$touchstoneVersionId/coverage/meta") against ("CoverageSetUploadMetadata") given {
-            addCoverageData(it, touchstoneStatus = "open")
+            addCoverageSets()
         } requiringPermissions { requiredPermissions } andCheckHasStatus 200..200
-
     }
 
     @Test
@@ -190,6 +188,17 @@ class PopulateCoverageTests : CoverageTests()
                         }
                     }
             db.dsl.batchStore(countryRecords).execute()
+        }
+    }
+
+    private fun addCoverageSets()
+    {
+        JooqContext().use {
+            it.addVaccine("YF")
+            it.addUserForTesting("some.user")
+            it.addTouchstoneVersion("t", 1, addTouchstone = true)
+            val setId = it.addCoverageSet("t-1", "name", "YF", "with", "campaign")
+            it.addCoverageSetUploadMetadata("description", "some.user", Instant.now(), setId)
         }
     }
 

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -113,6 +113,15 @@ class PopulateCoverageTests : CoverageTests()
         JSONValidator().validateError(response.text, "forbidden")
     }
 
+    @Test
+    fun `can get coverage upload metadata`()
+    {
+        setup()
+        validate("/touchstones/$touchstoneVersionId/coverage/meta") against ("CoverageSetUploadMetadata") given {
+            addCoverageData(it, touchstoneStatus = "open")
+        } requiringPermissions { requiredPermissions } andCheckHasStatus 200..200
+    }
+
     private fun setup()
     {
         JooqContext().use { db ->

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -208,8 +208,9 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
     }
 
     @Test
-    fun `can get coverage upload metadata`()
+    fun `can get latest coverage upload metadata`()
     {
+        val then = Instant.now()
         val now = Instant.now()
         withDatabase {
             it.addTouchstoneVersion("t", 1, addTouchstone = true)
@@ -218,15 +219,17 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
             it.addVaccine("v2")
         }
         val meta = withRepo {
-            val metaId = it.createCoverageSetMetadata("desc", "test.user", now)
-            it.createCoverageSet("t-1", "v1", ActivityType.ROUTINE, GAVISupportLevel.WITH, metaId)
-            it.createCoverageSet("t-1", "v2", ActivityType.ROUTINE, GAVISupportLevel.WITH, metaId)
+            val oldMetaId = it.createCoverageSetMetadata("desc", "test.user", then)
+            val recentMetaId = it.createCoverageSetMetadata("desc", "test.user", now)
+            it.createCoverageSet("t-1", "v1", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
+            it.createCoverageSet("t-1", "v2", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
+            it.createCoverageSet("t-1", "v2", ActivityType.ROUTINE, GAVISupportLevel.WITH, recentMetaId)
             it.getCoverageUploadMetadata("t-1")
         }
 
         assertThat(meta.count()).isEqualTo(2)
         assertThat(meta[0].vaccine).isEqualTo("v1")
-        assertThat(meta[0].uploadedOn).isEqualTo(now)
+        assertThat(meta[0].uploadedOn).isEqualTo(then)
         assertThat(meta[0].uploadedBy).isEqualTo("test.user")
 
         assertThat(meta[1].vaccine).isEqualTo("v2")

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -208,32 +208,32 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
     }
 
     @Test
-    fun `can get latest coverage upload metadata`()
+    fun `can get latest coverage upload metadata ordered by vaccine name`()
     {
         val then = Instant.now()
         val now = Instant.now()
         withDatabase {
             it.addTouchstoneVersion("t", 1, addTouchstone = true)
             it.addUserForTesting("test.user")
-            it.addVaccine("v1")
-            it.addVaccine("v2")
+            it.addVaccine("a")
+            it.addVaccine("b")
         }
         val meta = withRepo {
             val oldMetaId = it.createCoverageSetMetadata("desc", "test.user", then)
             val recentMetaId = it.createCoverageSetMetadata("desc", "test.user", now)
-            it.createCoverageSet("t-1", "v1", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
-            it.createCoverageSet("t-1", "v2", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
-            it.createCoverageSet("t-1", "v2", ActivityType.ROUTINE, GAVISupportLevel.WITH, recentMetaId)
+            it.createCoverageSet("t-1", "b", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
+            it.createCoverageSet("t-1", "a", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
+            it.createCoverageSet("t-1", "a", ActivityType.ROUTINE, GAVISupportLevel.WITH, recentMetaId)
             it.getCoverageUploadMetadata("t-1")
         }
 
         assertThat(meta.count()).isEqualTo(2)
-        assertThat(meta[0].vaccine).isEqualTo("v1")
-        assertThat(meta[0].uploadedOn).isEqualTo(then)
+        assertThat(meta[0].vaccine).isEqualTo("a")
+        assertThat(meta[0].uploadedOn).isEqualTo(now)
         assertThat(meta[0].uploadedBy).isEqualTo("test.user")
 
-        assertThat(meta[1].vaccine).isEqualTo("v2")
-        assertThat(meta[1].uploadedOn).isEqualTo(now)
+        assertThat(meta[1].vaccine).isEqualTo("b")
+        assertThat(meta[1].uploadedOn).isEqualTo(then)
         assertThat(meta[1].uploadedBy).isEqualTo("test.user")
     }
 

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/api/test_helpers/InsertHelpers.kt
@@ -427,6 +427,26 @@ fun JooqContext.addCoverageSet(
     return record.id
 }
 
+fun JooqContext.addCoverageSetUploadMetadata(
+        description: String,
+        uploadedBy: String,
+        uploadedOn: Instant,
+        coverageSetId: Int
+)
+{
+    val record = this.dsl.newRecord(COVERAGE_SET_UPLOAD_METADATA).apply {
+        this.description = description
+        this.uploadedBy = uploadedBy
+        this.uploadedOn = Timestamp.from(uploadedOn)
+    }
+    record.store()
+    val metaId = record.id
+    this.dsl.update(COVERAGE_SET)
+            .set(COVERAGE_SET.COVERAGE_SET_UPLOAD_METADATA, metaId)
+            .where(COVERAGE_SET.ID.eq(coverageSetId))
+            .execute()
+}
+
 fun JooqContext.addCoverageSetToScenario(scenarioId: Int, coverageSetId: Int, order: Int): Int
 {
     val record = this.dsl.newRecord(SCENARIO_COVERAGE_SET).apply {


### PR DESCRIPTION
This PR adds an endpoint `/touchstones/:touchstone-version-id/coverage/meta/` which returns metadata about the most recently uploaded coverage sets for each vaccine that has data in the touchstone. This is to reflect back in the portal to track upload progress. 

It also adds documentation on this endpoint, the `GET coverage/template` and the `POST coverage` endpoints which were overlooked in previous PRs.

This webmodels PR should be merged in at the same time: https://github.com/vimc/montagu-api/pull/446

~~Contains commits from https://github.com/vimc/montagu-api/pull/444~~