### PR TITLE
vimc-6443 upgrade kotlin

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -20,5 +20,8 @@ steps:
 
   - wait
 
+  - label: ":mag: Smoke test cli"
+    command: buildkite/test-cli.sh
+
   - label: ":mag: Run blackbox tests"
     command: buildkite/run-blackbox-tests.sh

--- a/buildkite/test-cli.sh
+++ b/buildkite/test-cli.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+HERE=$(dirname $0)
+. $HERE/common
+
+$HERE/../scripts/start-database.sh
+
+GIT_SHA=master
+image=vimc/montagu-cli:${GIT_SHA}
+docker run --network $NETWORK $image "$@" add "test" "test" "test" "test"

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -23,34 +23,35 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.app.app_start.MainKt"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "com.sparkjava:spark-kotlin:1.0.0-alpha"
+    implementation "com.google.code.gson:gson:2.2.4"
+    implementation "org.apache.commons:commons-lang3:3.7"
+    implementation "org.postgresql:postgresql:42.2.1"
+    implementation "org.jooq:jooq:3.10.5"
+    implementation "org.jooq:jooq-meta:3.10.5"
+    implementation "org.pac4j:spark-pac4j:2.2.0"
+    implementation "org.pac4j:pac4j-http:2.2.1"
+    implementation 'org.pac4j:pac4j-jwt:2.2.1'
+    implementation "commons-fileupload:commons-fileupload:1.3.3"
+    implementation "com.offbytwo:docopt:0.6.0.20150202"
+    implementation "com.github.jkcclemens:khttp:0.1.0"
+    implementation "com.squareup.okhttp3:okhttp:4.0.0-RC1"
 
-    compile "com.sparkjava:spark-core:2.7.1"
+    implementation project(":databaseInterface")
+    implementation project(":models")
+    implementation project(":security")
+    implementation project(":emails")
+    implementation project(":serialization")
 
-    compile "org.postgresql:postgresql:42.2.1"
-    compile "org.jooq:jooq:3.10.5"
-    compile "org.jooq:jooq-meta:3.10.5"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation "com.beust:klaxon:5.5"
+    testImplementation "com.github.fge:json-schema-validator:2.2.8"
 
