### PR TITLE
vimc-4397 gavi73 countries

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -90,7 +90,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
         val setDeterminants = mutableListOf<Pair<ActivityType, String>>()
         val setIds = mutableListOf<Int>()
         var expectedRowLookup = mutableMapOf<String, CountryLookup>()
-        val countries = expectationsRepository.getExpectedGAVICoverageCountries(touchstoneVersionId)
+        val countries = expectationsRepository.getExpectedGAVICoverageCountries()
         val metadataId = touchstoneRepository.createCoverageSetMetadata(description, uploader, timestamp)
         val records = rows.flatMap { row ->
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
@@ -10,5 +10,5 @@ interface ExpectationsRepository : Repository
     fun getExpectationsById(expectationsId: Int): ExpectationMapping
     fun getExpectationIdsForGroupAndTouchstone(groupId: String, touchstoneVersionId: String): List<Int>
     fun getAllExpectations(): List<TouchstoneModelExpectations>
-    fun getExpectedGAVICoverageCountries(touchstoneVersionId: String) : List<String>
+    fun getExpectedGAVICoverageCountries() : List<String>
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -140,7 +140,7 @@ class JooqExpectationsRepository(dsl: DSLContext)
 
     override fun getExpectedGAVICoverageCountries(): List<String>
     {
-        return dsl.select(COUNTRY.ID)
+        return dsl.selectDistinct(COUNTRY.ID)
                 .fromJoinPath(COUNTRY, COUNTRY_METADATA)
                 .where(COUNTRY_METADATA.GAVI73)
                 .orderBy(COUNTRY.ID)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -138,12 +138,11 @@ class JooqExpectationsRepository(dsl: DSLContext)
                 }
     }
 
-    override fun getExpectedGAVICoverageCountries(touchstoneVersionId: String): List<String>
+    override fun getExpectedGAVICoverageCountries(): List<String>
     {
         return dsl.select(COUNTRY.ID)
                 .fromJoinPath(COUNTRY, COUNTRY_METADATA)
                 .where(COUNTRY_METADATA.GAVI73)
-                .and(COUNTRY_METADATA.TOUCHSTONE.eq(touchstoneVersionId))
                 .orderBy(COUNTRY.ID)
                 .fetchInto(String::class.java)
                 .toList()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -31,7 +31,7 @@ class SaveCoverageTests : MontaguTests()
     )
 
     private val mockExpectationsRepo = mock<ExpectationsRepository> {
-        on { getExpectedGAVICoverageCountries(any()) } doReturn listOf("AFG")
+        on { getExpectedGAVICoverageCountries() } doReturn listOf("AFG")
     }
 
     private val now = Instant.now()

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -372,6 +372,7 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
     {
         withDatabase { db ->
             db.addTouchstoneVersion("t", 1, addTouchstone = true)
+            db.addTouchstoneVersion("t", 2, addTouchstone = false)
             db.dsl.newRecord(FRANCOPHONE_STATUS)
                     .apply {
                         id = "fff"
@@ -412,7 +413,28 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
                         }
                     }
             db.dsl.batchStore(countryRecords).execute()
+
+            // add one duplicate for another touchstone
+            db.dsl.newRecord(COUNTRY_METADATA).apply {
+                this.country = "AFG"
+                this.gavi73 = true
+                this.touchstone = "t-2"
+                this.whoRegion = "123"
+                this.continent = "aaa"
+                this.region = "bbb"
+                this.francophone = "fff"
+                this.vxdelSegment = "v1"
+                this.gaviRegion = "g1"
+                this.wuenicCoverage = false
+                this.pine_5 = false
+                this.dove94 = false
+                this.dove96 = false
+                this.gavi68 = false
+                this.gavi72 = false
+                this.gavi77 = false
+            }.store()
         }
+
         val countries = withRepo {
             it.getExpectedGAVICoverageCountries()
         }

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -414,7 +414,7 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
             db.dsl.batchStore(countryRecords).execute()
         }
         val countries = withRepo {
-            it.getExpectedGAVICoverageCountries("t-1")
+            it.getExpectedGAVICoverageCountries()
         }
         assertThat(countries.count()).isEqualTo(73)
     }

--- a/src/generateTestData/src/main/kotlin/org.vaccineimpact.api.generateTestData/App.kt
+++ b/src/generateTestData/src/main/kotlin/org.vaccineimpact.api.generateTestData/App.kt
@@ -1,7 +1,9 @@
 package org.vaccineimpact.api.generateTestData
 
 import org.vaccineimpact.api.db.JooqContext
+import org.vaccineimpact.api.db.Tables
 import org.vaccineimpact.api.db.direct.*
+import org.vaccineimpact.api.db.tables.Country
 
 fun main(args: Array<String>) {
 
@@ -37,8 +39,53 @@ fun main(args: Array<String>) {
         db.addTouchstoneVersion("future", 1, "Future (v1)", "in-preparation")
 
         db.addUserForTesting("test.user")
+
+        addGAVI73Countries(db)
     }
 
+}
+
+fun addGAVI73Countries(db: JooqContext) {
+    db.dsl.newRecord(Tables.FRANCOPHONE_STATUS)
+            .apply {
+                id = "member"
+            }.store()
+    db.dsl.newRecord(Tables.VXDEL_SEGMENT)
+            .apply {
+                id = "conflict areas"
+            }.store()
+
+    db.dsl.newRecord(Tables.GAVI_REGION)
+            .apply {
+                id = "AA"
+                name = "Anglophone Africa"
+            }.store()
+
+    val countryRecords = db.dsl.select(Country.COUNTRY.ID)
+            .from(Country.COUNTRY)
+            .limit(73)
+            .fetchInto(String::class.java)
+            .map {
+                db.dsl.newRecord(Tables.COUNTRY_METADATA).apply {
+                    this.country = it
+                    this.gavi73 = true
+                    this.touchstone = "op-2017-1"
+                    this.whoRegion = "AFR"
+                    this.continent = "Africa"
+                    this.region = "Eastern Africa"
+                    this.francophone = "member"
+                    this.vxdelSegment = "conflict areas"
+                    this.gaviRegion = "AA"
+                    this.wuenicCoverage = false
+                    this.pine_5 = false
+                    this.dove94 = false
+                    this.dove96 = false
+                    this.gavi68 = false
+                    this.gavi72 = false
+                    this.gavi77 = false
+                }
+            }
+    db.dsl.batchStore(countryRecords).execute()
 }
 
 fun addAllTestDataForOp2017v1(db: JooqContext, demographicTestData: DemographicTestData){


### PR DESCRIPTION
This PR:
* adds fake gavi73 countries to the test data, for use when running the webapps locally
* removes the parameterisation by touchstone of the `getExpectedGAVICoverageCountries` method - although the `country_metadata` includes `touchstone`, Xiang has instructed that the correct way to get all GAVI73 countries is just by retrieving all records with that flag.