### PR TITLE
vimc-6897 install constellation in every build step

### DIFF
--- a/buildkite/common
+++ b/buildkite/common
@@ -29,6 +29,9 @@ export DB_PORT=5432
 export NETWORK=test_nw
 export GIT_SHA=$GIT_SHA
 
+# Temporary measure to install constellation on all build steps - required by orderly-web install
+pip3 install constellation
+
 # Teardown on exit
 function cleanup() {
   $HERE/../scripts/stop-database.sh


### PR DESCRIPTION
Add constellation to `common` script called by every BK step to ensure it is installed when try to set up or tear down orderly-web. 

Could therefore now remove constellation install from the `start-orderly-web` script, but leaving that behind for now as it is also run for local development