### PR TITLE
vimc-6279 Remove gavi73 restriction on coverage countries

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/ExpectationsRepository.kt
@@ -11,4 +11,5 @@ interface ExpectationsRepository : Repository
     fun getExpectationIdsForGroupAndTouchstone(groupId: String, touchstoneVersionId: String): List<Int>
     fun getAllExpectations(): List<TouchstoneModelExpectations>
     fun getExpectedGAVICoverageCountries() : List<String>
+    fun getAllowedGAVICoverageCountries() : List<String>
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -143,7 +143,7 @@ class JooqExpectationsRepository(dsl: DSLContext)
     {
         // No current restrictions on expected GAVI countries, as long as they are in the db
         return dsl.selectDistinct(COUNTRY.ID)
-                .fromJoinPath(COUNTRY, COUNTRY_METADATA)
+                .from(COUNTRY)
                 .orderBy(COUNTRY.ID)
                 .fetchInto(String::class.java)
                 .toList()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -141,9 +141,9 @@ class JooqExpectationsRepository(dsl: DSLContext)
 
     override fun getExpectedGAVICoverageCountries(): List<String>
     {
+        // No current restrictions on expected GAVI countries, as long as they are in the db
         return dsl.selectDistinct(COUNTRY.ID)
                 .fromJoinPath(COUNTRY, COUNTRY_METADATA)
-                .where(COUNTRY_METADATA.GAVI73)
                 .orderBy(COUNTRY.ID)
                 .fetchInto(String::class.java)
                 .toList()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqExpectationsRepository.kt
@@ -141,7 +141,16 @@ class JooqExpectationsRepository(dsl: DSLContext)
 
     override fun getExpectedGAVICoverageCountries(): List<String>
     {
-        // No current restrictions on expected GAVI countries, as long as they are in the db
+        return dsl.selectDistinct(COUNTRY.ID)
+                .fromJoinPath(COUNTRY, COUNTRY_METADATA)
+                .where(COUNTRY_METADATA.GAVI73)
+                .orderBy(COUNTRY.ID)
+                .fetchInto(String::class.java)
+                .toList()
+    }
+
+    override fun getAllowedGAVICoverageCountries(): List<String>
+    {
         return dsl.selectDistinct(COUNTRY.ID)
                 .from(COUNTRY)
                 .orderBy(COUNTRY.ID)

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -472,17 +472,18 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
     @Test
     fun `can get allowed countries for GAVI coverage`()
     {
-        withDatabase { db ->
-            val countriesInDB = db.dsl.select(COUNTRY.ID)
+        val countriesInDB = withDatabase { db ->
+             db.dsl.select(COUNTRY.ID)
                     .from(COUNTRY)
                     .orderBy(COUNTRY.ID)
                     .fetchInto(String::class.java)
-
-            val countries = withRepo {
-                it.getExpectedGAVICoverageCountries()
-            }
-            assertThat(countries).containsExactlyElementsOf(countriesInDB)
         }
+
+        val countries = withRepo {
+            it.getAllowedGAVICoverageCountries()
+        }
+
+        assertThat(countries).containsExactlyElementsOf(countriesInDB)
     }
 
     private fun addResponsibilityAnd(action: (JooqContext, Int, Int) -> Int) = withDatabase { db ->

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -397,76 +397,17 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
     fun `can get countries for GAVI coverage`()
     {
         withDatabase { db ->
-            db.addTouchstoneVersion("t", 1, addTouchstone = true)
-            db.addTouchstoneVersion("t", 2, addTouchstone = false)
-            db.dsl.newRecord(FRANCOPHONE_STATUS)
-                    .apply {
-                        id = "fff"
-                    }.store()
-            db.dsl.newRecord(VXDEL_SEGMENT)
-                    .apply {
-                        id = "v1"
-                    }.store()
-
-            db.dsl.newRecord(GAVI_REGION)
-                    .apply {
-                        id = "g1"
-                        name = "gaviregion"
-                    }.store()
-
-            val countryRecords = db.dsl.select(COUNTRY.ID)
+            val countriesInDB = db.dsl.select(COUNTRY.ID)
                     .from(COUNTRY)
-                    .limit(73)
+                    .orderBy(COUNTRY.ID)
                     .fetchInto(String::class.java)
-                    .map {
-                        db.dsl.newRecord(COUNTRY_METADATA).apply {
-                            this.country = it
-                            this.gavi73 = true
-                            this.touchstone = "t-1"
-                            this.whoRegion = "123"
-                            this.continent = "aaa"
-                            this.region = "bbb"
-                            this.francophone = "fff"
-                            this.vxdelSegment = "v1"
-                            this.gaviRegion = "g1"
-                            this.wuenicCoverage = false
-                            this.pine_5 = false
-                            this.dove94 = false
-                            this.dove96 = false
-                            this.gavi68 = false
-                            this.gavi72 = false
-                            this.gavi77 = false
-                            this.gavi74 = false
-                        }
-                    }
-            db.dsl.batchStore(countryRecords).execute()
 
-            // add one duplicate for another touchstone
-            db.dsl.newRecord(COUNTRY_METADATA).apply {
-                this.country = "AFG"
-                this.gavi73 = true
-                this.touchstone = "t-2"
-                this.whoRegion = "123"
-                this.continent = "aaa"
-                this.region = "bbb"
-                this.francophone = "fff"
-                this.vxdelSegment = "v1"
-                this.gaviRegion = "g1"
-                this.wuenicCoverage = false
-                this.pine_5 = false
-                this.dove94 = false
-                this.dove96 = false
-                this.gavi68 = false
-                this.gavi72 = false
-                this.gavi77 = false
-                this.gavi74 = false
-            }.store()
+            val countries = withRepo {
+                it.getExpectedGAVICoverageCountries()
+            }
+            assertThat(countries.count()).isGreaterThan(73)
+            assertThat(countries).containsExactlyElementsOf(countriesInDB)
         }
-
-        val countries = withRepo {
-            it.getExpectedGAVICoverageCountries()
-        }
-        assertThat(countries.count()).isEqualTo(73)
     }
 
     private fun addResponsibilityAnd(action: (JooqContext, Int, Int) -> Int) = withDatabase { db ->

--- a/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
+++ b/src/databaseTests/src/test/kotlin/org/vaccineimpact/api/databaseTests/tests/ExpectationsRepositoryTests.kt
@@ -436,6 +436,7 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
                             this.gavi68 = false
                             this.gavi72 = false
                             this.gavi77 = false
+                            this.gavi74 = false
                         }
                     }
             db.dsl.batchStore(countryRecords).execute()
@@ -458,6 +459,7 @@ class ExpectationsRepositoryTests : RepositoryTests<ExpectationsRepository>()
                 this.gavi68 = false
                 this.gavi72 = false
                 this.gavi77 = false
+                this.gavi74 = false
             }.store()
         }
 


### PR DESCRIPTION
Allow coverage to be uploaded for all countries in the database, not just gavi73 countries. However, we continue to require gavi73 countries as a minimum for any coverage sets, and also require all mandatory years for coverage sets uploaded for any non-required countries. 

This means that we need to distinguish between `requiredCountries` and `allowedCountries` when doing validation in `CoverageLogic`, and also that we might need to inject some new year maps into the CountryLookup (which is initially generated for all required countries) if coverage include non-required countries. This should ensure that missing row errors should be raised if non-required country coverage is missing some years. 

This branch has been deployed to UAT, and can successfully ingest the OP19 coverage file with Syria data which failed on Production (which can be found [here](https://montagu.vaccineimpact.org/reports/report/incoming-op19/20220324-111800-95e277dc/#downloads). 