### PR TITLE
VIMC-4825 Fix diagnostic report test 

### DIFF
--- a/buildkite/make-build-env.sh
+++ b/buildkite/make-build-env.sh
@@ -3,7 +3,7 @@ set -e
 HERE=$(dirname $0)
 . $HERE/common
 
-docker pull vimc/openjdk-libsodium:vimc-4258
+docker pull vimc/openjdk-libsodium:master
 docker build -f ./docker/shared-build-env.dockerfile \
     -t $BUILD_ENV_TAG \
     .

--- a/docker/blackbox.Dockerfile
+++ b/docker/blackbox.Dockerfile
@@ -1,4 +1,4 @@
-FROM vimc/openjdk-libsodium:vimc-4258
+FROM vimc/openjdk-libsodium:master
 
 # Setup gradle
 COPY src/gradlew /api/src/

--- a/docker/shared-build-env.dockerfile
+++ b/docker/shared-build-env.dockerfile
@@ -1,4 +1,4 @@
-FROM vimc/openjdk-libsodium:vimc-4258
+FROM vimc/openjdk-libsodium:master
 
 # Install docker
 RUN apt-get update

--- a/scripts/orderly-web.yml
+++ b/scripts/orderly-web.yml
@@ -21,7 +21,7 @@ orderly:
     worker_name: orderly.server
   initial:
     source: clone
-    url: https://github.com/vimc/orderly-demo
+    url: https://github.com/vimc/montagu-task-queue-orderly
 
 web:
   image:

--- a/scripts/task-queue-config.yml
+++ b/scripts/task-queue-config.yml
@@ -19,7 +19,7 @@ tasks:
     reports:
       testGroup:
         testDisease:
-          - report_name: minimal
+          - report_name: diagnostic
             success_email:
               recipients:
                 - minimal_modeller@example.com

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/clients/CeleryClientTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/clients/CeleryClientTests.kt
@@ -21,7 +21,7 @@ class CeleryClientTests : MontaguTests()
     fun `can call task`()
     {
         val client = CeleryClient()
-        val response = client.runDiagnosticReport("testGroup", "testDisease", "testTouchstone",
+        val response = client.runDiagnosticReport("testGroup", "testDisease", "testTouchstone-1",
                 "testScenario",
                 "test.user@example.com")
 


### PR DESCRIPTION
Also revert `vimc/openjdk-libsodium` to `master` tag. `vimc-4258` was the last branch merged into `master`, so they have been equivalent until now, but needed to rebuild `master` image (without any changes to code) in order to ensure that package index reflects changes following recent Debian release.