### PR TITLE
vimc-4531 Negative value check

### DIFF
--- a/docs/spec/BurdenEstimates.md
+++ b/docs/spec/BurdenEstimates.md
@@ -103,6 +103,8 @@ based on which outcomes you wish to upload values for. More or fewer columns
 are allowed so long as all the outcome columns correspond to allowed burden
 outcomes in the database.
 
+Negative values are not allowed in outcome columns.
+
     "disease", "year", "age", "country", "country_name", "cohort_size", "deaths", "cases", "dalys"
        "Hib3",   1996,    50,     "AFG",  "Afghanistan",         10000,     1000,    2000,      NA
        "Hib3",   1997,    50,     "AFG",  "Afghanistan",         10500,      900,    2000,      NA

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.app
 
 import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.BurdenEstimateOutcomeError
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
 import org.vaccineimpact.api.models.expectations.RowLookup
@@ -35,6 +36,13 @@ fun Sequence<BurdenEstimateWithRunId>.validate(expectedRows: RowLookup
         if (years[it.year]!!){
             throw InconsistentDataError("Duplicate entry for country:${it.country} age:${it.age} year:${it.year}")
         }
+
+        it.outcomes.forEach{ (k, v) ->
+            if (v != null && v < 0) {
+                throw BurdenEstimateOutcomeError(
+                        "Negative value for country:${it.country} age:${it.age} year:${it.year} outcome:$k")
+            }
+        };
 
         expectedRows[it.country]!![it.age]!![it.year] = true
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
@@ -39,11 +39,7 @@ fun Sequence<BurdenEstimateWithRunId>.validate(expectedRows: RowLookup
 
         it.outcomes.forEach{ (k, v) ->
             val outcomeDescription = { "country:${it.country} age:${it.age} year:${it.year} outcome:$k" }
-            if (v == null)
-            {
-                throw BurdenEstimateOutcomeError("Missing value for ${outcomeDescription()}")
-            }
-            else if (v < 0)
+            if (v != null && v < 0)
             {
                 throw BurdenEstimateOutcomeError("Negative value for ${outcomeDescription()}")
             }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/SequenceExtensions.kt
@@ -38,11 +38,16 @@ fun Sequence<BurdenEstimateWithRunId>.validate(expectedRows: RowLookup
         }
 
         it.outcomes.forEach{ (k, v) ->
-            if (v != null && v < 0) {
-                throw BurdenEstimateOutcomeError(
-                        "Negative value for country:${it.country} age:${it.age} year:${it.year} outcome:$k")
+            val outcomeDescription = { "country:${it.country} age:${it.age} year:${it.year} outcome:$k" }
+            if (v == null)
+            {
+                throw BurdenEstimateOutcomeError("Missing value for ${outcomeDescription()}")
             }
-        };
+            else if (v < 0)
+            {
+                throw BurdenEstimateOutcomeError("Negative value for ${outcomeDescription()}")
+            }
+        }
 
         expectedRows[it.country]!![it.age]!![it.year] = true
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/BurdenEstimateOutcomeError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/BurdenEstimateOutcomeError.kt
@@ -1,0 +1,7 @@
+package org.vaccineimpact.api.app.errors
+
+import org.vaccineimpact.api.models.ErrorInfo
+
+class BurdenEstimateOutcomeError(message: String) : MontaguError(400, listOf(
+        ErrorInfo("burden-estimate-outcome", message)
+))

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
@@ -88,6 +88,7 @@ class ValidateBurdenEstimateSequenceTests : MontaguTests()
         val outcomes = mapOf(
           "deaths" to 1F,
           "cases" to 0F,
+          "severe_cases" to null,
           "dalys" to -1F
         );
         val source = listOf(BurdenEstimateWithRunId("d1", null, 2000, 1, "AFG", "", 10000F, outcomes))
@@ -98,19 +99,6 @@ class ValidateBurdenEstimateSequenceTests : MontaguTests()
                "Negative value for country:AFG age:1 year:2000 outcome:dalys")
     }
 
-    @Test
-    fun `throws exception on null value`()
-    {
-        val outcomes = mapOf(
-                "deaths" to null
-        );
-        val source = listOf(BurdenEstimateWithRunId("d1", null, 2000, 1, "AFG", "", 10000F, outcomes))
-
-        assertThatThrownBy {
-            source.asSequence().validate(expectations.expectedRowLookup()).toList()
-        }.isInstanceOf(BurdenEstimateOutcomeError::class.java).hasMessageContaining(
-                "Missing value for country:AFG age:1 year:2000 outcome:deaths")
-    }
 
     @Test
     fun `sequence remains lazy when checking all values`()

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.api.tests.logic
 import org.assertj.core.api.Assertions.*
 import org.junit.Test
 import org.vaccineimpact.api.app.errors.BadRequest
+import org.vaccineimpact.api.app.errors.BurdenEstimateOutcomeError
 import org.vaccineimpact.api.app.errors.InconsistentDataError
 import org.vaccineimpact.api.app.validate
 import org.vaccineimpact.api.models.BurdenEstimateWithRunId
@@ -80,6 +81,24 @@ class ValidateBurdenEstimateSequenceTests : MontaguTests()
             source.asSequence().validate(expectations.expectedRowLookup()).toList()
         }.isInstanceOf(InconsistentDataError::class.java).hasMessageContaining("Duplicate")
     }
