### PR TITLE
vimc-4431 Be more strict about validation when deserializing Booleans

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -5,16 +5,22 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Condition
 import org.junit.Test
 import org.vaccineimpact.api.app.context.ActionContext
 import org.vaccineimpact.api.app.context.InMemoryRequestData
 import org.vaccineimpact.api.app.controllers.CoverageController
-import org.vaccineimpact.api.app.requests.MultipartDataMap
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
-import org.vaccineimpact.api.models.*
+import org.vaccineimpact.api.app.requests.MultipartDataMap
+import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.CoverageIngestionRow
+import org.vaccineimpact.api.models.CoverageUploadMetadata
+import org.vaccineimpact.api.models.GenderEnum
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Instant
+import java.util.function.Predicate
+
 
 class PopulatingCoverageTests : MontaguTests()
 {
@@ -75,6 +81,27 @@ class PopulatingCoverageTests : MontaguTests()
     }
 
     @Test
+    fun `deserializing coverage throws error on invalid gavi_support`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { getParts(anyOrNull()) } doReturn MultipartDataMap(
+                    "description" to InMemoryRequestData("some description"),
+                    "file" to InMemoryRequestData(invalidGaviSupportCSVDataString)
+            )
+        }
+        val sut = CoverageController(mockContext, mock(), mock())
+        val exceptionCondition =  Condition<Throwable>(
+                Predicate<Throwable> { e: Throwable ->
+                    val ve = e as ValidationException
+                    ve.errors.count() == 1 && ve.errors[0].code == "csv-bad-data-type:1:gavi_support"
+                            && ve.errors[0].message == "Unable to parse 'ABC' as Boolean (Row 1, column gavi_support)"
+                }, "exceptionCondition")
+        assertThatThrownBy {
+            sut.getCoverageDataFromCSV().first.toList()
+        }.isInstanceOf(ValidationException::class.java).has(exceptionCondition)
+    }
+
+    @Test
     fun `can get coverage upload metadata`()
     {
         val mockContext = mock<ActionContext> {
@@ -105,5 +132,8 @@ class PopulatingCoverageTests : MontaguTests()
 "vaccine", "country code", "activity", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage", "subnational"
    "HepB_BD",   "AFG",    "a campaign",     "true",  "2020",         1,     10,    "both", 100, 78.8, true
 """
-
+    private val invalidGaviSupportCSVDataString = """
+"vaccine", "country", "activity_type", "gavi_support", "year", "age_first", "age_last", "gender", "target", "coverage", "subnational"
+   "HepB_BD",   "AFG",    "campaign",     "ABC",  "2020",         1,     10,    "both", 100, 78.8, true
+"""
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -12,15 +12,11 @@ import org.vaccineimpact.api.app.context.InMemoryRequestData
 import org.vaccineimpact.api.app.controllers.CoverageController
 import org.vaccineimpact.api.app.repositories.TouchstoneRepository
 import org.vaccineimpact.api.app.requests.MultipartDataMap
-import org.vaccineimpact.api.models.ActivityType
-import org.vaccineimpact.api.models.CoverageIngestionRow
-import org.vaccineimpact.api.models.CoverageUploadMetadata
-import org.vaccineimpact.api.models.GenderEnum
+import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import org.vaccineimpact.api.test_helpers.MontaguTests
 import java.time.Instant
 import java.util.function.Predicate
-
 
 class PopulatingCoverageTests : MontaguTests()
 {

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -46,14 +46,10 @@ class Deserializer
         }
     }
 
-    private fun String.toBooleanValidate(): Boolean
+    private fun String.toBooleanValidate() = when
     {
-        if (this.equals("true", ignoreCase = true)) {
-            return true;
-        }
-        if (this.equals("false", ignoreCase = true)) {
-            return false;
-        }
-        throw ValidationException(listOf(ErrorInfo("invalid-boolean", "Unable to parse '$this' as Boolean")))
+        equals("true", ignoreCase = true) -> true
+        equals("false", ignoreCase = true) -> false
+        else -> throw ValidationException(listOf(ErrorInfo("invalid-boolean", "Unable to parse '$this' as Boolean")))
     }
 }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -1,8 +1,10 @@
 package org.vaccineimpact.api.serialization
 
 import org.vaccineimpact.api.models.ActivityType
+import org.vaccineimpact.api.models.ErrorInfo
 import org.vaccineimpact.api.models.GAVISupportLevel
 import org.vaccineimpact.api.models.GenderEnum
+import org.vaccineimpact.api.serialization.validation.ValidationException
 import java.lang.UnsupportedOperationException
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
@@ -36,11 +38,22 @@ class Deserializer
             Int::class.createType() -> raw.toInt()
             Short::class.createType() -> raw.toShort()
             Float::class.createType() -> raw.toFloat()
-            Boolean::class.createType() -> raw.toBoolean()
+            Boolean::class.createType() -> raw.toBooleanValidate()
             ActivityType::class.createType() -> ActivityType.valueOf(raw.toUpperCase())
             GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.toUpperCase())
             GenderEnum::class.createType() -> GenderEnum.valueOf(raw.toUpperCase())
             else -> throw UnsupportedOperationException("org.vaccineimpact.api.serialization.Deserializer does not support target type $targetType")
         }
+    }
+
+    private fun String.toBooleanValidate(): Boolean
+    {
+        if (this.equals("true", ignoreCase = true)) {
+            return true;
+        }
+        if (this.equals("false", ignoreCase = true)) {
+            return false;
+        }
+        throw ValidationException(listOf(ErrorInfo("invalid-boolean", "Unable to parse '$this' as Boolean")))
     }
 }

--- a/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DeserializerTests.kt
+++ b/src/serialization/src/test/kotlin/org/vaccineimpact/api/tests/serialization/DeserializerTests.kt
@@ -2,12 +2,16 @@ package org.vaccineimpact.api.tests.serialization
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Condition
 import org.junit.Before
 import org.junit.Test
 import org.vaccineimpact.api.serialization.Deserializer
 import org.vaccineimpact.api.serialization.UnknownEnumValue
 import org.vaccineimpact.api.models.TouchstoneStatus
+import org.vaccineimpact.api.serialization.validation.ValidationException
 import org.vaccineimpact.api.test_helpers.MontaguTests
+import kotlin.reflect.full.createType
+import java.util.function.Predicate
 
 class DeserializerTests : MontaguTests()
 {
@@ -40,4 +44,28 @@ class DeserializerTests : MontaguTests()
                 .isInstanceOf(UnknownEnumValue::class.java)
     }
 
+    @Test
+    fun `can parse Boolean`()
+    {
+        assertThat(deserializer.deserialize("true", Boolean::class.createType())).isEqualTo(true)
+        assertThat(deserializer.deserialize("True", Boolean::class.createType())).isEqualTo(true)
+
+        assertThat(deserializer.deserialize("false", Boolean::class.createType())).isEqualTo(false)
+        assertThat(deserializer.deserialize("FALSE", Boolean::class.createType())).isEqualTo(false)
+    }
+
+    @Test
+    fun `throws exception on invalid Boolean`()
+    {
+        val exceptionCondition =  Condition<Throwable>(
+                Predicate<Throwable> { e: Throwable ->
+                    val ve = e as ValidationException
+                    ve.errors.count() == 1 && ve.errors[0].code == "invalid-boolean"
+                            && ve.errors[0].message == "Unable to parse '123' as Boolean"
+                }, "exceptionCondition")
+
+        assertThatThrownBy {
+            deserializer.deserialize("123", Boolean::class.createType())
+        }.has(exceptionCondition)
+    }
 }


### PR DESCRIPTION
We were using the default java toBoolean method to deserialize booleans (for all our deserializations, not just coverage). This is actually very lenient, and interprets any string which is not equal to "true" (ignoring case) as a false value. 

I've introduced a validate method of our own for booleans, which throws an exception if the input is nether "true" nor "false" (ignoring case). 

This will impact coverage, as intended. I don't believe this will impact burden estimate uploads, our other main deserialization usage, since no values in the burden estimates are booleans.  