-    compile "org.pac4j:spark-pac4j:2.2.0"
-    compile "org.pac4j:pac4j-http:2.2.1"
-    compile "commons-fileupload:commons-fileupload:1.3.3"
-    compile "com.offbytwo:docopt:0.6.0.20150202"
-    compile "khttp:khttp:0.1.0"
-    compile "com.squareup.okhttp3:okhttp:4.0.0-RC1"
-
-    compile project(":databaseInterface")
-    compile project(":models")
-    compile project(":security")
-    compile project(":emails")
-    compile project(":serialization")
-
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-    testCompile "org.assertj:assertj-core:3.9.1"
-    testCompile "com.beust:klaxon:2.1.8"
-    testCompile "com.github.fge:json-schema-validator:2.2.8"
-    testCompile project(":testHelpers")
+    testImplementation project(":testHelpers")
 }
 
 docker {

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ErrorHandler.kt
@@ -14,7 +14,6 @@ import org.vaccineimpact.api.serialization.Serializer
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import spark.Request
 import spark.Response
-import spark.Spark as spk
 
 @Suppress("RemoveExplicitTypeArguments")
 open class ErrorHandler(private val logger: Logger = LoggerFactory.getLogger(ErrorHandler::class.java),

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/context/RequestDataSource.kt
@@ -19,7 +19,7 @@ interface RequestDataSource
          */
         fun fromContentType(context: ActionContext, partNameToUseForMultipart: String = "file"): RequestDataSource
         {
-            val type = context.contentType().toLowerCase()
+            val type = context.contentType().lowercase()
             return when
             {
                 type.startsWith("multipart/form-data") -> MultipartStreamSource(partNameToUseForMultipart, context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnexpectedError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnexpectedError.kt
@@ -31,6 +31,6 @@ class UnexpectedError private constructor() : MontaguError(500, listOf(ErrorInfo
 
 private fun newCode(): String
 {
-    fun r(count: Int) = RandomStringUtils.randomAlphabetic(count).toLowerCase()
+    fun r(count: Int) = RandomStringUtils.randomAlphabetic(count).lowercase()
     return "u${r(2)}-${r(3)}-${r(3)}"
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnknownObjectError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/errors/UnknownObjectError.kt
@@ -13,7 +13,7 @@ class UnknownObjectError(val id: Any, val typeName: String) : MontaguError(404, 
     companion object
     {
         fun mangleTypeName(typeName: String) = typeName
-                .replace(Regex("[A-Z]"), { "-" + it.value.toLowerCase() })
+                .replace(Regex("[A-Z]"), { "-" + it.value.lowercase() })
                 .trim('-')
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/BurdenEstimateLogic.kt
@@ -73,15 +73,15 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
         val modellingGroup = modellingGroupRepository.getModellingGroup(groupId)
 
         val responsibilityInfo = burdenEstimateRepository.getResponsibilityInfo(modellingGroup.id, touchstoneVersionId, scenarioId)
-        val status = responsibilityInfo.setStatus.toLowerCase()
+        val status = responsibilityInfo.setStatus.lowercase()
 
-        if (status == ResponsibilitySetStatus.SUBMITTED.name.toLowerCase())
+        if (status == ResponsibilitySetStatus.SUBMITTED.name.lowercase())
         {
             throw InvalidOperationError("The burden estimates uploaded for this touchstone have been submitted " +
                     "for review. You cannot upload any new estimates.")
         }
 
-        if (status == ResponsibilitySetStatus.APPROVED.name.toLowerCase())
+        if (status == ResponsibilitySetStatus.APPROVED.name.lowercase())
         {
             throw InvalidOperationError("The burden estimates uploaded for this touchstone have been reviewed" +
                     " and approved. You cannot upload any new estimates.")
@@ -189,7 +189,7 @@ class RepositoriesBurdenEstimateLogic(private val modellingGroupRepository: Mode
             {
                 burdenEstimateRepository.changeBurdenEstimateStatus(setId, BurdenEstimateSetStatus.INVALID)
                 // Adding problem to estimate set also marks ResponsibilityStatus as INVALID via convertScenarioToResponsibility()
-                val missingEstimateCount = validatedRowMap?.values?.flatMap { age -> age.values.flatMap { year -> year.values } }?.count { !it }
+                val missingEstimateCount = validatedRowMap.values.flatMap { age -> age.values.flatMap { year -> year.values } }.count { !it }
                 burdenEstimateRepository.addBurdenEstimateSetProblem(setId, "$missingEstimateCount missing estimate(s)")
 
                 notifier.notify(groupId, responsibilityInfo.disease, scenarioId,

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/logic/CoverageLogic.kt
@@ -272,7 +272,7 @@ class RepositoriesCoverageLogic(private val modellingGroupRepository: ModellingG
     private fun mapVaccineForCoverageSet(vaccine: String): List<String>
     {
         // GAVI may provide combination vaccines rather than individual vaccines in some coverage rows
-        return when (vaccine.toUpperCase())
+        return when (vaccine.uppercase())
         {
             "PENTA", "PENTAVALENT" -> listOf("Hib3", "HepB", "DTP3")
             "MR1" -> listOf("MCV1", "Rubella")

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioFilter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqScenarioFilter.kt
@@ -11,8 +11,8 @@ class JooqScenarioFilter : JooqFilterSet<ScenarioFilterParameters>()
     private val table = Tables.SCENARIO_DESCRIPTION
 
     override val filters: Iterable<JooqFilter<ScenarioFilterParameters>>
-        get() = listOf<JooqEqualityFilter<ScenarioFilterParameters, Any>>(
-                JooqEqualityFilter(table.ID, { it.scenarioId }),
-                JooqEqualityFilter(table.DISEASE, { it.disease })
+        get() = listOf(
+                JooqEqualityFilter(table.ID) { it.scenarioId },
+                JooqEqualityFilter(table.DISEASE) { it.disease }
         )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqTouchstoneRepository.kt
@@ -228,8 +228,8 @@ class JooqTouchstoneRepository(
                                    supportLevel: GAVISupportLevel,
                                    metadataId: Int): Int
     {
-        val support = supportLevel.toString().toLowerCase()
-        val activity = activityType.toString().toLowerCase().replace('_', '-')
+        val support = supportLevel.toString().lowercase()
+        val activity = activityType.toString().lowercase().replace('_', '-')
         val record = this.dsl.newRecord(COVERAGE_SET).apply {
             this.touchstone = touchstoneVersionId
             this.name = "$vaccine: $vaccine, $support, $activity"
@@ -255,7 +255,7 @@ class JooqTouchstoneRepository(
                 .fetchInto(CoverageUploadMetadata::class.java)
                 .groupBy { Pair(it.vaccine, it.activityType) }
                 .map { g ->
-                    g.value.maxBy { it.uploadedOn }!!
+                    g.value.maxByOrNull { it.uploadedOn }!!
                 }
     }
 
@@ -509,7 +509,7 @@ class JooqTouchstoneRepository(
     override fun getGenders(): Map<GenderEnum, Int>
     {
         return dsl.fetch(GENDER).associate {
-            GenderEnum.valueOf(it.name.toUpperCase()) to it.id
+            GenderEnum.valueOf(it.name.uppercase()) to it.id
         }
     }
 
@@ -595,7 +595,7 @@ class JooqTouchstoneRepository(
                         record[COVERAGE.AGE_RANGE_VERBATIM],
                         record[COVERAGE.TARGET],
                         record[COVERAGE.COVERAGE_],
-                        (record[GENDER.NAME] ?: defaultGender(diseaseId)).toLowerCase(),
+                        (record[GENDER.NAME] ?: defaultGender(diseaseId)).lowercase(),
                         record[COVERAGE.PROPORTION_RISK]
                 )
             }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/repositories/jooq/JooqUserRepository.kt
@@ -254,10 +254,10 @@ class JooqUserRepository(dsl: DSLContext) : JooqRepository(dsl), UserRepository
     }
 
     private fun caseInsensitiveEmailMatch(email: String)
-            = APP_USER.EMAIL.lower().eq(email.toLowerCase())
+            = APP_USER.EMAIL.lower().eq(email.lowercase())
 
     private fun caseInsensitiveUsernameMatch(username: String)
-            = APP_USER.USERNAME.lower().eq(username.toLowerCase())
+            = APP_USER.USERNAME.lower().eq(username.lowercase())
 
     private fun mapPermission(record: Record) = ReifiedPermission(record[PERMISSION.NAME], mapScope(record))
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/ConfigExtensions.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/security/ConfigExtensions.kt
@@ -11,7 +11,7 @@ fun Config.addMethodMatchers()
 {
     for (pac4jMethod in HTTP_METHOD.values())
     {
-        val sparkMethod = HttpMethod.valueOf(pac4jMethod.name.toLowerCase())
+        val sparkMethod = HttpMethod.valueOf(pac4jMethod.name.lowercase())
         addMatcher("method:$sparkMethod", HttpMethodMatcher(pac4jMethod))
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/api/tests/logic/BurdenEstimateLogic/CreateBurdenEstimateLogicTests.kt
@@ -43,7 +43,7 @@ class CreateBurdenEstimateLogicTests : MontaguTests()
             on {
                 getResponsibilityInfo(realGroupId, touchstoneVersionId, scenarioId)
             } doReturn
-                    ResponsibilityInfo(responsibilityId, disease, responsibilitySetStatus.toString().toLowerCase(), 100)
+                    ResponsibilityInfo(responsibilityId, disease, responsibilitySetStatus.toString().lowercase(), 100)
             on {
                 createBurdenEstimateSet(eq(responsibilityId), eq(modelVersionId), any(), eq("uploader"), any())
             } doReturn 123

--- a/src/blackboxTests/build.gradle
+++ b/src/blackboxTests/build.gradle
@@ -2,25 +2,27 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.blackboxTests.AppKt"
 
 dependencies {
-    compile project(":testHelpers")
+    implementation project(":testHelpers")
 
-    testCompile "junit:junit:4.12"
-    testCompile "org.assertj:assertj-core:3.9.1"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation "com.sparkjava:spark-kotlin:1.0.0-alpha"
+    testImplementation "org.slf4j:slf4j-simple:1.7.25"
+    testImplementation "com.github.jkcclemens:khttp:0.1.0"
+    testImplementation 'com.beust:klaxon:5.5'
+    testImplementation "com.opencsv:opencsv:4.1"
+    testImplementation "com.auth0:java-jwt:3.3.0"
+    testImplementation "com.github.fge:json-schema-validator:2.2.8"
+    testImplementation "org.jooq:jooq:3.10.5"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.59"
 
-    testCompile "org.slf4j:slf4j-simple:1.7.25"
-
-    testCompile "khttp:khttp:0.1.0"
-    testCompile "com.beust:klaxon:2.1.8"
-    testCompile "com.opencsv:opencsv:4.1"
-    testCompile "com.auth0:java-jwt:3.3.0"
-
-    testCompile "com.github.fge:json-schema-validator:2.2.8"
-
-    testCompile project(":testHelpers")
-    testCompile project(":databaseInterface")
-    testCompile project(":security")
-    testCompile project(":validateSchema")
-    testCompile project(":emails")
+    testImplementation project(":testHelpers")
+    testImplementation project(":databaseInterface")
+    testImplementation project(":security")
+    testImplementation project(":serialization")
+    testImplementation project(":validateSchema")
+    testImplementation project(":emails")
+    testImplementation project(":models")
 }
 
 test {

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -1,9 +1,8 @@
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = "1.6.0"
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -13,6 +12,7 @@ buildscript {
 
 plugins {
     id 'com.github.ben-manes.versions' version '0.20.0'
+    id "org.jetbrains.kotlin.jvm" version "$kotlin_version"
 }
 
 group 'org.vaccineimpact'
@@ -106,25 +106,26 @@ task stopTestAPI(type: Exec) {
 }
 
 subprojects {
-    apply plugin: 'kotlin'
-    apply plugin: 'jacoco'
+
+    apply plugin: "jacoco"
+    apply plugin: "org.jetbrains.kotlin.jvm"
 
     repositories {
         mavenCentral()
-        jcenter()
         maven { url 'https://jitpack.io' }
     }
 
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        compile "org.slf4j:slf4j-simple:1.7.25"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+        implementation "org.slf4j:slf4j-simple:1.7.25"
+        implementation "com.google.code.gson:gson:2.2.4"
     }
 
     jacoco {
         toolVersion = "0.8.3"
         reportsDir = file("$projectDir/coverage")
     }
-    
+
     jacocoTestReport {
         reports {
             xml.enabled true
@@ -180,4 +181,8 @@ subprojects {
         into 'build/classes/test/spec'
         outputs.upToDateWhen { false }
     }
+
+    jar.dependsOn "copySpec"
+    jar.dependsOn "copyConfig"
+    compileTestKotlin.dependsOn "copyConfig"
 }

--- a/src/databaseInterface/build.gradle
+++ b/src/databaseInterface/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.postgresql:postgresql:42.2.1"
-    compile "org.jooq:jooq:3.10.5"
-    compile "org.jooq:jooq-meta:3.10.5"
-    compile "org.apache.commons:commons-lang3:3.7"
-    compile "javax.annotation:javax.annotation-api:1.3.2"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "org.postgresql:postgresql:42.2.1"
+    implementation "org.jooq:jooq:3.10.5"
+    implementation "org.jooq:jooq-meta:3.10.5"
+    implementation "org.apache.commons:commons-lang3:3.7"
+    implementation "javax.annotation:javax.annotation-api:1.3.2"
 }

--- a/src/databaseTests/build.gradle
+++ b/src/databaseTests/build.gradle
@@ -2,20 +2,25 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.databaseTests.AppKt"
 
 dependencies {
-    compile project(":testHelpers")
+    implementation project(":testHelpers")
 
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-    testCompile "org.assertj:assertj-core:3.9.1"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+    testImplementation "org.assertj:assertj-core:3.9.1"
 
-    testCompile "org.jooq:jooq:3.10.5"
-    testCompile "org.jooq:jooq-meta:3.10.5"
+    testImplementation "org.jooq:jooq:3.10.5"
+    testImplementation "org.jooq:jooq-meta:3.10.5"
+    testImplementation "com.sparkjava:spark-kotlin:1.0.0-alpha"
+    testImplementation "org.pac4j:pac4j-http:2.2.1"
+    testImplementation "org.postgresql:postgresql:42.2.1"
 
-    testCompile project(":app")
-    testCompile project(":models")
-    testCompile project(":databaseInterface")
-    testCompile project(":testHelpers")
+    testImplementation project(":app")
+    testImplementation project(":models")
+    testImplementation project(":databaseInterface")
+    testImplementation project(":testHelpers")
+    testImplementation project(":security")
+    testImplementation project(":serialization")
 }
 
 test {

--- a/src/emails/build.gradle
+++ b/src/emails/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    compile 'com.github.spullara.mustache.java:compiler:0.9.5'
-    compile "org.simplejavamail:simple-java-mail:4.4.5"
+    implementation 'com.github.spullara.mustache.java:compiler:0.9.5'
+    implementation "org.simplejavamail:simple-java-mail:4.4.5"
 
-    compile project(":databaseInterface")
-    compile project(":security")
+    implementation project(":databaseInterface")
+    implementation project(":security")
 }

--- a/src/generateDatabaseInterface/build.gradle
+++ b/src/generateDatabaseInterface/build.gradle
@@ -9,12 +9,12 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.generateDatabaseInterface.AppKt"
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile "org.postgresql:postgresql:42.2.1"
-    compile "org.jooq:jooq:3.10.5"
-    compile "org.jooq:jooq-meta:3.10.5"
-    compile "org.jooq:jooq-codegen:3.10.5"
+    implementation "org.postgresql:postgresql:42.2.1"
+    implementation "org.jooq:jooq:3.10.5"
+    implementation "org.jooq:jooq-meta:3.10.5"
+    implementation "org.jooq:jooq-codegen:3.10.5"
 }
 
 run.dependsOn ':startDatabase'

--- a/src/generateTestData/build.gradle
+++ b/src/generateTestData/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.generateTestData.AppKt"
 
 dependencies {
-    compile project(":testHelpers")
-    compile project(":databaseInterface")
+    implementation "org.jooq:jooq:3.10.5"
+    implementation project(":testHelpers")
+    implementation project(":databaseInterface")
 }
 

--- a/src/security/build.gradle
+++ b/src/security/build.gradle
@@ -1,20 +1,22 @@
 dependencies {
-    compile 'org.pac4j:spark-pac4j:2.2.0'
-    compile 'org.pac4j:pac4j-jwt:2.2.1'
-    compile 'commons-codec:commons-codec:1.11'
-    compile 'org.apache.httpcomponents:httpclient:4.5.6'
-    compile 'org.abstractj.kalium:kalium:0.7.0'
+    implementation 'org.pac4j:spark-pac4j:2.2.0'
+    implementation 'org.pac4j:pac4j-jwt:2.2.1'
+    implementation 'commons-codec:commons-codec:1.11'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.6'
+    implementation 'org.abstractj.kalium:kalium:0.7.0'
+    implementation "org.jooq:jooq:3.10.5"
+    implementation "org.jooq:jooq-meta:3.10.5"
 
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-    testCompile "org.assertj:assertj-core:3.9.1"
-    testCompile "com.beust:klaxon:2.1.8"
-    testCompile project(":testHelpers")
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation 'com.beust:klaxon:5.5'
+    testImplementation project(":testHelpers")
 
-    compile project(":models")
-    compile project(":databaseInterface")
-    compile project(":serialization")
+    implementation project(":models")
+    implementation project(":databaseInterface")
+    implementation project(":serialization")
 
 }
 

--- a/src/security/src/main/kotlin/org/vaccineimpact/api/security/UserHelper.kt
+++ b/src/security/src/main/kotlin/org/vaccineimpact/api/security/UserHelper.kt
@@ -40,7 +40,7 @@ object UserHelper
 
     fun suggestUsername(name: String): String
     {
-        val names = name.toLowerCase().split(' ')
+        val names = name.lowercase().split(' ')
         var username = names.first()
         if (names.size > 1)
         {

--- a/src/serialization/build.gradle
+++ b/src/serialization/build.gradle
@@ -1,16 +1,18 @@
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.opencsv:opencsv:4.1"
-    compile "com.google.code.gson:gson:2.8.2"
-    compile "com.github.salomonbrys.kotson:kotson:2.5.0"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "com.opencsv:opencsv:4.1"
+    implementation "com.google.code.gson:gson:2.8.2"
+    implementation "com.github.salomonbrys.kotson:kotson:2.5.0"
 
-    compile project(":models")
+    implementation project(":models")
 
-    testCompile "junit:junit:4.12"
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-    testCompile "org.assertj:assertj-core:3.9.1"
-    testCompile "com.beust:klaxon:2.1.8"
-    testCompile project(":testHelpers")
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation 'com.beust:klaxon:5.5'
+
+    testImplementation project(":testHelpers")
+    testImplementation project(":databaseInterface")
 
 }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/Deserializer.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.api.models.GAVISupportLevel
 import org.vaccineimpact.api.models.GenderEnum
 import org.vaccineimpact.api.serialization.validation.ValidationException
 import java.lang.UnsupportedOperationException
+import java.util.*
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.withNullability
@@ -39,9 +40,9 @@ class Deserializer
             Short::class.createType() -> raw.toShort()
             Float::class.createType() -> raw.toFloat()
             Boolean::class.createType() -> raw.toBooleanValidate()
-            ActivityType::class.createType() -> ActivityType.valueOf(raw.toUpperCase())
-            GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.toUpperCase())
-            GenderEnum::class.createType() -> GenderEnum.valueOf(raw.toUpperCase())
+            ActivityType::class.createType() -> ActivityType.valueOf(raw.uppercase())
+            GAVISupportLevel::class.createType() -> GAVISupportLevel.valueOf(raw.uppercase())
+            GenderEnum::class.createType() -> GenderEnum.valueOf(raw.uppercase())
             else -> throw UnsupportedOperationException("org.vaccineimpact.api.serialization.Deserializer does not support target type $targetType")
         }
     }

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/MontaguSerializer.kt
@@ -103,7 +103,7 @@ open class MontaguSerializer : Serializer
         {
             if (char.isUpperCase())
             {
-                builder.append("_" + char.toLowerCase())
+                builder.append("_" + char.lowercaseChar())
             }
             else
             {
@@ -120,7 +120,7 @@ open class MontaguSerializer : Serializer
             is GAVISupportLevel -> mapGAVISupportLevel(value)
             else -> value.toString()
         }
-        return text.toLowerCase().replace('_', '-')
+        return text.lowercase().replace('_', '-')
     }
 
     override val serializeNullsTo = "<NA>"

--- a/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/SplitData.kt
+++ b/src/serialization/src/main/kotlin/org/vaccineimpact/api/serialization/SplitData.kt
@@ -17,8 +17,8 @@ data class SplitData<out Metadata, out DataRow : Any>(
     {
         val metadata = serializer.toResult(structuredMetadata)
         stream.writer().let {
-            it.appendln(metadata)
-            it.appendln("---")
+            it.appendLine(metadata)
+            it.appendLine("---")
             // We want to flush this writer, but we don't want to close the underlying stream, as there
             // be more to write to it
             it.flush()

--- a/src/testHelpers/build.gradle
+++ b/src/testHelpers/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    compile "junit:junit:4.12"
-    compile "org.jooq:jooq:3.10.5"
-    compile "org.jooq:jooq-meta:3.10.5"
-    compile "com.offbytwo:docopt:0.6.0.20150202"
+    implementation "junit:junit:4.12"
+    implementation "org.jooq:jooq:3.10.5"
+    implementation "org.jooq:jooq-meta:3.10.5"
+    implementation "com.offbytwo:docopt:0.6.0.20150202"
 
-    compile project(':databaseInterface')
-    compile project(':models')
-    compile project(':security')
+    implementation project(':databaseInterface')
+    implementation project(':models')
+    implementation project(':security')
 }

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -6,14 +6,20 @@ apply plugin: 'application'
 mainClassName = "org.vaccineimpact.api.security.AppKt"
 
 dependencies {
-    compile "org.slf4j:slf4j-simple:1.7.25"
-    compile "org.simplejavamail:simple-java-mail:4.4.5"
-    compile project(":security")
+    implementation "org.slf4j:slf4j-simple:1.7.25"
+    implementation "org.simplejavamail:simple-java-mail:4.4.5"
+    implementation "org.jooq:jooq:3.10.5"
 
-    testCompile "org.assertj:assertj-core:3.9.1"
-    testCompile "org.mockito:mockito-core:2.+"
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-    testCompile project(":testHelpers")
+    implementation project(":security")
+    implementation project(":models")
+    implementation project(":databaseInterface")
+
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+
+    testImplementation project(":testHelpers")
 }
 
 def cli_docker_version = 'UNKNOWN'

--- a/src/validateSchema/build.gradle
+++ b/src/validateSchema/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    compile 'com.atlassian.commonmark:commonmark:0.11.0'
-    compile "org.assertj:assertj-core:3.9.1"
-    compile "com.github.fge:json-schema-validator:2.2.8"
+    implementation 'com.atlassian.commonmark:commonmark:0.11.0'
+    implementation "org.assertj:assertj-core:3.9.1"
+    implementation "com.github.fge:json-schema-validator:2.2.8"
 
-    testCompile "junit:junit:4.12"
-    testCompile "org.assertj:assertj-core:3.9.1"
-    testCompile project(":testHelpers")
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.assertj:assertj-core:3.9.1"
+    testImplementation project(":testHelpers")
 }
 
 test.dependsOn 'copySpec'


### PR DESCRIPTION
Required some small changes due to deprecated syntax and some additional dependency declarations in the gradle files as seems like deps are no longer resolved transitively where the first one is a local project.

Also adds a test for the cli image

~~https://github.com/vimc/montagu-api/pull/468 should be merged first and the base here changed to master~~