### PR TITLE
vimc-4617 Do not return closed expectations for closed responsibilities

### DIFF
--- a/scripts/orderly-web.yml
+++ b/scripts/orderly-web.yml
@@ -5,12 +5,14 @@ network: db_nw
 
 volumes:
   orderly: orderly_volume
+  redis: orderly_web_redis_data
 
 orderly:
   image:
     repo: vimc
     name: orderly.server
     tag: master
+    worker_name: orderly.server
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/scripts/orderly-web.yml
+++ b/scripts/orderly-web.yml
@@ -7,6 +7,12 @@ volumes:
   orderly: orderly_volume
   redis: orderly_web_redis_data
 
+redis:
+  image:
+    name: redis
+    tag: "5.0"
+  volume: orderly_web_redis_data
+
 orderly:
   image:
     repo: vimc

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -74,6 +74,7 @@ class JooqExpectationsRepository(dsl: DSLContext)
                 .where(
                         RESPONSIBILITY_SET.TOUCHSTONE.eq(touchstoneVersion)
                                 .and(RESPONSIBILITY_SET.MODELLING_GROUP.eq(modellingGroup))
+                                .and(RESPONSIBILITY.IS_OPEN)
                 )
                 .groupBy { it[Tables.expectations.ID] }
                 .map { getBasicDataAndMappingFromRecords(it.value) }


### PR DESCRIPTION
Closing responsibilites within a responsibility set caused an error in the contribution portal when loading the burden estimates template page. 

This was because the Expectations respository was not checking `is_open` flag on responsibilities, and was returning applicable scenarios for those expectations belonging to closed reponsibilities. However only open responsibilities  were returned in the `responsibilities` part of the response so there was an internal inconsistency in the data which caused the front end code to fail. This branch adds this check of `is_open` so all returned data is consistent. 

To reproduce the bug locally:
- Run development dependencies for montagu-webapps (see instructions in that repo)
- Open the montagu db with: `docker exec -it montagu_db_1 psql -U vimc -d montagu`
- Close a responsibility with: `update responsibility set is_open = FALSE where id = 6;`  This will close the `yf-campaign` responsibility for touchstone `op-2018-1`.
- Run the contrib portal
- Browse to: http://localhost:5000/contribution/IC-Garske/responsibilities/op-2018-1/templates/
- You should see the page fail to load, with a console error: 
```
 Uncaught TypeError: Cannot read property 'id' of undefined
    at ExpectationsDescription.scenarioMapping (ExpectationsDescription.tsx:17)
    at ExpectationsDescription.tsx:45
    ...
```

To test that the fix in this branch works:
- Repeat all of the above process, but this time set the value in `config/api_version` to `vimc-4617` before running dependencies to load the image for this branch
- Browsing to http://localhost:5000/contribution/IC-Garske/responsibilities/op-2018-1/templates/ should load the page successfully, and a template should be shown for the `yf-routine` scenario only