### PR TITLE
vimc-4465 Add activityType to CoverageUploadMetadata

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -246,13 +246,15 @@ class JooqTouchstoneRepository(
     override fun getCoverageUploadMetadata(touchstoneVersionId: String): List<CoverageUploadMetadata>
     {
         return dsl.select(COVERAGE_SET.VACCINE,
+                ACTIVITY_TYPE.NAME.`as`("activityType"),
                 COVERAGE_SET_UPLOAD_METADATA.UPLOADED_BY,
                 COVERAGE_SET_UPLOAD_METADATA.UPLOADED_ON)
                 .fromJoinPath(COVERAGE_SET, COVERAGE_SET_UPLOAD_METADATA)
+                .joinPath(COVERAGE_SET, ACTIVITY_TYPE)
                 .where(COVERAGE_SET.TOUCHSTONE.eq(touchstoneVersionId))
-                .orderBy(COVERAGE_SET.VACCINE)
+                .orderBy(COVERAGE_SET.VACCINE, COVERAGE_SET.ACTIVITY_TYPE)
                 .fetchInto(CoverageUploadMetadata::class.java)
-                .groupBy { it.vaccine }
+                .groupBy { Pair(it.vaccine, it.activityType) }
                 .map { g ->
                     g.value.maxBy { it.uploadedOn }!!
                 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/controllers/coverage/PopulatingCoverageTests.kt
@@ -103,7 +103,7 @@ class PopulatingCoverageTests : MontaguTests()
         val mockContext = mock<ActionContext> {
             on { params(":touchstone-version-id") } doReturn "t1"
         }
-        val fakeData = CoverageUploadMetadata("YF", "test.user", Instant.now())
+        val fakeData = CoverageUploadMetadata("YF", "campaign", "test.user", Instant.now())
         val mockRepo = mock<TouchstoneRepository> {
             on { getCoverageUploadMetadata("t1") } doReturn
                     listOf(fakeData)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/touchstoneRepository/SaveCoverageTests.kt
@@ -228,17 +228,25 @@ class SaveCoverageTests : TouchstoneRepositoryTests()
             it.createCoverageSet("t-1", "b", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
             it.createCoverageSet("t-1", "a", ActivityType.ROUTINE, GAVISupportLevel.WITH, oldMetaId)
             it.createCoverageSet("t-1", "a", ActivityType.ROUTINE, GAVISupportLevel.WITH, recentMetaId)
+            it.createCoverageSet("t-1", "b", ActivityType.CAMPAIGN, GAVISupportLevel.WITH, recentMetaId)
             it.getCoverageUploadMetadata("t-1")
         }
 
-        assertThat(meta.count()).isEqualTo(2)
+        assertThat(meta.count()).isEqualTo(3)
         assertThat(meta[0].vaccine).isEqualTo("a")
         assertThat(meta[0].uploadedOn).isEqualTo(now)
+        assertThat(meta[0].activityType).isEqualTo("Routine vaccination")
         assertThat(meta[0].uploadedBy).isEqualTo("test.user")
 
         assertThat(meta[1].vaccine).isEqualTo("b")
-        assertThat(meta[1].uploadedOn).isEqualTo(then)
+        assertThat(meta[1].uploadedOn).isEqualTo(now)
+        assertThat(meta[1].activityType).isEqualTo("Campaign vaccination")
         assertThat(meta[1].uploadedBy).isEqualTo("test.user")
+
+        assertThat(meta[2].vaccine).isEqualTo("b")
+        assertThat(meta[2].uploadedOn).isEqualTo(then)
+        assertThat(meta[2].activityType).isEqualTo("Routine vaccination")
+        assertThat(meta[2].uploadedBy).isEqualTo("test.user")
     }
 
     @Test


### PR DESCRIPTION
Retrieve activityType names for coverage sets when returning metadata. Group by activity type as well as vaccine. Only the latest coverage set per vaccine and activity Type are returned.

Should be merged alongside the change to the models repo:
vimc/montagu-webmodels#95

This change is required to complete https://github.com/vimc/montagu-webapps/pull/444