### PR TITLE
VIMC-4779 Fix IntelliJ error when importing montagu-api

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ group 'ac.uk.imperial.vimc'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.0-rc-91'
+    ext.kotlin_version = '1.1.0'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Hopefully the most inconsequential fix imaginable: do the minimum necessary to fix errors by switching to non- RC release i.e. one that actually has artefacts available from bintray.

Steps to reproduce:
```bash
docker run -it --rm openjdk:8u282-jre-slim
apt-get update && apt-get install -y git
git clone https://github.com/vimc/montagu-api.git
cd montagu-api/demo

./gradlew
# BUILD FAILED

git checkout VIMC-4779
./gradlew
# BUILD SUCCESSFUL
```