### PR TITLE
vimc-6329 let task queue clean up burden estimate files

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileCache.kt
@@ -38,9 +38,7 @@ class ChunkedFileCache(private val flushInterval: Long = TimeUnit.HOURS.toMillis
 
     override fun remove(uniqueIdentifier: String)
     {
-        val item = memoryCache[uniqueIdentifier]
         memoryCache.remove(uniqueIdentifier)
-        item?.left?.cleanUp()
     }
 
     private fun recycle()

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.api.app
 
 import org.vaccineimpact.api.app.models.ChunkedFile
+import org.vaccineimpact.api.db.Config
 import java.io.File
 import java.io.InputStream
 import java.io.RandomAccessFile
@@ -10,7 +11,6 @@ open class ChunkedFileManager
     // Note: currentChunk is 1-indexed
     open fun writeChunk(inputStream: InputStream, contentLength: Int, metadata: ChunkedFile, currentChunk: Int)
     {
-        File(UPLOAD_DIR).mkdir()
         val uploadPath = "$UPLOAD_DIR/${metadata.uniqueIdentifier}.temp"
         val raf = RandomAccessFile(uploadPath, "rw")
 
@@ -46,6 +46,6 @@ open class ChunkedFileManager
 
     companion object
     {
-        const val UPLOAD_DIR = "upload_dir"
+        val UPLOAD_DIR = Config["upload.dir"]
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/api/app/ChunkedFileManager.kt
@@ -8,6 +8,11 @@ import java.io.RandomAccessFile
 
 open class ChunkedFileManager
 {
+    init
+    {
+        File(UPLOAD_DIR).mkdir()
+    }
+
     // Note: currentChunk is 1-indexed
     open fun writeChunk(inputStream: InputStream, contentLength: Int, metadata: ChunkedFile, currentChunk: Int)
     {

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -29,3 +29,4 @@ email.password=${email_password}
 contact.support=${contact_support}
 flow.url=${flow_url}
 orderlyweb.api.url=${orderlyweb_api_url}
+upload.dir=${upload_dir}

--- a/src/config/default.properties
+++ b/src/config/default.properties
@@ -39,3 +39,5 @@ email_password=none
 
 flow_url=
 orderlyweb_api_url=http://localhost:8888/api/v1
+
+upload_dir=upload_dir


### PR DESCRIPTION
* makes upload directory configurable (to use an absolute path in prod, local directory locally)
* still remove files from cache, i.e. the app forgets about them, but don't delete the files on disk

Once merged, should also merge https://github.com/vimc/montagu/pull/223 to configure the deployment