+
+    @Test
+    fun `throws exception on negative value`()
+    {
+        val outcomes = mapOf(
+          "deaths" to 1F,
+          "cases" to 0F,
+          "dalys" to null,
+          "severe_cases" to -1F
+        );
+        val source = listOf(BurdenEstimateWithRunId("d1", null, 2000, 1, "AFG", "", 10000F, outcomes))
+
+        assertThatThrownBy {
+            source.asSequence().validate(expectations.expectedRowLookup()).toList()
+        }.isInstanceOf(BurdenEstimateOutcomeError::class.java).hasMessageContaining(
+               "Negative value for country:AFG age:1 year:2000 outcome:severe_cases")
+    }
+
     @Test
     fun `sequence remains lazy when checking all values`()
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/ValidateBurdenEstimateSequenceTests.kt
@@ -88,15 +88,28 @@ class ValidateBurdenEstimateSequenceTests : MontaguTests()
         val outcomes = mapOf(
           "deaths" to 1F,
           "cases" to 0F,
-          "dalys" to null,
-          "severe_cases" to -1F
+          "dalys" to -1F
         );
         val source = listOf(BurdenEstimateWithRunId("d1", null, 2000, 1, "AFG", "", 10000F, outcomes))
 
         assertThatThrownBy {
             source.asSequence().validate(expectations.expectedRowLookup()).toList()
         }.isInstanceOf(BurdenEstimateOutcomeError::class.java).hasMessageContaining(
-               "Negative value for country:AFG age:1 year:2000 outcome:severe_cases")
+               "Negative value for country:AFG age:1 year:2000 outcome:dalys")
+    }
+
+    @Test
+    fun `throws exception on null value`()
+    {
+        val outcomes = mapOf(
+                "deaths" to null
+        );
+        val source = listOf(BurdenEstimateWithRunId("d1", null, 2000, 1, "AFG", "", 10000F, outcomes))
+
+        assertThatThrownBy {
+            source.asSequence().validate(expectations.expectedRowLookup()).toList()
+        }.isInstanceOf(BurdenEstimateOutcomeError::class.java).hasMessageContaining(
+                "Missing value for country:AFG age:1 year:2000 outcome:deaths")
     }
 
     @Test


### PR DESCRIPTION
Disallow negative values for any outcome from being uploaded as part of burden estimates. A burden estimate set containing any negative values will be rejected with an exception. Can be tested manually by targeting this branch and running the montagu webapps locally. 

There's some ongoing discussion about whether null or 'NA' values should also be rejected, so I'm just going to keep this ticket to its original scope of checking for negatives. 0 values are allowed. 