### PR TITLE
vimc-4434 Allow years 2000-2100 in coverage upload, mandatory years are 2021-2030

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -48,7 +48,8 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
             repositories.scenario,
             repositories.expectations)
 
-    private val expectedGAVICoverageYears = LocalDate.now().plusYears(1).year..2030
+    private val mandatoryGAVICoverageYears = 2021..2030
+    private val allowedGAVICoverageYears = 2000..2100
 
     override fun getCoverageSetsForGroup(groupId: String, touchstoneVersionId: String, scenarioId: String):
             ScenarioTouchstoneAndCoverageSets
@@ -70,7 +71,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
         for (country in countries)
         {
             val yearMap = YearLookup()
-            for (year in expectedGAVICoverageYears)
+            for (year in mandatoryGAVICoverageYears)
             {
                 yearMap[year.toShort()] = false
             }
@@ -143,7 +144,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
                          countries: List<String>,
                          expectedRowLookup: CoverageRowLookup): CoverageRowLookup
     {
-        if (!expectedGAVICoverageYears.contains(row.year))
+        if (!allowedGAVICoverageYears.contains(row.year))
         {
             throw BadRequest("Unexpected year: ${row.year}")
         }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -197,7 +197,7 @@ and 13 others"""
         )
 
         val testSequenceLate = sequenceOf(
-                CoverageIngestionRow("HepB", "AFG", activityType, true, 21019, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
+                CoverageIngestionRow("HepB", "AFG", activityType, true, 2101, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
         )
 
         val expectedMessageEarly = "Unexpected year: 1999"

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/CoverageLogic/SaveCoverageTests.kt
@@ -116,6 +116,7 @@ class SaveCoverageTests : MontaguTests()
         }
         val testSequence = sequenceOf(
                 CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
+                CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, true, 2031, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
                 CoverageIngestionRow("YF", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
                 CoverageIngestionRow("Measles", "AFG", ActivityType.ROUTINE, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false))
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock(), mockExpectationsRepo)
@@ -144,10 +145,12 @@ and 13 others"""
         val testSequence = sequenceOf(
                 CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
                 CoverageIngestionRow("YF", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
-                CoverageIngestionRow("YF", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false))
+                CoverageIngestionRow("YF", "AFG", ActivityType.CAMPAIGN, true, 2025, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false),
+                CoverageIngestionRow("YF", "AFG", ActivityType.CAMPAIGN, true, 2020, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
+        )
         val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock(), mockExpectationsRepo)
         sut.saveCoverageForTouchstone("t1", testSequence, "", "", now)
-        verify(mockRepo, Times(3)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        verify(mockRepo, Times(4)).newCoverageRowRecord(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -172,37 +175,42 @@ and 13 others"""
     @Test
     fun `validation detects bad campaign years`()
     {
-        val mockRepo = mock<TouchstoneRepository> {
-            on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
-        }
-        val testSequence = sequenceOf(
-                CoverageIngestionRow("HepB", "AFG", ActivityType.CAMPAIGN, true, 2010, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
-        )
-        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock(), mockExpectationsRepo)
-        val expectedMessage = "Unexpected year: 2010"
-
-        assertThatThrownBy {
-            sut.saveCoverageForTouchstone("t1", testSequence, "", "", now)
-        }.isInstanceOf(BadRequest::class.java)
-                .hasMessageContaining(expectedMessage)
+       `validation detects bad years`(ActivityType.CAMPAIGN)
     }
 
     @Test
     fun `validation detects bad routine years`()
     {
+        `validation detects bad years`(ActivityType.ROUTINE)
+    }
+
+    private fun `validation detects bad years`(activityType: ActivityType)
+    {
         val mockRepo = mock<TouchstoneRepository> {
             on { getGenders() } doReturn mapOf(GenderEnum.BOTH to 111)
         }
-        val testSequence = sequenceOf(
-                CoverageIngestionRow("HepB", "AFG", ActivityType.ROUTINE, true, 2010, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
-        )
-        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock(), mockExpectationsRepo)
-        val expectedMessage = "Unexpected year: 2010"
 
+        val sut = RepositoriesCoverageLogic(mock(), mock(), mockRepo, mock(), mockExpectationsRepo)
+
+        val testSequenceEarly = sequenceOf(
+                CoverageIngestionRow("HepB", "AFG", activityType, true, 1999, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
+        )
+
+        val testSequenceLate = sequenceOf(
+                CoverageIngestionRow("HepB", "AFG", activityType, true, 21019, 1, 10, GenderEnum.BOTH, 100F, 65.5F, false)
+        )
+
+        val expectedMessageEarly = "Unexpected year: 1999"
         assertThatThrownBy {
-            sut.saveCoverageForTouchstone("t1", testSequence, "", "", now)
+            sut.saveCoverageForTouchstone("t1", testSequenceEarly, "", "", now)
         }.isInstanceOf(BadRequest::class.java)
-                .hasMessageContaining(expectedMessage)
+                .hasMessageContaining(expectedMessageEarly)
+
+        val expectedMessageLate = "Unexpected year: 2101"
+        assertThatThrownBy {
+            sut.saveCoverageForTouchstone("t1", testSequenceLate, "", "", now)
+        }.isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining(expectedMessageLate)
     }
 
     @Test

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -83,7 +83,7 @@ class PopulateCoverageTests : CoverageTests()
                 token = token,
                 data = mapOf("description" to "test description"))
         JSONValidator().validateError(response.text, "bad-request",
-                "Unexpected year: 2031")
+                "Unexpected year: 1999")
     }
 
     @Test

--- a/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
+++ b/src/blackboxTests/src/test/kotlin/org/vaccineimpact/api/blackboxTests/tests/Coverage/PopulateCoverageTests.kt
@@ -252,6 +252,6 @@ class PopulateCoverageTests : CoverageTests()
 
     private val unexpectedYearCsvData = """
 "vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage", "subnational"
-   "HepB_BD",   "AFG",    "routine",     "true",  "2031",         1,     10,    "female", 100, 78.8, false
+   "HepB_BD",   "AFG",    "routine",     "true",  "1999",         1,     10,    "female", 100, 78.8, false
 """
 }


### PR DESCRIPTION
This ticket:
* takes out [current year + 1] as expected start year, replace with 2021
* allows upload of any number of coverage rows covering years 2000-2100 (mandatory years are still 2021-2030)